### PR TITLE
Implement step toggle functionality in SequenceEditor

### DIFF
--- a/src/components/editor/SequenceEditor.css
+++ b/src/components/editor/SequenceEditor.css
@@ -1,0 +1,39 @@
+.sequence-editor {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.sequence-editor .step {
+	width: 30px;
+	height: 30px;
+	padding: 0;
+	background-color: var(--color-background-highlight);
+	border: none;
+	cursor: pointer;
+	position: relative;
+	transition: background-color 0.1s ease;
+}
+
+.sequence-editor .step:hover {
+	background-color: #3a3d4a;
+}
+
+.sequence-editor .step.active {
+	background-color: var(--color-background-highlight);
+}
+
+.sequence-editor .step-cross {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 30px;
+	height: 30px;
+	pointer-events: none;
+}
+
+.sequence-editor .step-cross line {
+	stroke: white;
+	stroke-width: 1;
+}

--- a/src/components/editor/SequenceEditor.tsx
+++ b/src/components/editor/SequenceEditor.tsx
@@ -1,5 +1,7 @@
-import type { Component } from "solid-js";
+import { For, type Component } from "solid-js";
+import { setSequenceStep } from "../../model/project";
 import type { Sequence } from "../../model/types";
+import "./SequenceEditor.css";
 
 type SequenceEditorProps = {
 	sequence: Sequence;
@@ -9,10 +11,37 @@ type SequenceEditorProps = {
 export default function SequenceEditor(
 	props: SequenceEditorProps,
 ): Component<SequenceEditorProps> {
+	const handleStepToggle = (stepIndex: number) => {
+		const currentNote = props.sequence.steps[stepIndex];
+		const newNote = currentNote === null ? "C3" : null;
+		// Currently hardcoded to pattern 0, as seen in Editor.tsx
+		setSequenceStep(0, props.trackIndex, stepIndex, newNote);
+	};
+
 	return (
 		<div class="sequence-editor">
-			{/* Step sequencer UI will go here */}
-			{/* Will display {props.sequence.steps.length} steps */}
+			<For each={props.sequence.steps}>
+				{(note, index) => (
+					<button
+						type="button"
+						class="step"
+						classList={{ active: note !== null }}
+						onClick={() => handleStepToggle(index())}
+						aria-label={`Step ${index() + 1}${note ? ` - ${note}` : ""}`}
+					>
+						{note !== null && (
+							<svg
+								viewBox="0 0 30 30"
+								xmlns="http://www.w3.org/2000/svg"
+								class="step-cross"
+							>
+								<line x1="0" y1="0" x2="30" y2="30" />
+								<line x1="30" y1="0" x2="0" y2="30" />
+							</svg>
+						)}
+					</button>
+				)}
+			</For>
 		</div>
 	);
 }

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -72,6 +72,25 @@ export function setSong(song: Song) {
 	dataService.updateProject(store.data);
 }
 
+export function setSequenceStep(
+	patternIndex: number,
+	trackIndex: number,
+	stepIndex: number,
+	note: string | null,
+) {
+	if (!store.data) return;
+
+	setStore(
+		produce((state) => {
+			state.data!.latestSnapshot.song.patterns[patternIndex].sequences[
+				trackIndex
+			].steps[stepIndex] = note;
+		}),
+	);
+
+	dataService.updateProject(store.data);
+}
+
 export function setProject(project: Project) {
 	setStore(
 		produce((state) => {


### PR DESCRIPTION
Add interactive step sequencer with the following features:
- Display sequence steps as clickable 30px square buttons
- Toggle steps between null and "C3" note on click
- Show white cross SVG overlay on selected steps
- Style steps with background color slightly lighter than workspace
- Add setSequenceStep function to project store for updating steps
- Changes automatically propagate to Firestore and SongPlayer

Changes made:
- src/components/editor/SequenceEditor.tsx: Implement step buttons with toggle logic
- src/components/editor/SequenceEditor.css: Add styling for steps and cross overlay
- src/model/project.ts: Add setSequenceStep function to update sequence steps

Prompt:

> Let's flesh out the SequenceEditor component. Here we want users to be able to toggle the steps of a sequence on and off.
> 
> The component should have a set of checkboxes representing steps. These should be styled to be plain squares in a tint colour slightly lighter than the background. They should be 30px square with some padding in between. Clicking them should set that step of the sequence to the string “C3”. Unselecting should set the step to null. Selected steps should be highlighted with a thin white cross going from corner to corner. We should use an inline SVG snippet for this.
> 
> Toggling a step should update the project store. Once the project store is updated, changes should propagate to SongPlayer and to the server via Cloud Firestore subscription automatically. No changes should be required to enable this propagation, but it would be good to read the code carefully to check that this will work.