### PR TITLE
FND-002 - Canonical schema-v1 domain model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,17 @@ src/
 │   ├── Dashboard.tsx
 │   ├── LoginButton.tsx
 │   └── ProjectList.tsx
-├── model/              # Data models and state management
-│   ├── types.ts             # TypeScript types for data models
+├── domain/             # Canonical schema-v1 domain model (authoritative)
+│   ├── entities.ts          # Entity shapes and their Zod schemas
+│   ├── ids.ts               # Prefixed stable IDs and ID factories
+│   ├── time.ts              # Integer musical time at 192 PPQ
+│   ├── parameters.ts        # Shared parameter definitions
+│   ├── parse.ts             # Validation and domain invariants
+│   ├── serialize.ts         # Deterministic JSON serialization
+│   ├── factories.ts         # Blank/entity factories
+│   └── fixtures.ts          # Deterministic reference projects
+├── model/              # Prototype state, superseded by src/domain
+│   ├── types.ts             # Prototype types (removed by the FND-009 slice)
 │   ├── project.ts           # Project store and update functions
 │   └── dataService.ts       # Firestore data access layer
 ├── routes/             # File-based routing
@@ -139,11 +148,20 @@ bun run test:ui      # Run tests with UI
 - Example: `import { useAuth } from "~/auth/AuthProvider"`
 
 ### TypeScript
-- Define types in `src/model/types.ts` for data models
-- Use discriminated unions for variant types (see Instrument type)
+- Define domain types in `src/domain` alongside their runtime schema; `src/model/types.ts` holds prototype types only
+- Use discriminated unions for variant types (see the domain Instrument and ClipContent types)
 - Leverage `Partial<T>` for update operations
 
 ## Architecture Patterns
+
+### Canonical domain model (`src/domain`)
+- `src/domain` is the authoritative schema-v1 contract (PRD sections 9.4 and 9.5). Its types, Zod schemas, invariants, and tests replace any separate domain-model document.
+- It has no Firebase, Tone.js, or SolidJS imports. Persistence, commands, audio, and rendering consume it from outside; audio nodes and Firestore `Timestamp`s never enter project state.
+- Persistent relationships use prefixed IDs from `createIdFactory()` (`createSeededIdFactory()` in tests), never array positions.
+- Musical time is integer ticks at 192 PPQ. Seconds, bars/beats/16ths, and pixels are derived through `src/domain/time.ts`.
+- A user-controlled numeric value declares its range, unit, default, clamping policy, and automation capability once in `src/domain/parameters.ts`; UI, validation, audio, and assistant tools read that definition instead of repeating literals.
+- `parseProject` is the only way to obtain a `Project`. It either returns a fully valid project or a list of issues, and never partially repairs input.
+- Changing this contract is its own backlog task, not incidental work inside a feature.
 
 ### Service Layer
 - Create service modules for external integrations (authService, dataService)

--- a/bun.lock
+++ b/bun.lock
@@ -13,8 +13,10 @@
         "@testing-library/jest-dom": "^6.6.2",
         "@testing-library/user-event": "^14.5.2",
         "@vitest/ui": "3.0.5",
+        "fast-check": "^4.9.0",
         "firebase": "^12.3.0",
         "jsdom": "^25.0.1",
+        "nanoid": "^6.0.0",
         "node-web-audio-api": "^2.1.0",
         "since-time-ago": "^1.1.1",
         "solid-firebase": "^0.3.0",
@@ -26,6 +28,7 @@
         "vite": "^6.0.0",
         "vite-plugin-solid": "^2.11.6",
         "vitest": "3.0.5",
+        "zod": "^4.4.3",
       },
     },
   },
@@ -772,6 +775,8 @@
 
     "exsolve": ["exsolve@1.0.7", "", {}, "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -1010,7 +1015,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "nitropack": ["nitropack@2.12.6", "", { "dependencies": { "@cloudflare/kv-asset-handler": "^0.4.0", "@rollup/plugin-alias": "^5.1.1", "@rollup/plugin-commonjs": "^28.0.6", "@rollup/plugin-inject": "^5.0.5", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.1", "@rollup/plugin-replace": "^6.0.2", "@rollup/plugin-terser": "^0.4.4", "@vercel/nft": "^0.30.1", "archiver": "^7.0.1", "c12": "^3.2.0", "chokidar": "^4.0.3", "citty": "^0.1.6", "compatx": "^0.2.0", "confbox": "^0.2.2", "consola": "^3.4.2", "cookie-es": "^2.0.0", "croner": "^9.1.0", "crossws": "^0.3.5", "db0": "^0.3.2", "defu": "^6.1.4", "destr": "^2.0.5", "dot-prop": "^9.0.0", "esbuild": "^0.25.9", "escape-string-regexp": "^5.0.0", "etag": "^1.8.1", "exsolve": "^1.0.7", "globby": "^14.1.0", "gzip-size": "^7.0.0", "h3": "^1.15.4", "hookable": "^5.5.3", "httpxy": "^0.1.7", "ioredis": "^5.7.0", "jiti": "^2.5.1", "klona": "^2.0.6", "knitwork": "^1.2.0", "listhen": "^1.9.0", "magic-string": "^0.30.19", "magicast": "^0.3.5", "mime": "^4.0.7", "mlly": "^1.8.0", "node-fetch-native": "^1.6.7", "node-mock-http": "^1.0.3", "ofetch": "^1.4.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "pretty-bytes": "^7.0.1", "radix3": "^1.1.2", "rollup": "^4.50.1", "rollup-plugin-visualizer": "^6.0.3", "scule": "^1.3.0", "semver": "^7.7.2", "serve-placeholder": "^2.0.2", "serve-static": "^2.2.0", "source-map": "^0.7.6", "std-env": "^3.9.0", "ufo": "^1.6.1", "ultrahtml": "^1.6.0", "uncrypto": "^0.1.3", "unctx": "^2.4.1", "unenv": "^2.0.0-rc.21", "unimport": "^5.2.0", "unplugin-utils": "^0.3.0", "unstorage": "^1.17.1", "untyped": "^2.0.0", "unwasm": "^0.3.11", "youch": "^4.1.0-beta.11", "youch-core": "^0.3.3" }, "peerDependencies": { "xml2js": "^0.6.2" }, "optionalPeers": ["xml2js"], "bin": { "nitro": "dist/cli/index.mjs", "nitropack": "dist/cli/index.mjs" } }, "sha512-DEq31s0SP4/Z5DIoVBRo9DbWFPWwIoYD4cQMEz7eE+iJMiAP+1k9A3B9kcc6Ihc0jDJmfUcHYyh6h2XlynCx6g=="],
 
@@ -1097,6 +1102,8 @@
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
@@ -1410,7 +1417,7 @@
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -1520,6 +1527,8 @@
 
     "open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -1553,6 +1562,8 @@
     "untyped/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "vinxi/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "vinxi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
 		"@testing-library/jest-dom": "^6.6.2",
 		"@testing-library/user-event": "^14.5.2",
 		"@vitest/ui": "3.0.5",
+		"fast-check": "^4.9.0",
 		"firebase": "^12.3.0",
 		"jsdom": "^25.0.1",
+		"nanoid": "^6.0.0",
 		"node-web-audio-api": "^2.1.0",
 		"since-time-ago": "^1.1.1",
 		"solid-firebase": "^0.3.0",
@@ -21,7 +23,8 @@
 		"vinxi": "^0.5.7",
 		"vite": "^6.0.0",
 		"vite-plugin-solid": "^2.11.6",
-		"vitest": "3.0.5"
+		"vitest": "3.0.5",
+		"zod": "^4.4.3"
 	},
 	"scripts": {
 		"samples": "node scripts/generate-samples.mjs",

--- a/src/domain/boundaries.test.ts
+++ b/src/domain/boundaries.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The domain model is framework-free (PRD section 9.2). Persistence, audio, and
+ * UI consume it from the outside, so a Firestore `Timestamp`, a Tone node, or a
+ * Solid signal can never reach stored project state.
+ */
+
+const domainDirectory = join(process.cwd(), "src", "domain");
+
+const FORBIDDEN_IMPORTS = [
+	"firebase",
+	"solid-js",
+	"@solidjs/",
+	"tone",
+	"vitest",
+];
+
+function sourceFiles(): string[] {
+	return readdirSync(domainDirectory).filter(
+		(file) => file.endsWith(".ts") && !file.endsWith(".test.ts"),
+	);
+}
+
+describe("domain boundaries", () => {
+	it("has source files to check", () => {
+		expect(sourceFiles().length).toBeGreaterThan(5);
+	});
+
+	it("imports no Firebase, Tone, Solid, or test-framework module", () => {
+		for (const file of sourceFiles()) {
+			const source = readFileSync(join(domainDirectory, file), "utf8");
+			const imports = [...source.matchAll(/from\s+"([^"]+)"/g)].map(
+				(match) => match[1],
+			);
+			for (const specifier of imports) {
+				for (const forbidden of FORBIDDEN_IMPORTS) {
+					expect(
+						specifier.startsWith(forbidden),
+						`${file} imports "${specifier}"`,
+					).toBe(false);
+				}
+			}
+		}
+	});
+});

--- a/src/domain/entities.ts
+++ b/src/domain/entities.ts
@@ -150,7 +150,7 @@ export const trackSchema = z.strictObject({
 	type: trackTypeSchema,
 	instrument: instrumentSchema.nullable(),
 	devices: z.array(deviceSchema),
-	sends: z.array(sendSchema),
+	sendConfig: z.array(sendSchema),
 	mixer: trackMixerSchema,
 });
 export type Track = z.infer<typeof trackSchema>;
@@ -197,6 +197,11 @@ export type Placement = z.infer<typeof placementSchema>;
 
 export const automationInterpolationSchema = z.enum(["linear", "step"]);
 
+/**
+ * `track` targets a parameter the track itself owns (mixer volume, pan, ...);
+ * `trackDevice` targets a parameter on one device in that track's chain, so
+ * it also needs `deviceId` to say which device.
+ */
 export const automationTargetSchema = z.discriminatedUnion("scope", [
 	z.strictObject({
 		scope: z.literal("track"),

--- a/src/domain/entities.ts
+++ b/src/domain/entities.ts
@@ -1,0 +1,339 @@
+import { z } from "zod";
+import {
+	assetIdSchema,
+	automationIdSchema,
+	clipIdSchema,
+	deviceIdSchema,
+	eventIdSchema,
+	padIdSchema,
+	placementIdSchema,
+	projectIdSchema,
+	returnIdSchema,
+	revisionIdSchema,
+	sectionIdSchema,
+	trackIdSchema,
+} from "./ids";
+import {
+	MASTER_VOLUME,
+	NOTE_PROBABILITY,
+	NOTE_VELOCITY,
+	parameterValueSchema,
+	RETURN_PAN,
+	RETURN_VOLUME,
+	SONG_TEMPO,
+	TRACK_PAN,
+	TRACK_SEND_LEVEL,
+	TRACK_VOLUME,
+} from "./parameters";
+import { durationTickSchema, tickSchema } from "./time";
+
+/**
+ * Schema-v1 entity shapes (PRD section 9.4).
+ *
+ * These runtime schemas and the types inferred from them are the authoritative
+ * domain contract. Every object is strict: an unknown key is malformed input,
+ * not a forward-compatible extension. Cross-entity integrity (dangling and
+ * cross-owner references, ordering, automation targets) is checked in
+ * `parse.ts`, which is the only entry point that yields a `Project`.
+ */
+
+/** The first production schema version. Prototype documents are not v1. */
+export const SCHEMA_VERSION = 1;
+
+const nonEmptyString = z.string().min(1);
+const displayName = z.string().min(1).max(120);
+const colorSchema = z
+	.string()
+	.regex(/^#[0-9a-fA-F]{6}$/, "Expected a #rrggbb color");
+const epochMillis = z.int().min(0);
+
+/** Free-form device/instrument parameter values, authored in Phase 1. */
+const parameterValues = z.record(z.string().min(1), z.number());
+
+export const assetKindSchema = z.enum(["sample", "loop", "recording"]);
+
+/** Asset identity is the ID; the storage reference is never identity. */
+export const assetSchema = z.strictObject({
+	id: assetIdSchema,
+	kind: assetKindSchema,
+	name: displayName,
+	storageRef: nonEmptyString,
+	url: z.string().nullable(),
+	durationSeconds: z.number().min(0).nullable(),
+	sampleRate: z.int().min(1).nullable(),
+	channelCount: z.int().min(1).max(2).nullable(),
+	provenance: z.strictObject({
+		source: nonEmptyString,
+		licence: nonEmptyString,
+		attribution: z.string().nullable(),
+	}),
+});
+export type Asset = z.infer<typeof assetSchema>;
+
+export const devicePresetSchema = z.strictObject({
+	id: nonEmptyString,
+	name: displayName,
+	source: nonEmptyString,
+});
+
+/**
+ * A processor in an ordered insert chain. Typed processors and their parameter
+ * definitions arrive with Phase 1 devices; v1 stores finite numeric values and
+ * validates them against a parameter definition once one is registered.
+ */
+export const deviceSchema = z.strictObject({
+	id: deviceIdSchema,
+	type: nonEmptyString,
+	order: z.int().min(0),
+	bypassed: z.boolean(),
+	parameters: parameterValues,
+	preset: devicePresetSchema.nullable(),
+});
+export type Device = z.infer<typeof deviceSchema>;
+
+export const padMixerSchema = z.strictObject({
+	volume: parameterValueSchema(TRACK_VOLUME),
+	pan: parameterValueSchema(TRACK_PAN),
+	muted: z.boolean(),
+});
+
+export const drumPadSchema = z.strictObject({
+	id: padIdSchema,
+	name: displayName,
+	assetId: assetIdSchema.nullable(),
+	chokeGroup: z.int().min(0).max(15).nullable(),
+	parameters: parameterValues,
+	mixer: padMixerSchema,
+});
+export type DrumPad = z.infer<typeof drumPadSchema>;
+
+export const instrumentSchema = z.discriminatedUnion("kind", [
+	z.strictObject({
+		kind: z.literal("sampler"),
+		assetId: assetIdSchema.nullable(),
+		parameters: parameterValues,
+	}),
+	z.strictObject({
+		kind: z.literal("synth"),
+		parameters: parameterValues,
+	}),
+	z.strictObject({
+		kind: z.literal("drumMachine"),
+		pads: z.array(drumPadSchema),
+		parameters: parameterValues,
+	}),
+]);
+export type Instrument = z.infer<typeof instrumentSchema>;
+
+export const sendSchema = z.strictObject({
+	returnId: returnIdSchema,
+	level: parameterValueSchema(TRACK_SEND_LEVEL),
+	preFader: z.boolean(),
+});
+export type Send = z.infer<typeof sendSchema>;
+
+export const trackMixerSchema = z.strictObject({
+	volume: parameterValueSchema(TRACK_VOLUME),
+	pan: parameterValueSchema(TRACK_PAN),
+	muted: z.boolean(),
+	soloed: z.boolean(),
+});
+export type TrackMixer = z.infer<typeof trackMixerSchema>;
+
+export const trackTypeSchema = z.enum(["instrument", "audio"]);
+
+export const trackSchema = z.strictObject({
+	id: trackIdSchema,
+	name: displayName,
+	color: colorSchema,
+	order: z.int().min(0),
+	type: trackTypeSchema,
+	instrument: instrumentSchema.nullable(),
+	devices: z.array(deviceSchema),
+	sends: z.array(sendSchema),
+	mixer: trackMixerSchema,
+});
+export type Track = z.infer<typeof trackSchema>;
+
+export const returnBusSchema = z.strictObject({
+	id: returnIdSchema,
+	name: displayName,
+	order: z.int().min(0),
+	devices: z.array(deviceSchema),
+	mixer: z.strictObject({
+		volume: parameterValueSchema(RETURN_VOLUME),
+		pan: parameterValueSchema(RETURN_PAN),
+		muted: z.boolean(),
+	}),
+});
+export type ReturnBus = z.infer<typeof returnBusSchema>;
+
+export const masterSettingsSchema = z.strictObject({
+	volume: parameterValueSchema(MASTER_VOLUME),
+	devices: z.array(deviceSchema),
+});
+export type MasterSettings = z.infer<typeof masterSettingsSchema>;
+
+export const sectionSchema = z.strictObject({
+	id: sectionIdSchema,
+	name: displayName,
+	color: colorSchema,
+	startTicks: tickSchema,
+	durationTicks: durationTickSchema,
+});
+export type Section = z.infer<typeof sectionSchema>;
+
+/** Arrangement placement of a clip. Clip content stays separate (invariant 3). */
+export const placementSchema = z.strictObject({
+	id: placementIdSchema,
+	clipId: clipIdSchema,
+	trackId: trackIdSchema,
+	startTicks: tickSchema,
+	durationTicks: durationTickSchema,
+	clipOffsetTicks: tickSchema,
+	looped: z.boolean(),
+});
+export type Placement = z.infer<typeof placementSchema>;
+
+export const automationInterpolationSchema = z.enum(["linear", "step"]);
+
+export const automationTargetSchema = z.discriminatedUnion("scope", [
+	z.strictObject({
+		scope: z.literal("track"),
+		trackId: trackIdSchema,
+		parameterId: nonEmptyString,
+	}),
+	z.strictObject({
+		scope: z.literal("trackDevice"),
+		trackId: trackIdSchema,
+		deviceId: deviceIdSchema,
+		parameterId: nonEmptyString,
+	}),
+	z.strictObject({
+		scope: z.literal("send"),
+		trackId: trackIdSchema,
+		returnId: returnIdSchema,
+		parameterId: nonEmptyString,
+	}),
+	z.strictObject({
+		scope: z.literal("return"),
+		returnId: returnIdSchema,
+		parameterId: nonEmptyString,
+	}),
+	z.strictObject({
+		scope: z.literal("master"),
+		parameterId: nonEmptyString,
+	}),
+]);
+export type AutomationTarget = z.infer<typeof automationTargetSchema>;
+
+export const automationPointSchema = z.strictObject({
+	tick: tickSchema,
+	value: z.number(),
+});
+export type AutomationPoint = z.infer<typeof automationPointSchema>;
+
+export const automationLaneSchema = z.strictObject({
+	id: automationIdSchema,
+	target: automationTargetSchema,
+	interpolation: automationInterpolationSchema,
+	points: z.array(automationPointSchema),
+});
+export type AutomationLane = z.infer<typeof automationLaneSchema>;
+
+/** A note triggers either a pitch or a drum pad on the owning track. */
+export const noteTriggerSchema = z.discriminatedUnion("kind", [
+	z.strictObject({ kind: z.literal("pitch"), pitch: z.int().min(0).max(127) }),
+	z.strictObject({ kind: z.literal("pad"), padId: padIdSchema }),
+]);
+export type NoteTrigger = z.infer<typeof noteTriggerSchema>;
+
+export const noteEventSchema = z.strictObject({
+	id: eventIdSchema,
+	trigger: noteTriggerSchema,
+	startTicks: tickSchema,
+	durationTicks: durationTickSchema,
+	velocity: parameterValueSchema(NOTE_VELOCITY),
+	probability: parameterValueSchema(NOTE_PROBABILITY).nullable(),
+});
+export type NoteEvent = z.infer<typeof noteEventSchema>;
+
+export const clipContentSchema = z.discriminatedUnion("kind", [
+	z.strictObject({
+		kind: z.literal("notes"),
+		events: z.array(noteEventSchema),
+	}),
+	z.strictObject({
+		kind: z.literal("audioLoop"),
+		assetId: assetIdSchema,
+		sourceTempo: parameterValueSchema(SONG_TEMPO),
+		startOffsetTicks: tickSchema,
+	}),
+]);
+export type ClipContent = z.infer<typeof clipContentSchema>;
+
+export const clipSchema = z.strictObject({
+	id: clipIdSchema,
+	trackId: trackIdSchema,
+	name: displayName,
+	color: colorSchema,
+	lengthTicks: durationTickSchema,
+	content: clipContentSchema,
+});
+export type Clip = z.infer<typeof clipSchema>;
+
+/** The alpha time signature is fixed at 4/4; the field exists for migration. */
+export const timeSignatureSchema = z.strictObject({
+	numerator: z.literal(4),
+	denominator: z.literal(4),
+});
+export type TimeSignature = z.infer<typeof timeSignatureSchema>;
+
+export const songSchema = z.strictObject({
+	tempo: parameterValueSchema(SONG_TEMPO),
+	timeSignature: timeSignatureSchema,
+	tracks: z.array(trackSchema),
+	returns: z.array(returnBusSchema),
+	master: masterSettingsSchema,
+	sections: z.array(sectionSchema),
+	placements: z.array(placementSchema),
+	automation: z.array(automationLaneSchema),
+	assets: z.array(assetSchema),
+});
+export type Song = z.infer<typeof songSchema>;
+
+export const projectMetadataSchema = z.strictObject({
+	id: projectIdSchema,
+	schemaVersion: z.literal(SCHEMA_VERSION),
+	revision: z.int().min(0),
+	name: displayName,
+	ownerId: nonEmptyString,
+	collaboratorIds: z.array(nonEmptyString),
+	createdAt: epochMillis,
+	modifiedAt: epochMillis,
+	template: z.string().nullable(),
+	genre: z.string().nullable(),
+});
+export type ProjectMetadata = z.infer<typeof projectMetadataSchema>;
+
+/** A named checkpoint (PRJ-05). v1 stores the shape; restore ships later. */
+export const revisionSchema = z.strictObject({
+	id: revisionIdSchema,
+	projectId: projectIdSchema,
+	revision: z.int().min(0),
+	authorId: nonEmptyString,
+	createdAt: epochMillis,
+	name: z.string().nullable(),
+});
+export type Revision = z.infer<typeof revisionSchema>;
+
+/**
+ * The whole project aggregate. Its three parts map one-to-one onto the PRD
+ * section 9.9 Firestore tiers: metadata, song, and clips.
+ */
+export const projectSchema = z.strictObject({
+	metadata: projectMetadataSchema,
+	song: songSchema,
+	clips: z.array(clipSchema),
+});
+export type Project = z.infer<typeof projectSchema>;

--- a/src/domain/factories.test.ts
+++ b/src/domain/factories.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { SCHEMA_VERSION } from "./entities";
+import { createBlankProject } from "./factories";
+import { createReferenceProject, createSliceFixtureProject } from "./fixtures";
+import { createSeededIdFactory, idPattern } from "./ids";
+import { MASTER_VOLUME, SONG_TEMPO } from "./parameters";
+import { isProject, parseProject } from "./parse";
+import { minutesToTicks, TICKS_PER_BAR } from "./time";
+
+describe("blank project factory", () => {
+	it("produces a valid, empty schema-v1 project", () => {
+		const project = createBlankProject({ ownerId: "user_1" });
+
+		expect(isProject(project)).toBe(true);
+		expect(project.metadata.schemaVersion).toBe(SCHEMA_VERSION);
+		expect(project.metadata.revision).toBe(0);
+		expect(project.metadata.id).toMatch(idPattern("project"));
+		expect(project.song.tempo).toBe(SONG_TEMPO.defaultValue);
+		expect(project.song.master.volume).toBe(MASTER_VOLUME.defaultValue);
+		expect(project.song.tracks).toEqual([]);
+		expect(project.clips).toEqual([]);
+	});
+
+	it("keeps Firebase and audio types out of the domain", () => {
+		const project = createBlankProject({ ownerId: "user_1", now: 1_700_000 });
+		expect(typeof project.metadata.createdAt).toBe("number");
+		expect(typeof project.metadata.modifiedAt).toBe("number");
+		expect(JSON.parse(JSON.stringify(project)).metadata.createdAt).toBe(
+			1_700_000,
+		);
+	});
+
+	it("produces independent projects that share no mutable state", () => {
+		const first = createBlankProject({ ownerId: "user_1" });
+		const second = createBlankProject({ ownerId: "user_1" });
+
+		expect(second.metadata.id).not.toBe(first.metadata.id);
+		expect(second.song).not.toBe(first.song);
+
+		second.song.tracks.push(createSliceFixtureProject().song.tracks[0]);
+		expect(first.song.tracks).toHaveLength(0);
+	});
+
+	it("takes an injected clock and id factory for deterministic state", () => {
+		const options = {
+			ownerId: "user_1",
+			name: "Seeded",
+			ids: createSeededIdFactory("blank"),
+			now: 1_234_567,
+		};
+		const first = createBlankProject(options);
+		const second = createBlankProject({
+			...options,
+			ids: createSeededIdFactory("blank"),
+		});
+
+		expect(second).toEqual(first);
+		expect(first.metadata.createdAt).toBe(1_234_567);
+	});
+
+	it("clamps an out-of-range tempo through the shared parameter definition", () => {
+		expect(
+			createBlankProject({ ownerId: "user_1", tempo: 5_000 }).song.tempo,
+		).toBe(SONG_TEMPO.max);
+	});
+});
+
+describe("fixtures", () => {
+	it("builds the slice fixture: a sampler track, a one-bar clip, one placement", () => {
+		const project = createSliceFixtureProject();
+
+		expect(parseProject(project).ok).toBe(true);
+		expect(project.song.tracks).toHaveLength(1);
+		expect(project.song.tracks[0].instrument?.kind).toBe("sampler");
+		expect(project.clips).toHaveLength(1);
+		expect(project.clips[0].lengthTicks).toBe(TICKS_PER_BAR);
+		expect(project.song.placements).toHaveLength(1);
+		if (project.clips[0].content.kind === "notes") {
+			expect(project.clips[0].content.events).toHaveLength(4);
+		}
+	});
+
+	it("is deterministic and independent across calls", () => {
+		const first = createSliceFixtureProject();
+		const second = createSliceFixtureProject();
+
+		expect(second).toEqual(first);
+		expect(second.song.tracks[0]).not.toBe(first.song.tracks[0]);
+
+		second.song.tracks[0].name = "changed";
+		expect(first.song.tracks[0].name).toBe("BD");
+	});
+
+	it("varies ids by seed while staying valid", () => {
+		const other = createSliceFixtureProject({ seed: "another" });
+		expect(other.metadata.id).not.toBe(createSliceFixtureProject().metadata.id);
+		expect(isProject(other)).toBe(true);
+	});
+
+	it("builds the PRD reference arrangement at ten-minute bounds", () => {
+		const project = createReferenceProject();
+		const lengthTicks = minutesToTicks(10, project.song.tempo);
+
+		expect(parseProject(project).ok).toBe(true);
+		expect(project.song.tracks).toHaveLength(50);
+		expect(project.song.placements.length).toBeGreaterThanOrEqual(2_500);
+		expect(project.song.automation).toHaveLength(100);
+		expect(project.clips).toHaveLength(50);
+
+		const lastTick = Math.max(
+			...project.song.placements.map(
+				(placement) => placement.startTicks + placement.durationTicks,
+			),
+		);
+		expect(lastTick).toBeLessThanOrEqual(lengthTicks);
+		expect(lengthTicks).toBe(230_400);
+	});
+
+	it("scales down to a smaller arrangement without breaking invariants", () => {
+		const small = createReferenceProject({
+			trackCount: 4,
+			minutes: 1,
+			placementCount: 16,
+			automationLaneCount: 4,
+		});
+		expect(parseProject(small).ok).toBe(true);
+		expect(small.song.tracks).toHaveLength(4);
+	});
+});

--- a/src/domain/factories.ts
+++ b/src/domain/factories.ts
@@ -147,6 +147,12 @@ export function createDrumPad(
 	};
 }
 
+export function createDrumMachineInstrument(
+	pads: readonly DrumPad[] = [],
+): Instrument {
+	return { kind: "drumMachine", pads: [...pads], parameters: {} };
+}
+
 export function createReturnBus(
 	context: DomainFactoryContext,
 	options: { name: string; order: number },
@@ -224,6 +230,38 @@ export function createNoteClip(
 		color: options.color ?? TRACK_COLORS[0],
 		lengthTicks: toTicks(options.lengthTicks ?? TICKS_PER_BAR),
 		content: { kind: "notes", events: options.events ?? [] },
+	};
+}
+
+export interface CreateAudioLoopClipOptions {
+	trackId: TrackId;
+	assetId: AssetId;
+	name: string;
+	lengthTicks?: number;
+	color?: string;
+	sourceTempo?: number;
+	startOffsetTicks?: number;
+}
+
+export function createAudioLoopClip(
+	context: DomainFactoryContext,
+	options: CreateAudioLoopClipOptions,
+): Clip {
+	return {
+		id: context.ids("clip"),
+		trackId: options.trackId,
+		name: options.name,
+		color: options.color ?? TRACK_COLORS[0],
+		lengthTicks: toTicks(options.lengthTicks ?? TICKS_PER_BAR),
+		content: {
+			kind: "audioLoop",
+			assetId: options.assetId,
+			sourceTempo: clampParameterValue(
+				SONG_TEMPO,
+				options.sourceTempo ?? SONG_TEMPO.defaultValue,
+			),
+			startOffsetTicks: toTicks(options.startOffsetTicks ?? 0),
+		},
 	};
 }
 

--- a/src/domain/factories.ts
+++ b/src/domain/factories.ts
@@ -1,0 +1,369 @@
+import {
+	type Asset,
+	type Clip,
+	type Device,
+	type DrumPad,
+	type Instrument,
+	type NoteEvent,
+	type Placement,
+	type Project,
+	type ProjectMetadata,
+	type ReturnBus,
+	SCHEMA_VERSION,
+	type Section,
+	type Song,
+	type Track,
+} from "./entities";
+import {
+	type AssetId,
+	type ClipId,
+	createIdFactory,
+	type IdFactory,
+	type PadId,
+	type ReturnId,
+	type TrackId,
+} from "./ids";
+import {
+	clampParameterValue,
+	MASTER_VOLUME,
+	NOTE_VELOCITY,
+	RETURN_PAN,
+	RETURN_VOLUME,
+	SONG_TEMPO,
+	TRACK_PAN,
+	TRACK_SEND_LEVEL,
+	TRACK_VOLUME,
+} from "./parameters";
+import { assertProject } from "./parse";
+import { TICKS_PER_BAR, type Ticks, toTicks } from "./time";
+
+/**
+ * Domain factories.
+ *
+ * Factories build valid schema-v1 state from plain arguments. They never touch
+ * Firebase, Tone, or Solid: an ID factory and a clock are injected so fixtures
+ * and tests are deterministic. Every project-level factory returns state that
+ * has passed `assertProject`, so an invalid project cannot escape a factory.
+ */
+
+/** Track colors from the editor palette, cycled by track order. */
+export const TRACK_COLORS = [
+	"#e0573e",
+	"#e8a33d",
+	"#4fa86b",
+	"#3d7fe8",
+	"#8a5ce0",
+	"#d84f9c",
+] as const;
+
+export type Clock = () => number;
+
+export interface DomainFactoryContext {
+	readonly ids: IdFactory;
+	readonly now: Clock;
+}
+
+export function createFactoryContext(
+	options: { ids?: IdFactory; now?: number | Clock } = {},
+): DomainFactoryContext {
+	const now =
+		typeof options.now === "function"
+			? options.now
+			: () => (typeof options.now === "number" ? options.now : Date.now());
+	return { ids: options.ids ?? createIdFactory(), now };
+}
+
+export function trackColor(order: number): string {
+	return TRACK_COLORS[order % TRACK_COLORS.length];
+}
+
+export interface CreateTrackOptions {
+	name: string;
+	order: number;
+	type?: Track["type"];
+	instrument?: Instrument | null;
+	color?: string;
+	devices?: Device[];
+	sends?: Track["sends"];
+	volume?: number;
+	pan?: number;
+	muted?: boolean;
+	soloed?: boolean;
+}
+
+export function createTrack(
+	context: DomainFactoryContext,
+	options: CreateTrackOptions,
+): Track {
+	return {
+		id: context.ids("track"),
+		name: options.name,
+		color: options.color ?? trackColor(options.order),
+		order: options.order,
+		type: options.type ?? "instrument",
+		instrument: options.instrument ?? null,
+		devices: options.devices ?? [],
+		sends: options.sends ?? [],
+		mixer: {
+			volume: clampParameterValue(
+				TRACK_VOLUME,
+				options.volume ?? TRACK_VOLUME.defaultValue,
+			),
+			pan: clampParameterValue(
+				TRACK_PAN,
+				options.pan ?? TRACK_PAN.defaultValue,
+			),
+			muted: options.muted ?? false,
+			soloed: options.soloed ?? false,
+		},
+	};
+}
+
+export function createSamplerInstrument(
+	assetId: AssetId | null = null,
+): Instrument {
+	return { kind: "sampler", assetId, parameters: {} };
+}
+
+export function createDrumPad(
+	context: DomainFactoryContext,
+	options: {
+		name: string;
+		assetId?: AssetId | null;
+		chokeGroup?: number | null;
+	},
+): DrumPad {
+	return {
+		id: context.ids("pad"),
+		name: options.name,
+		assetId: options.assetId ?? null,
+		chokeGroup: options.chokeGroup ?? null,
+		parameters: {},
+		mixer: {
+			volume: TRACK_VOLUME.defaultValue,
+			pan: TRACK_PAN.defaultValue,
+			muted: false,
+		},
+	};
+}
+
+export function createReturnBus(
+	context: DomainFactoryContext,
+	options: { name: string; order: number },
+): ReturnBus {
+	return {
+		id: context.ids("return"),
+		name: options.name,
+		order: options.order,
+		devices: [],
+		mixer: {
+			volume: RETURN_VOLUME.defaultValue,
+			pan: RETURN_PAN.defaultValue,
+			muted: false,
+		},
+	};
+}
+
+export function createSend(
+	returnId: ReturnId,
+	level: number = TRACK_SEND_LEVEL.defaultValue,
+	preFader = false,
+): Track["sends"][number] {
+	return {
+		returnId,
+		level: clampParameterValue(TRACK_SEND_LEVEL, level),
+		preFader,
+	};
+}
+
+export interface CreateNoteEventOptions {
+	startTicks: number;
+	durationTicks: number;
+	pitch?: number;
+	padId?: PadId;
+	velocity?: number;
+	probability?: number | null;
+}
+
+export function createNoteEvent(
+	context: DomainFactoryContext,
+	options: CreateNoteEventOptions,
+): NoteEvent {
+	return {
+		id: context.ids("event"),
+		trigger:
+			options.padId !== undefined
+				? { kind: "pad", padId: options.padId }
+				: { kind: "pitch", pitch: options.pitch ?? 60 },
+		startTicks: toTicks(options.startTicks),
+		durationTicks: toTicks(options.durationTicks),
+		velocity: clampParameterValue(
+			NOTE_VELOCITY,
+			options.velocity ?? NOTE_VELOCITY.defaultValue,
+		),
+		probability: options.probability ?? null,
+	};
+}
+
+export interface CreateNoteClipOptions {
+	trackId: TrackId;
+	name: string;
+	lengthTicks?: number;
+	color?: string;
+	events?: NoteEvent[];
+}
+
+export function createNoteClip(
+	context: DomainFactoryContext,
+	options: CreateNoteClipOptions,
+): Clip {
+	return {
+		id: context.ids("clip"),
+		trackId: options.trackId,
+		name: options.name,
+		color: options.color ?? TRACK_COLORS[0],
+		lengthTicks: toTicks(options.lengthTicks ?? TICKS_PER_BAR),
+		content: { kind: "notes", events: options.events ?? [] },
+	};
+}
+
+export interface CreatePlacementOptions {
+	clipId: ClipId;
+	trackId: TrackId;
+	startTicks: number;
+	durationTicks: number;
+	clipOffsetTicks?: number;
+	looped?: boolean;
+}
+
+export function createPlacement(
+	context: DomainFactoryContext,
+	options: CreatePlacementOptions,
+): Placement {
+	return {
+		id: context.ids("placement"),
+		clipId: options.clipId,
+		trackId: options.trackId,
+		startTicks: toTicks(options.startTicks),
+		durationTicks: toTicks(options.durationTicks),
+		clipOffsetTicks: toTicks(options.clipOffsetTicks ?? 0),
+		looped: options.looped ?? false,
+	};
+}
+
+export interface CreateSectionOptions {
+	name: string;
+	startTicks: number;
+	durationTicks: number;
+	color?: string;
+}
+
+export function createSection(
+	context: DomainFactoryContext,
+	options: CreateSectionOptions,
+): Section {
+	return {
+		id: context.ids("section"),
+		name: options.name,
+		color: options.color ?? TRACK_COLORS[3],
+		startTicks: toTicks(options.startTicks),
+		durationTicks: toTicks(options.durationTicks),
+	};
+}
+
+export interface CreateAssetOptions {
+	name: string;
+	storageRef: string;
+	kind?: Asset["kind"];
+	url?: string | null;
+	durationSeconds?: number | null;
+	sampleRate?: number | null;
+	channelCount?: number | null;
+	source?: string;
+	licence?: string;
+	attribution?: string | null;
+}
+
+export function createAsset(
+	context: DomainFactoryContext,
+	options: CreateAssetOptions,
+): Asset {
+	return {
+		id: context.ids("asset"),
+		kind: options.kind ?? "sample",
+		name: options.name,
+		storageRef: options.storageRef,
+		url: options.url ?? null,
+		durationSeconds: options.durationSeconds ?? null,
+		sampleRate: options.sampleRate ?? null,
+		channelCount: options.channelCount ?? null,
+		provenance: {
+			source: options.source ?? "solid-groove",
+			licence: options.licence ?? "internal",
+			attribution: options.attribution ?? null,
+		},
+	};
+}
+
+export function createEmptySong(tempo: number = SONG_TEMPO.defaultValue): Song {
+	return {
+		tempo: clampParameterValue(SONG_TEMPO, tempo),
+		timeSignature: { numerator: 4, denominator: 4 },
+		tracks: [],
+		returns: [],
+		master: { volume: MASTER_VOLUME.defaultValue, devices: [] },
+		sections: [],
+		placements: [],
+		automation: [],
+		assets: [],
+	};
+}
+
+export interface CreateProjectMetadataOptions {
+	ownerId: string;
+	name?: string;
+	collaboratorIds?: string[];
+	template?: string | null;
+	genre?: string | null;
+	revision?: number;
+}
+
+export function createProjectMetadata(
+	context: DomainFactoryContext,
+	options: CreateProjectMetadataOptions,
+): ProjectMetadata {
+	const timestamp = context.now();
+	return {
+		id: context.ids("project"),
+		schemaVersion: SCHEMA_VERSION,
+		revision: options.revision ?? 0,
+		name: options.name ?? "Untitled Project",
+		ownerId: options.ownerId,
+		collaboratorIds: options.collaboratorIds ?? [],
+		createdAt: timestamp,
+		modifiedAt: timestamp,
+		template: options.template ?? null,
+		genre: options.genre ?? null,
+	};
+}
+
+export interface CreateProjectOptions extends CreateProjectMetadataOptions {
+	ids?: IdFactory;
+	now?: number | Clock;
+	tempo?: number;
+}
+
+/** A valid, empty schema-v1 project. Each call returns independent state. */
+export function createBlankProject(options: CreateProjectOptions): Project {
+	const context = createFactoryContext(options);
+	return assertProject({
+		metadata: createProjectMetadata(context, options),
+		song: createEmptySong(options.tempo),
+		clips: [],
+	});
+}
+
+/** Bar length helper for factories and fixtures. */
+export function bars(count: number): Ticks {
+	return toTicks(count * TICKS_PER_BAR);
+}

--- a/src/domain/factories.ts
+++ b/src/domain/factories.ts
@@ -46,14 +46,52 @@ import { TICKS_PER_BAR, type Ticks, toTicks } from "./time";
  * has passed `assertProject`, so an invalid project cannot escape a factory.
  */
 
-/** Track colors from the editor palette, cycled by track order. */
+/**
+ * Track colors from the editor palette, cycled by track order. Spans the hue
+ * wheel once at a mid tone, once lighter, then a handful more at a darker
+ * tone, so tracks stay visually distinct well past a typical track count.
+ */
 export const TRACK_COLORS = [
-	"#e0573e",
-	"#e8a33d",
-	"#4fa86b",
-	"#3d7fe8",
-	"#8a5ce0",
-	"#d84f9c",
+	"#ef4444",
+	"#f97316",
+	"#f59e0b",
+	"#eab308",
+	"#84cc16",
+	"#22c55e",
+	"#10b981",
+	"#14b8a6",
+	"#06b6d4",
+	"#0ea5e9",
+	"#3b82f6",
+	"#6366f1",
+	"#8b5cf6",
+	"#a855f7",
+	"#d946ef",
+	"#ec4899",
+	"#f43f5e",
+	"#f87171",
+	"#fb923c",
+	"#fbbf24",
+	"#facc15",
+	"#a3e635",
+	"#4ade80",
+	"#34d399",
+	"#2dd4bf",
+	"#22d3ee",
+	"#38bdf8",
+	"#60a5fa",
+	"#818cf8",
+	"#a78bfa",
+	"#c084fc",
+	"#e879f9",
+	"#f472b6",
+	"#fb7185",
+	"#dc2626",
+	"#ca8a04",
+	"#059669",
+	"#0284c7",
+	"#9333ea",
+	"#e11d48",
 ] as const;
 
 export type Clock = () => number;
@@ -63,14 +101,19 @@ export interface DomainFactoryContext {
 	readonly now: Clock;
 }
 
+function resolveClock(now: number | Clock | undefined): Clock {
+	if (typeof now === "function") return now;
+	if (typeof now === "number") return () => now;
+	return () => Date.now();
+}
+
 export function createFactoryContext(
 	options: { ids?: IdFactory; now?: number | Clock } = {},
 ): DomainFactoryContext {
-	const now =
-		typeof options.now === "function"
-			? options.now
-			: () => (typeof options.now === "number" ? options.now : Date.now());
-	return { ids: options.ids ?? createIdFactory(), now };
+	return {
+		ids: options.ids ?? createIdFactory(),
+		now: resolveClock(options.now),
+	};
 }
 
 export function trackColor(order: number): string {
@@ -84,7 +127,7 @@ export interface CreateTrackOptions {
 	instrument?: Instrument | null;
 	color?: string;
 	devices?: Device[];
-	sends?: Track["sends"];
+	sendConfig?: Track["sendConfig"];
 	volume?: number;
 	pan?: number;
 	muted?: boolean;
@@ -103,7 +146,7 @@ export function createTrack(
 		type: options.type ?? "instrument",
 		instrument: options.instrument ?? null,
 		devices: options.devices ?? [],
-		sends: options.sends ?? [],
+		sendConfig: options.sendConfig ?? [],
 		mixer: {
 			volume: clampParameterValue(
 				TRACK_VOLUME,
@@ -174,7 +217,7 @@ export function createSend(
 	returnId: ReturnId,
 	level: number = TRACK_SEND_LEVEL.defaultValue,
 	preFader = false,
-): Track["sends"][number] {
+): Track["sendConfig"][number] {
 	return {
 		returnId,
 		level: clampParameterValue(TRACK_SEND_LEVEL, level),

--- a/src/domain/fixtures.ts
+++ b/src/domain/fixtures.ts
@@ -1,0 +1,257 @@
+import type {
+	AutomationLane,
+	Clip,
+	Placement,
+	Project,
+	Section,
+	Track,
+} from "./entities";
+import {
+	bars,
+	createAsset,
+	createEmptySong,
+	createFactoryContext,
+	createNoteClip,
+	createNoteEvent,
+	createPlacement,
+	createProjectMetadata,
+	createSamplerInstrument,
+	createSection,
+	createTrack,
+	type DomainFactoryContext,
+} from "./factories";
+import { createSeededIdFactory, type IdFactory } from "./ids";
+import { TRACK_PAN, TRACK_VOLUME } from "./parameters";
+import { assertProject } from "./parse";
+import {
+	minutesToTicks,
+	TICKS_PER_BAR,
+	TICKS_PER_SIXTEENTH,
+	toTicks,
+} from "./time";
+
+/**
+ * Deterministic domain fixtures.
+ *
+ * These are the shared reference projects for schema, persistence, renderer,
+ * and audio tests. They are built from the same factories as production state
+ * and are always seeded, so two runs produce identical IDs and identical
+ * serialized JSON.
+ */
+
+export interface FixtureOptions {
+	seed?: string;
+	ownerId?: string;
+	now?: number;
+	tempo?: number;
+}
+
+interface FixtureContext extends DomainFactoryContext {
+	readonly ids: IdFactory;
+}
+
+function fixtureContext(options: FixtureOptions, seed: string): FixtureContext {
+	return createFactoryContext({
+		ids: createSeededIdFactory(options.seed ?? seed),
+		now: options.now ?? 1_700_000_000_000,
+	});
+}
+
+/**
+ * The `FND-009` vertical slice fixture: one sampler track holding a one-bar
+ * four-on-the-floor clip placed once in the arrangement.
+ */
+export function createSliceFixtureProject(
+	options: FixtureOptions = {},
+): Project {
+	const context = fixtureContext(options, "slice-fixture");
+	const song = createEmptySong(options.tempo ?? 120);
+
+	const asset = createAsset(context, {
+		name: "909 Bass Drum",
+		storageRef: "samples/house/drums/bd/909-bd.wav",
+		url: "/samples/house/drums/bd/909-bd.wav",
+		durationSeconds: 0.6,
+		sampleRate: 44_100,
+		channelCount: 1,
+	});
+
+	const track = createTrack(context, {
+		name: "BD",
+		order: 0,
+		instrument: createSamplerInstrument(asset.id),
+	});
+
+	const clip = createNoteClip(context, {
+		trackId: track.id,
+		name: "Four on the floor",
+		lengthTicks: TICKS_PER_BAR,
+		events: [0, 4, 8, 12].map((sixteenth) =>
+			createNoteEvent(context, {
+				startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+				durationTicks: TICKS_PER_SIXTEENTH,
+				pitch: 36,
+			}),
+		),
+	});
+
+	const placement = createPlacement(context, {
+		clipId: clip.id,
+		trackId: track.id,
+		startTicks: 0,
+		durationTicks: TICKS_PER_BAR,
+	});
+
+	return assertProject({
+		metadata: createProjectMetadata(context, {
+			ownerId: options.ownerId ?? "user_fixture",
+			name: "Slice fixture",
+			template: "blank",
+		}),
+		song: {
+			...song,
+			assets: [asset],
+			tracks: [track],
+			placements: [placement],
+		},
+		clips: [clip],
+	});
+}
+
+export interface ReferenceProjectOptions extends FixtureOptions {
+	/** Tracks in the arrangement. The PRD reference project uses 50. */
+	trackCount?: number;
+	/** Arrangement length in minutes. The PRD reference project uses 10. */
+	minutes?: number;
+	/** Total arrangement placements. The PRD reference project uses 2,500. */
+	placementCount?: number;
+	/** Automation lanes. The PRD reference project uses 100. */
+	automationLaneCount?: number;
+}
+
+/**
+ * The PRD section 9.3 reference arrangement: 50 tracks, ten minutes of musical
+ * time, 2,500 placements, and 100 automation lanes by default. Used for
+ * ten-minute bound tests here, and by persistence and renderer budgets later.
+ */
+export function createReferenceProject(
+	options: ReferenceProjectOptions = {},
+): Project {
+	const context = fixtureContext(options, "reference-fixture");
+	const tempo = options.tempo ?? 120;
+	const trackCount = options.trackCount ?? 50;
+	const minutes = options.minutes ?? 10;
+	const placementCount = options.placementCount ?? 2_500;
+	const automationLaneCount = options.automationLaneCount ?? 100;
+
+	const lengthTicks = minutesToTicks(minutes, tempo);
+	const barCount = Math.floor(lengthTicks / TICKS_PER_BAR);
+
+	const tracks: Track[] = [];
+	const clips: Clip[] = [];
+	const placements: Placement[] = [];
+	const automation: AutomationLane[] = [];
+
+	const asset = createAsset(context, {
+		name: "Reference loop",
+		storageRef: "samples/reference/loop.wav",
+		url: "/samples/reference/loop.wav",
+		durationSeconds: 2,
+		sampleRate: 44_100,
+		channelCount: 2,
+	});
+
+	const placementsPerTrack = Math.ceil(placementCount / trackCount);
+
+	for (let index = 0; index < trackCount; index += 1) {
+		const track = createTrack(context, {
+			name: `Track ${index + 1}`,
+			order: index,
+			instrument: createSamplerInstrument(asset.id),
+		});
+		tracks.push(track);
+
+		const clip = createNoteClip(context, {
+			trackId: track.id,
+			name: `Clip ${index + 1}`,
+			lengthTicks: TICKS_PER_BAR * 2,
+			events: [0, 2, 4, 6, 8, 10, 12, 14].map((sixteenth) =>
+				createNoteEvent(context, {
+					startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+					durationTicks: TICKS_PER_SIXTEENTH,
+					pitch: 36 + (index % 24),
+					velocity: 0.6 + (index % 4) / 10,
+				}),
+			),
+		});
+		clips.push(clip);
+
+		const spacingBars = Math.max(
+			2,
+			Math.floor(barCount / Math.max(1, placementsPerTrack)),
+		);
+		for (let slot = 0; slot < placementsPerTrack; slot += 1) {
+			const startBar = slot * spacingBars;
+			if (startBar + 2 > barCount) {
+				break;
+			}
+			if (placements.length >= placementCount) {
+				break;
+			}
+			placements.push(
+				createPlacement(context, {
+					clipId: clip.id,
+					trackId: track.id,
+					startTicks: bars(startBar),
+					durationTicks: bars(2),
+				}),
+			);
+		}
+	}
+
+	for (let index = 0; index < automationLaneCount; index += 1) {
+		const track = tracks[index % tracks.length];
+		const parameter = index % 2 === 0 ? TRACK_VOLUME : TRACK_PAN;
+		automation.push({
+			id: context.ids("automation"),
+			target: {
+				scope: "track",
+				trackId: track.id,
+				parameterId: parameter.id,
+			},
+			interpolation: "linear",
+			points: Array.from({ length: 32 }, (_, pointIndex) => ({
+				tick: toTicks(pointIndex * Math.floor(lengthTicks / 32)),
+				value:
+					parameter.min +
+					((parameter.max - parameter.min) * (pointIndex % 8)) / 8,
+			})),
+		});
+	}
+
+	const sections: Section[] = ["Intro", "Verse", "Chorus", "Outro"].map(
+		(name, index) =>
+			createSection(context, {
+				name,
+				startTicks: bars(index * Math.floor(barCount / 4)),
+				durationTicks: bars(Math.max(1, Math.floor(barCount / 4))),
+			}),
+	);
+
+	return assertProject({
+		metadata: createProjectMetadata(context, {
+			ownerId: options.ownerId ?? "user_fixture",
+			name: "Reference arrangement",
+			genre: "house",
+		}),
+		song: {
+			...createEmptySong(tempo),
+			assets: [asset],
+			tracks,
+			placements,
+			automation,
+			sections,
+		},
+		clips,
+	});
+}

--- a/src/domain/fixtures.ts
+++ b/src/domain/fixtures.ts
@@ -9,6 +9,9 @@ import type {
 import {
 	bars,
 	createAsset,
+	createAudioLoopClip,
+	createDrumMachineInstrument,
+	createDrumPad,
 	createEmptySong,
 	createFactoryContext,
 	createNoteClip,
@@ -115,6 +118,125 @@ export function createSliceFixtureProject(
 			placements: [placement],
 		},
 		clips: [clip],
+	});
+}
+
+/**
+ * The drum-machine fixture: a `drumMachine` track whose pads reference assets
+ * and whose clip triggers those pads, plus an audio track holding an
+ * `audioLoop` clip. It covers the clip-content and instrument variants the
+ * slice fixture deliberately leaves out.
+ */
+export function createDrumMachineFixtureProject(
+	options: FixtureOptions = {},
+): Project {
+	const context = fixtureContext(options, "drum-machine-fixture");
+	const tempo = options.tempo ?? 120;
+	const song = createEmptySong(tempo);
+
+	const kickAsset = createAsset(context, {
+		name: "909 Bass Drum",
+		storageRef: "samples/house/drums/bd/909-bd.wav",
+		url: "/samples/house/drums/bd/909-bd.wav",
+		durationSeconds: 0.6,
+		sampleRate: 44_100,
+		channelCount: 1,
+	});
+	const clapAsset = createAsset(context, {
+		name: "909 Clap",
+		storageRef: "samples/house/drums/cp/909-cp.wav",
+		url: "/samples/house/drums/cp/909-cp.wav",
+		durationSeconds: 0.4,
+		sampleRate: 44_100,
+		channelCount: 1,
+	});
+	const loopAsset = createAsset(context, {
+		name: "Break loop",
+		kind: "loop",
+		storageRef: "samples/house/loops/break-120.wav",
+		url: "/samples/house/loops/break-120.wav",
+		durationSeconds: 4,
+		sampleRate: 44_100,
+		channelCount: 2,
+	});
+
+	const kickPad = createDrumPad(context, {
+		name: "BD",
+		assetId: kickAsset.id,
+	});
+	const clapPad = createDrumPad(context, {
+		name: "CP",
+		assetId: clapAsset.id,
+	});
+
+	const drumTrack = createTrack(context, {
+		name: "Drums",
+		order: 0,
+		instrument: createDrumMachineInstrument([kickPad, clapPad]),
+	});
+	const audioTrack = createTrack(context, {
+		name: "Break",
+		order: 1,
+		type: "audio",
+		instrument: null,
+	});
+
+	const drumClip = createNoteClip(context, {
+		trackId: drumTrack.id,
+		name: "Beat",
+		lengthTicks: TICKS_PER_BAR,
+		events: [
+			...[0, 4, 8, 12].map((sixteenth) =>
+				createNoteEvent(context, {
+					startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+					durationTicks: TICKS_PER_SIXTEENTH,
+					padId: kickPad.id,
+				}),
+			),
+			...[4, 12].map((sixteenth) =>
+				createNoteEvent(context, {
+					startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+					durationTicks: TICKS_PER_SIXTEENTH,
+					padId: clapPad.id,
+				}),
+			),
+		],
+	});
+
+	const loopClip = createAudioLoopClip(context, {
+		trackId: audioTrack.id,
+		assetId: loopAsset.id,
+		name: "Break loop",
+		lengthTicks: TICKS_PER_BAR * 2,
+		sourceTempo: tempo,
+	});
+
+	return assertProject({
+		metadata: createProjectMetadata(context, {
+			ownerId: options.ownerId ?? "user_fixture",
+			name: "Drum machine fixture",
+			template: "blank",
+		}),
+		song: {
+			...song,
+			assets: [kickAsset, clapAsset, loopAsset],
+			tracks: [drumTrack, audioTrack],
+			placements: [
+				createPlacement(context, {
+					clipId: drumClip.id,
+					trackId: drumTrack.id,
+					startTicks: 0,
+					durationTicks: TICKS_PER_BAR,
+				}),
+				createPlacement(context, {
+					clipId: loopClip.id,
+					trackId: audioTrack.id,
+					startTicks: 0,
+					durationTicks: TICKS_PER_BAR * 2,
+				}),
+			],
+		},
+		clips: [drumClip, loopClip],
 	});
 }
 

--- a/src/domain/ids.test.ts
+++ b/src/domain/ids.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+	createIdFactory,
+	createSeededIdFactory,
+	ENTITY_KINDS,
+	type EntityKind,
+	ID_PREFIXES,
+	ID_SUFFIX_LENGTH,
+	idPattern,
+	idSchemaFor,
+	isEntityId,
+	parseEntityId,
+	trackIdSchema,
+} from "./ids";
+
+describe("entity ids", () => {
+	it("covers every PRD section 9.4 entity with its documented prefix", () => {
+		expect(ID_PREFIXES).toEqual({
+			project: "prj",
+			track: "trk",
+			clip: "clp",
+			placement: "plc",
+			event: "evt",
+			device: "dev",
+			pad: "pad",
+			automation: "aut",
+			section: "sec",
+			return: "ret",
+			asset: "ast",
+			revision: "rev",
+		});
+	});
+
+	it("produces prefixed, 21-character, URL-safe ids for every kind", () => {
+		const ids = createIdFactory();
+		for (const kind of ENTITY_KINDS) {
+			const id = ids(kind);
+			expect(id).toMatch(idPattern(kind));
+			expect(id.slice(ID_PREFIXES[kind].length + 1)).toHaveLength(
+				ID_SUFFIX_LENGTH,
+			);
+			expect(encodeURIComponent(id)).toBe(id);
+		}
+	});
+
+	it("does not repeat ids", () => {
+		const ids = createIdFactory();
+		const generated = new Set(
+			Array.from({ length: 1_000 }, () => ids("event") as string),
+		);
+		expect(generated.size).toBe(1_000);
+	});
+
+	it("replays the same sequence for the same seed and differs across seeds", () => {
+		const first = createSeededIdFactory("fixture-seed");
+		const second = createSeededIdFactory("fixture-seed");
+		const other = createSeededIdFactory("другой-seed");
+
+		const firstRun = Array.from({ length: 5 }, () => first("track"));
+		const secondRun = Array.from({ length: 5 }, () => second("track"));
+		const otherRun = Array.from({ length: 5 }, () => other("track"));
+
+		expect(secondRun).toEqual(firstRun);
+		expect(otherRun).not.toEqual(firstRun);
+		for (const id of firstRun) {
+			expect(id).toMatch(idPattern("track"));
+		}
+	});
+
+	it("accepts numeric seeds and keeps the production id format", () => {
+		const first = createSeededIdFactory(42)("clip");
+		expect(first).toMatch(idPattern("clip"));
+		expect(createSeededIdFactory(42)("clip")).toBe(first);
+		expect(createSeededIdFactory(43)("clip")).not.toBe(first);
+	});
+
+	it("rejects ids of the wrong kind, length, or alphabet", () => {
+		const ids = createSeededIdFactory("wrong-kind");
+		const trackId = ids("track");
+
+		expect(isEntityId("track", trackId)).toBe(true);
+		expect(isEntityId("clip", trackId)).toBe(false);
+		expect(isEntityId("track", "trk_tooshort")).toBe(false);
+		expect(isEntityId("track", `trk_${"a".repeat(22)}`)).toBe(false);
+		expect(isEntityId("track", `trk_${"!".repeat(21)}`)).toBe(false);
+		expect(isEntityId("track", 42)).toBe(false);
+		expect(() => parseEntityId("clip", trackId)).toThrow(/Invalid clip id/);
+	});
+
+	it("exposes a runtime schema per kind that rejects a foreign prefix", () => {
+		const ids = createSeededIdFactory("schema");
+		const clipId = ids("clip");
+		for (const kind of ENTITY_KINDS as EntityKind[]) {
+			expect(idSchemaFor(kind).safeParse(ids(kind)).success).toBe(true);
+		}
+		expect(trackIdSchema.safeParse(clipId).success).toBe(false);
+	});
+});

--- a/src/domain/ids.ts
+++ b/src/domain/ids.ts
@@ -1,0 +1,193 @@
+import { customRandom, nanoid, urlAlphabet } from "nanoid";
+import { z } from "zod";
+
+/**
+ * Prefixed, URL-safe entity identifiers (PRD section 9.4).
+ *
+ * Every persistent entity ID is `<prefix>_<21-character nanoid>`. The prefix
+ * makes an ID self-describing in diffs, logs, Firestore paths, and test
+ * failures; it is never parsed to look up a type the schema already knows.
+ */
+
+/** Length of the random suffix that follows the type prefix. */
+export const ID_SUFFIX_LENGTH = 21;
+
+/** URL-safe alphabet used for the random suffix. */
+export const ID_ALPHABET = urlAlphabet;
+
+/** Entity kind to ID prefix, per the PRD section 9.4 table. */
+export const ID_PREFIXES = {
+	project: "prj",
+	track: "trk",
+	clip: "clp",
+	placement: "plc",
+	event: "evt",
+	device: "dev",
+	pad: "pad",
+	automation: "aut",
+	section: "sec",
+	return: "ret",
+	asset: "ast",
+	revision: "rev",
+} as const;
+
+export type EntityKind = keyof typeof ID_PREFIXES;
+export type IdPrefix = (typeof ID_PREFIXES)[EntityKind];
+
+export const ENTITY_KINDS = Object.keys(ID_PREFIXES) as EntityKind[];
+
+const SUFFIX_SOURCE = `[A-Za-z0-9_-]{${ID_SUFFIX_LENGTH}}`;
+
+/** Regular expression matching a well-formed ID for one entity kind. */
+export function idPattern(kind: EntityKind): RegExp {
+	return new RegExp(`^${ID_PREFIXES[kind]}_${SUFFIX_SOURCE}$`);
+}
+
+function brandedIdSchema<K extends EntityKind>(kind: K) {
+	return z
+		.string()
+		.regex(idPattern(kind), `Expected a "${ID_PREFIXES[kind]}_" prefixed id`)
+		.brand<K>();
+}
+
+export const projectIdSchema = brandedIdSchema("project");
+export const trackIdSchema = brandedIdSchema("track");
+export const clipIdSchema = brandedIdSchema("clip");
+export const placementIdSchema = brandedIdSchema("placement");
+export const eventIdSchema = brandedIdSchema("event");
+export const deviceIdSchema = brandedIdSchema("device");
+export const padIdSchema = brandedIdSchema("pad");
+export const automationIdSchema = brandedIdSchema("automation");
+export const sectionIdSchema = brandedIdSchema("section");
+export const returnIdSchema = brandedIdSchema("return");
+export const assetIdSchema = brandedIdSchema("asset");
+export const revisionIdSchema = brandedIdSchema("revision");
+
+export type ProjectId = z.infer<typeof projectIdSchema>;
+export type TrackId = z.infer<typeof trackIdSchema>;
+export type ClipId = z.infer<typeof clipIdSchema>;
+export type PlacementId = z.infer<typeof placementIdSchema>;
+export type EventId = z.infer<typeof eventIdSchema>;
+export type DeviceId = z.infer<typeof deviceIdSchema>;
+export type PadId = z.infer<typeof padIdSchema>;
+export type AutomationId = z.infer<typeof automationIdSchema>;
+export type SectionId = z.infer<typeof sectionIdSchema>;
+export type ReturnId = z.infer<typeof returnIdSchema>;
+export type AssetId = z.infer<typeof assetIdSchema>;
+export type RevisionId = z.infer<typeof revisionIdSchema>;
+
+export interface EntityIdMap {
+	project: ProjectId;
+	track: TrackId;
+	clip: ClipId;
+	placement: PlacementId;
+	event: EventId;
+	device: DeviceId;
+	pad: PadId;
+	automation: AutomationId;
+	section: SectionId;
+	return: ReturnId;
+	asset: AssetId;
+	revision: RevisionId;
+}
+
+export type EntityId<K extends EntityKind> = EntityIdMap[K];
+export type AnyEntityId = EntityIdMap[EntityKind];
+
+const ID_SCHEMAS = {
+	project: projectIdSchema,
+	track: trackIdSchema,
+	clip: clipIdSchema,
+	placement: placementIdSchema,
+	event: eventIdSchema,
+	device: deviceIdSchema,
+	pad: padIdSchema,
+	automation: automationIdSchema,
+	section: sectionIdSchema,
+	return: returnIdSchema,
+	asset: assetIdSchema,
+	revision: revisionIdSchema,
+} as const;
+
+/** Runtime schema for one entity kind's ID. */
+export function idSchemaFor<K extends EntityKind>(
+	kind: K,
+): (typeof ID_SCHEMAS)[K] {
+	return ID_SCHEMAS[kind];
+}
+
+/** Type guard: is `value` a well-formed ID of the given entity kind? */
+export function isEntityId<K extends EntityKind>(
+	kind: K,
+	value: unknown,
+): value is EntityId<K> {
+	return typeof value === "string" && idPattern(kind).test(value);
+}
+
+/** Parses an ID of the given kind, throwing when the format does not match. */
+export function parseEntityId<K extends EntityKind>(
+	kind: K,
+	value: unknown,
+): EntityId<K> {
+	if (!isEntityId(kind, value)) {
+		throw new TypeError(
+			`Invalid ${kind} id: expected "${ID_PREFIXES[kind]}_" followed by ${ID_SUFFIX_LENGTH} URL-safe characters`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Creates prefixed IDs for any entity kind. One shared factory keeps the
+ * format in a single place; tests substitute the seeded variant below.
+ */
+export type IdFactory = <K extends EntityKind>(kind: K) => EntityId<K>;
+
+function factoryFrom(generateSuffix: () => string): IdFactory {
+	return <K extends EntityKind>(kind: K): EntityId<K> =>
+		`${ID_PREFIXES[kind]}_${generateSuffix()}` as EntityId<K>;
+}
+
+/** Production factory backed by nanoid's hardware random source. */
+export function createIdFactory(): IdFactory {
+	return factoryFrom(() => nanoid(ID_SUFFIX_LENGTH));
+}
+
+/**
+ * Deterministic factory for fixtures and serialization round trips. The same
+ * seed always produces the same sequence of IDs in the same prefixed format.
+ */
+export function createSeededIdFactory(seed: string | number): IdFactory {
+	const random = seededBytes(hashSeed(seed));
+	const generate = customRandom(ID_ALPHABET, ID_SUFFIX_LENGTH, random);
+	return factoryFrom(() => generate());
+}
+
+function hashSeed(seed: string | number): number {
+	if (typeof seed === "number") {
+		return Math.trunc(seed) >>> 0;
+	}
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < seed.length; index += 1) {
+		hash ^= seed.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	// A zero state would make the generator emit a constant stream.
+	return hash === 0 ? 0x9e3779b9 : hash;
+}
+
+/** Mulberry32: small, fast, and stable across engines. */
+function seededBytes(seed: number): (byteCount: number) => Uint8Array {
+	let state = seed >>> 0;
+	return (byteCount: number) => {
+		const bytes = new Uint8Array(byteCount);
+		for (let index = 0; index < byteCount; index += 1) {
+			state = (state + 0x6d2b79f5) >>> 0;
+			let next = state;
+			next = Math.imul(next ^ (next >>> 15), next | 1);
+			next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+			bytes[index] = ((next ^ (next >>> 14)) >>> 0) & 0xff;
+		}
+		return bytes;
+	};
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,20 @@
+/**
+ * The canonical schema-v1 domain model.
+ *
+ * These modules are the authoritative domain contract (PRD sections 9.4 and
+ * 9.5): entity shapes and their runtime schemas, prefixed stable IDs, integer
+ * musical time at 192 PPQ, shared parameter definitions, validation of every
+ * invariant, deterministic serialization, and factories/fixtures.
+ *
+ * Nothing here knows about Firebase, Tone.js, or SolidJS. Persistence,
+ * commands, audio, and rendering consume this model from the outside.
+ */
+
+export * from "./entities";
+export * from "./factories";
+export * from "./fixtures";
+export * from "./ids";
+export * from "./parameters";
+export * from "./parse";
+export * from "./serialize";
+export * from "./time";

--- a/src/domain/parameters.test.ts
+++ b/src/domain/parameters.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampParameterValue,
+	coerceParameterValue,
+	defineParameter,
+	getParameterDefinition,
+	isAutomatable,
+	isParameterValueInRange,
+	MASTER_VOLUME,
+	NOTE_VELOCITY,
+	parameterDefinitions,
+	parameterSchemaFor,
+	requireParameterDefinition,
+	SONG_TEMPO,
+	TRACK_PAN,
+	TRACK_VOLUME,
+} from "./parameters";
+
+describe("parameter definitions", () => {
+	it("declares range, unit, default, clamping policy, and automation once", () => {
+		expect(TRACK_VOLUME).toMatchObject({
+			id: "track.volume",
+			unit: "decibels",
+			min: -60,
+			max: 6,
+			defaultValue: 0,
+			clampPolicy: "clamp",
+			automatable: true,
+		});
+		expect(SONG_TEMPO.unit).toBe("bpm");
+		expect(SONG_TEMPO.automatable).toBe(false);
+		expect(NOTE_VELOCITY.automatable).toBe(false);
+		expect(MASTER_VOLUME.automatable).toBe(true);
+	});
+
+	it("keeps the registry to the parameters the foundation slice needs", () => {
+		expect([...parameterDefinitions().keys()].sort()).toEqual([
+			"master.volume",
+			"note.probability",
+			"note.velocity",
+			"return.pan",
+			"return.volume",
+			"song.tempo",
+			"track.pan",
+			"track.sendLevel",
+			"track.volume",
+		]);
+	});
+
+	it("every registered definition has a default inside its own range", () => {
+		for (const definition of parameterDefinitions().values()) {
+			expect(isParameterValueInRange(definition, definition.defaultValue)).toBe(
+				true,
+			);
+			expect(definition.min).toBeLessThan(definition.max);
+		}
+	});
+
+	it("rejects definitions with an impossible range, default, or step", () => {
+		expect(() =>
+			defineParameter({
+				id: "bad.range",
+				label: "Bad",
+				unit: "normalized",
+				min: 1,
+				max: 0,
+				defaultValue: 0,
+				automatable: false,
+			}),
+		).toThrow(/min < max/);
+		expect(() =>
+			defineParameter({
+				id: "bad.default",
+				label: "Bad",
+				unit: "normalized",
+				min: 0,
+				max: 1,
+				defaultValue: 2,
+				automatable: false,
+			}),
+		).toThrow(/outside its range/);
+		expect(() =>
+			defineParameter({
+				id: "bad.step",
+				label: "Bad",
+				unit: "normalized",
+				min: 0,
+				max: 1,
+				defaultValue: 0,
+				step: 0,
+				automatable: false,
+			}),
+		).toThrow(/step must be a positive number/);
+	});
+
+	it("clamps out-of-range values and refuses non-finite ones", () => {
+		expect(clampParameterValue(TRACK_VOLUME, 40)).toBe(6);
+		expect(clampParameterValue(TRACK_VOLUME, -400)).toBe(-60);
+		expect(clampParameterValue(TRACK_PAN, -1.5)).toBe(-1);
+		expect(() => clampParameterValue(TRACK_PAN, Number.NaN)).toThrow(
+			/non-finite/,
+		);
+	});
+
+	it("quantizes to the declared step", () => {
+		const stepped = defineParameter({
+			id: "test.stepped",
+			label: "Stepped",
+			unit: "normalized",
+			min: 0,
+			max: 1,
+			defaultValue: 0,
+			step: 0.25,
+			automatable: false,
+		});
+		expect(clampParameterValue(stepped, 0.3)).toBe(0.25);
+		expect(clampParameterValue(stepped, 0.4)).toBe(0.5);
+		expect(clampParameterValue(stepped, 9)).toBe(1);
+	});
+
+	it("applies the clamping policy when coercing command input", () => {
+		expect(coerceParameterValue(TRACK_VOLUME, 40)).toEqual({
+			ok: true,
+			value: 6,
+		});
+		expect(coerceParameterValue(TRACK_VOLUME, Number.NaN)).toEqual({
+			ok: false,
+			reason: 'Parameter "track.volume" requires a finite number',
+		});
+
+		const strict = defineParameter({
+			id: "test.strict",
+			label: "Strict",
+			unit: "normalized",
+			min: 0,
+			max: 1,
+			defaultValue: 0,
+			clampPolicy: "reject",
+			automatable: false,
+		});
+		expect(coerceParameterValue(strict, 2).ok).toBe(false);
+		expect(coerceParameterValue(strict, 0.5)).toEqual({ ok: true, value: 0.5 });
+	});
+
+	it("answers automation capability from the one definition", () => {
+		expect(isAutomatable("track.volume")).toBe(true);
+		expect(isAutomatable("song.tempo")).toBe(false);
+		expect(isAutomatable("device.unregistered")).toBe(false);
+		expect(getParameterDefinition("device.unregistered")).toBeUndefined();
+		expect(() => requireParameterDefinition("device.unregistered")).toThrow(
+			/Unknown parameter/,
+		);
+	});
+
+	it("builds a runtime value schema from the definition", () => {
+		const schema = parameterSchemaFor("track.pan");
+		expect(schema.safeParse(0.5).success).toBe(true);
+		expect(schema.safeParse(1.5).success).toBe(false);
+		expect(schema.safeParse(Number.POSITIVE_INFINITY).success).toBe(false);
+	});
+});

--- a/src/domain/parameters.test.ts
+++ b/src/domain/parameters.test.ts
@@ -97,9 +97,16 @@ describe("parameter definitions", () => {
 		expect(clampParameterValue(TRACK_VOLUME, 40)).toBe(6);
 		expect(clampParameterValue(TRACK_VOLUME, -400)).toBe(-60);
 		expect(clampParameterValue(TRACK_PAN, -1.5)).toBe(-1);
+		// "non-finite" covers both NaN and +/-Infinity; exercise both kinds.
 		expect(() => clampParameterValue(TRACK_PAN, Number.NaN)).toThrow(
 			/non-finite/,
 		);
+		expect(() =>
+			clampParameterValue(TRACK_PAN, Number.POSITIVE_INFINITY),
+		).toThrow(/non-finite/);
+		expect(() =>
+			clampParameterValue(TRACK_PAN, Number.NEGATIVE_INFINITY),
+		).toThrow(/non-finite/);
 	});
 
 	it("quantizes to the declared step", () => {

--- a/src/domain/parameters.ts
+++ b/src/domain/parameters.ts
@@ -1,0 +1,308 @@
+import { z } from "zod";
+
+/**
+ * Shared parameter definitions (PRD section 9.5 invariants 4, 10, 11).
+ *
+ * A parameter declares its range, unit, default, clamping policy, and
+ * automation capability exactly once. UI controls, command validation, the
+ * audio engine, and assistant tools all read this definition rather than
+ * repeating literals.
+ *
+ * Schema v1 defines only the parameters the `FND-009` vertical slice needs.
+ * Per-device instrument and effect parameters are authored with their devices
+ * in Phase 1, where they can be tuned by ear, and are registered through
+ * `defineParameter` at that point.
+ */
+
+export type ParameterUnit =
+	| "bpm"
+	| "decibels"
+	| "normalized"
+	| "bipolar"
+	| "hertz"
+	| "seconds"
+	| "semitones";
+
+/** How a UI control and the audio engine interpolate across the range. */
+export type ParameterScale = "linear" | "logarithmic";
+
+/**
+ * What a validated command does with an out-of-range input: `clamp` folds it
+ * into range, `reject` refuses the edit. Stored state is always in range
+ * either way — the policy only governs coercion of incoming values.
+ */
+export type ClampPolicy = "clamp" | "reject";
+
+export interface ParameterDefinition {
+	readonly id: string;
+	readonly label: string;
+	readonly unit: ParameterUnit;
+	readonly min: number;
+	readonly max: number;
+	readonly defaultValue: number;
+	/** Quantization applied by `coerceParameterValue`, or `null` for continuous. */
+	readonly step: number | null;
+	readonly scale: ParameterScale;
+	readonly clampPolicy: ClampPolicy;
+	readonly automatable: boolean;
+}
+
+export interface ParameterDefinitionInput {
+	id: string;
+	label: string;
+	unit: ParameterUnit;
+	min: number;
+	max: number;
+	defaultValue: number;
+	step?: number | null;
+	scale?: ParameterScale;
+	clampPolicy?: ClampPolicy;
+	automatable: boolean;
+}
+
+/** Validates and freezes one parameter definition. */
+export function defineParameter(
+	input: ParameterDefinitionInput,
+): ParameterDefinition {
+	const { id, min, max, defaultValue, step = null } = input;
+	if (!Number.isFinite(min) || !Number.isFinite(max) || min >= max) {
+		throw new TypeError(
+			`Parameter "${id}" needs a finite range with min < max, received ${min}..${max}`,
+		);
+	}
+	if (
+		!Number.isFinite(defaultValue) ||
+		defaultValue < min ||
+		defaultValue > max
+	) {
+		throw new TypeError(
+			`Parameter "${id}" default ${defaultValue} is outside its range ${min}..${max}`,
+		);
+	}
+	if (step !== null && (!Number.isFinite(step) || step <= 0)) {
+		throw new TypeError(`Parameter "${id}" step must be a positive number`);
+	}
+	return Object.freeze({
+		id,
+		label: input.label,
+		unit: input.unit,
+		min,
+		max,
+		defaultValue,
+		step,
+		scale: input.scale ?? "linear",
+		clampPolicy: input.clampPolicy ?? "clamp",
+		automatable: input.automatable,
+	});
+}
+
+const definitions = new Map<string, ParameterDefinition>();
+
+function register(input: ParameterDefinitionInput): ParameterDefinition {
+	const definition = defineParameter(input);
+	if (definitions.has(definition.id)) {
+		throw new TypeError(`Parameter "${definition.id}" is already defined`);
+	}
+	definitions.set(definition.id, definition);
+	return definition;
+}
+
+export const SONG_TEMPO = register({
+	id: "song.tempo",
+	label: "Tempo",
+	unit: "bpm",
+	min: 20,
+	max: 300,
+	defaultValue: 120,
+	automatable: false,
+});
+
+export const TRACK_VOLUME = register({
+	id: "track.volume",
+	label: "Track volume",
+	unit: "decibels",
+	min: -60,
+	max: 6,
+	defaultValue: 0,
+	automatable: true,
+});
+
+export const TRACK_PAN = register({
+	id: "track.pan",
+	label: "Track pan",
+	unit: "bipolar",
+	min: -1,
+	max: 1,
+	defaultValue: 0,
+	automatable: true,
+});
+
+export const TRACK_SEND_LEVEL = register({
+	id: "track.sendLevel",
+	label: "Send level",
+	unit: "normalized",
+	min: 0,
+	max: 1,
+	defaultValue: 0,
+	automatable: true,
+});
+
+export const RETURN_VOLUME = register({
+	id: "return.volume",
+	label: "Return volume",
+	unit: "decibels",
+	min: -60,
+	max: 6,
+	defaultValue: 0,
+	automatable: true,
+});
+
+export const RETURN_PAN = register({
+	id: "return.pan",
+	label: "Return pan",
+	unit: "bipolar",
+	min: -1,
+	max: 1,
+	defaultValue: 0,
+	automatable: true,
+});
+
+export const MASTER_VOLUME = register({
+	id: "master.volume",
+	label: "Master volume",
+	unit: "decibels",
+	min: -60,
+	max: 6,
+	defaultValue: 0,
+	automatable: true,
+});
+
+export const NOTE_VELOCITY = register({
+	id: "note.velocity",
+	label: "Velocity",
+	unit: "normalized",
+	min: 0,
+	max: 1,
+	defaultValue: 0.8,
+	automatable: false,
+});
+
+export const NOTE_PROBABILITY = register({
+	id: "note.probability",
+	label: "Probability",
+	unit: "normalized",
+	min: 0,
+	max: 1,
+	defaultValue: 1,
+	automatable: false,
+});
+
+/** Every parameter registered so far, keyed by parameter ID. */
+export function parameterDefinitions(): ReadonlyMap<
+	string,
+	ParameterDefinition
+> {
+	return definitions;
+}
+
+export function getParameterDefinition(
+	id: string,
+): ParameterDefinition | undefined {
+	return definitions.get(id);
+}
+
+export function requireParameterDefinition(id: string): ParameterDefinition {
+	const definition = definitions.get(id);
+	if (!definition) {
+		throw new TypeError(`Unknown parameter "${id}"`);
+	}
+	return definition;
+}
+
+/** Registers a device or instrument parameter defined by a later phase. */
+export function registerParameter(
+	input: ParameterDefinitionInput,
+): ParameterDefinition {
+	return register(input);
+}
+
+/** Only registered, automation-capable parameters may carry automation. */
+export function isAutomatable(id: string): boolean {
+	return definitions.get(id)?.automatable === true;
+}
+
+export function isParameterValueInRange(
+	definition: ParameterDefinition,
+	value: number,
+): boolean {
+	return (
+		Number.isFinite(value) && value >= definition.min && value <= definition.max
+	);
+}
+
+/** Folds a value into range and onto the definition's step grid. */
+export function clampParameterValue(
+	definition: ParameterDefinition,
+	value: number,
+): number {
+	if (!Number.isFinite(value)) {
+		throw new TypeError(
+			`Parameter "${definition.id}" cannot take a non-finite value`,
+		);
+	}
+	const bounded = Math.min(definition.max, Math.max(definition.min, value));
+	if (definition.step === null) {
+		return bounded;
+	}
+	const stepped =
+		definition.min +
+		Math.round((bounded - definition.min) / definition.step) * definition.step;
+	return Math.min(definition.max, Math.max(definition.min, roundStep(stepped)));
+}
+
+function roundStep(value: number): number {
+	// Guards against step arithmetic producing 0.30000000000000004-style noise.
+	return Number(value.toFixed(9));
+}
+
+export type ParameterCoercion =
+	| { ok: true; value: number }
+	| { ok: false; reason: string };
+
+/**
+ * Applies a raw input value according to the definition's clamping policy.
+ * Command validation calls this; stored state is always already in range.
+ */
+export function coerceParameterValue(
+	definition: ParameterDefinition,
+	value: number,
+): ParameterCoercion {
+	if (!Number.isFinite(value)) {
+		return {
+			ok: false,
+			reason: `Parameter "${definition.id}" requires a finite number`,
+		};
+	}
+	if (
+		definition.clampPolicy === "reject" &&
+		!isParameterValueInRange(definition, value)
+	) {
+		return {
+			ok: false,
+			reason: `Parameter "${definition.id}" must be between ${definition.min} and ${definition.max}`,
+		};
+	}
+	return { ok: true, value: clampParameterValue(definition, value) };
+}
+
+/** Runtime schema for a stored value of this parameter. */
+export function parameterValueSchema(
+	definition: ParameterDefinition,
+): z.ZodNumber {
+	return z.number().min(definition.min).max(definition.max);
+}
+
+/** Runtime schema for the stored value of a registered parameter ID. */
+export function parameterSchemaFor(id: string): z.ZodNumber {
+	return parameterValueSchema(requireParameterDefinition(id));
+}

--- a/src/domain/parse.test.ts
+++ b/src/domain/parse.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { SCHEMA_VERSION } from "./entities";
-import { createSliceFixtureProject } from "./fixtures";
+import {
+	createDrumMachineFixtureProject,
+	createSliceFixtureProject,
+} from "./fixtures";
 import { createSeededIdFactory } from "./ids";
 import {
 	assertProject,
@@ -48,8 +51,18 @@ interface MutableTrack extends JsonRecord {
 	order: number;
 	devices: (JsonRecord & { id: string; order: number })[];
 	sends: (JsonRecord & { returnId: string })[];
-	instrument: (JsonRecord & { assetId?: string | null }) | null;
+	instrument:
+		| (JsonRecord & {
+				assetId?: string | null;
+				pads?: MutableDrumPad[];
+		  })
+		| null;
 	mixer: JsonRecord & { volume: number };
+}
+
+interface MutableDrumPad extends JsonRecord {
+	id: string;
+	assetId: string | null;
 }
 
 interface MutablePlacement extends JsonRecord {
@@ -70,6 +83,7 @@ interface MutableClip extends JsonRecord {
 	lengthTicks: number;
 	content: JsonRecord & {
 		kind: string;
+		assetId?: string;
 		events: (JsonRecord & { id: string; startTicks: number })[];
 	};
 }
@@ -81,6 +95,33 @@ function baseProject(): MutableProject {
 	return JSON.parse(
 		JSON.stringify(serializeProject(createSliceFixtureProject())),
 	) as MutableProject;
+}
+
+/** A serialized copy of the drum-machine/audio-loop fixture, safe to mutate. */
+function drumMachineProject(): MutableProject {
+	return JSON.parse(
+		JSON.stringify(serializeProject(createDrumMachineFixtureProject())),
+	) as MutableProject;
+}
+
+function audioLoopClip(project: MutableProject): MutableClip {
+	const clip = project.clips.find(
+		(entry) => entry.content.kind === "audioLoop",
+	);
+	if (!clip) {
+		throw new Error("fixture has no audioLoop clip");
+	}
+	return clip;
+}
+
+function drumPads(project: MutableProject): MutableDrumPad[] {
+	const pads = project.song.tracks.find(
+		(track) => track.instrument?.kind === "drumMachine",
+	)?.instrument?.pads;
+	if (!pads || pads.length === 0) {
+		throw new Error("fixture has no drum pads");
+	}
+	return pads;
 }
 
 function expectIssue<T>(result: ParseResult<T>, code: DomainIssueCode): void {
@@ -262,6 +303,59 @@ describe("parseProject", () => {
 		expectIssue(parseProject(fixedParameter), "invalid_automation");
 	});
 
+	it("rejects automation targeting a device the track does not own", () => {
+		const input = baseProject();
+		input.song.automation = [
+			{
+				id: ids("automation"),
+				target: {
+					scope: "trackDevice",
+					trackId: input.song.tracks[0].id,
+					deviceId: ids("device"),
+					parameterId: "track.volume",
+				},
+				interpolation: "linear",
+				points: [{ tick: 0, value: 0 }],
+			},
+		];
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+
+	it("rejects automation targeting a send the track does not have", () => {
+		const input = baseProject();
+		input.song.automation = [
+			{
+				id: ids("automation"),
+				target: {
+					scope: "send",
+					trackId: input.song.tracks[0].id,
+					returnId: ids("return"),
+					parameterId: "track.sendLevel",
+				},
+				interpolation: "linear",
+				points: [{ tick: 0, value: 0 }],
+			},
+		];
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+
+	it("rejects automation targeting a missing return bus", () => {
+		const input = baseProject();
+		input.song.automation = [
+			{
+				id: ids("automation"),
+				target: {
+					scope: "return",
+					returnId: ids("return"),
+					parameterId: "return.volume",
+				},
+				interpolation: "linear",
+				points: [{ tick: 0, value: 0 }],
+			},
+		];
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+
 	it("rejects automation points that are unordered or out of range", () => {
 		const unordered = baseProject();
 		const unorderedLane = lane(
@@ -344,6 +438,28 @@ describe("parseProject", () => {
 	});
 });
 
+describe("audio loop clips and drum pads", () => {
+	it("accepts the drum-machine fixture", () => {
+		const input = drumMachineProject();
+		const result = parseProject(input);
+		expect(result.ok, `issues: ${JSON.stringify(result)}`).toBe(true);
+		expect(audioLoopClip(input).content.kind).toBe("audioLoop");
+		expect(drumPads(input).length).toBeGreaterThan(0);
+	});
+
+	it("rejects an audio-loop clip that references a missing asset", () => {
+		const input = drumMachineProject();
+		audioLoopClip(input).content.assetId = ids("asset");
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+
+	it("rejects a drum pad that references a missing asset", () => {
+		const input = drumMachineProject();
+		drumPads(input)[0].assetId = ids("asset");
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+});
+
 describe("persistence tier parsers", () => {
 	it("parses metadata, song, and clip documents separately", () => {
 		const input = baseProject();
@@ -356,6 +472,24 @@ describe("persistence tier parsers", () => {
 		const input = baseProject();
 		input.song.tracks[0].order = 4;
 		expectIssue(parseSong(input.song), "invalid_order");
+	});
+
+	it("rejects a standalone song whose placement references a missing track", () => {
+		const input = baseProject();
+		input.song.placements[0].trackId = ids("track");
+		expectIssue(parseSong(input.song), "dangling_reference");
+	});
+
+	it("applies clip-local invariants to a standalone clip document", () => {
+		const outsideClip = baseProject();
+		outsideClip.clips[0].content.events[0].startTicks =
+			outsideClip.clips[0].lengthTicks + 10_000;
+		expectIssue(parseClip(outsideClip.clips[0]), "invalid_musical_time");
+
+		const duplicateEvent = baseProject();
+		const events = duplicateEvent.clips[0].content.events;
+		events[1].id = events[0].id;
+		expectIssue(parseClip(duplicateEvent.clips[0]), "duplicate_id");
 	});
 
 	it("refuses a future schema version on the metadata document", () => {

--- a/src/domain/parse.test.ts
+++ b/src/domain/parse.test.ts
@@ -50,7 +50,7 @@ interface MutableTrack extends JsonRecord {
 	id: string;
 	order: number;
 	devices: (JsonRecord & { id: string; order: number })[];
-	sends: (JsonRecord & { returnId: string })[];
+	sendConfig: (JsonRecord & { returnId: string })[];
 	instrument:
 		| (JsonRecord & {
 				assetId?: string | null;
@@ -233,7 +233,7 @@ describe("parseProject", () => {
 
 	it("rejects a send to a missing return bus", () => {
 		const input = baseProject();
-		input.song.tracks[0].sends = [
+		input.song.tracks[0].sendConfig = [
 			{ returnId: ids("return"), level: 0.5, preFader: false },
 		];
 		expectIssue(parseProject(input), "dangling_reference");
@@ -251,7 +251,7 @@ describe("parseProject", () => {
 				mixer: { volume: 0, pan: 0, muted: false },
 			},
 		];
-		input.song.tracks[0].sends = [
+		input.song.tracks[0].sendConfig = [
 			{ returnId, level: 0.5, preFader: false },
 			{ returnId, level: 0.2, preFader: false },
 		];

--- a/src/domain/parse.test.ts
+++ b/src/domain/parse.test.ts
@@ -1,0 +1,399 @@
+import { describe, expect, it } from "vitest";
+import { SCHEMA_VERSION } from "./entities";
+import { createSliceFixtureProject } from "./fixtures";
+import { createSeededIdFactory } from "./ids";
+import {
+	assertProject,
+	type DomainIssueCode,
+	DomainValidationError,
+	isProject,
+	type ParseResult,
+	parseClip,
+	parseProject,
+	parseProjectMetadata,
+	parseSong,
+} from "./parse";
+import { serializeProject } from "./serialize";
+
+/**
+ * Every invariant in PRD section 9.5 is exercised by mutating one field of a
+ * known-good fixture, so a test failure points at exactly one rule.
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+interface MutableProject {
+	metadata: JsonRecord & {
+		schemaVersion: number;
+		createdAt: number;
+		modifiedAt: number;
+		collaboratorIds: string[];
+	};
+	song: {
+		tempo: number;
+		timeSignature: JsonRecord;
+		tracks: MutableTrack[];
+		returns: JsonRecord[];
+		master: JsonRecord;
+		sections: JsonRecord[];
+		placements: MutablePlacement[];
+		automation: MutableAutomation[];
+		assets: JsonRecord[];
+	};
+	clips: MutableClip[];
+}
+
+interface MutableTrack extends JsonRecord {
+	id: string;
+	order: number;
+	devices: (JsonRecord & { id: string; order: number })[];
+	sends: (JsonRecord & { returnId: string })[];
+	instrument: (JsonRecord & { assetId?: string | null }) | null;
+	mixer: JsonRecord & { volume: number };
+}
+
+interface MutablePlacement extends JsonRecord {
+	id: string;
+	clipId: string;
+	trackId: string;
+}
+
+interface MutableAutomation extends JsonRecord {
+	id: string;
+	target: JsonRecord & { parameterId: string; trackId?: string };
+	points: { tick: number; value: number }[];
+}
+
+interface MutableClip extends JsonRecord {
+	id: string;
+	trackId: string;
+	lengthTicks: number;
+	content: JsonRecord & {
+		kind: string;
+		events: (JsonRecord & { id: string; startTicks: number })[];
+	};
+}
+
+const ids = createSeededIdFactory("parse-test");
+
+/** A serialized copy of the fixture: plain JSON, safe to mutate. */
+function baseProject(): MutableProject {
+	return JSON.parse(
+		JSON.stringify(serializeProject(createSliceFixtureProject())),
+	) as MutableProject;
+}
+
+function expectIssue<T>(result: ParseResult<T>, code: DomainIssueCode): void {
+	expect(result.ok).toBe(false);
+	if (result.ok) {
+		return;
+	}
+	expect(
+		result.issues.map((issue) => issue.code),
+		`issues: ${JSON.stringify(result.issues)}`,
+	).toContain(code);
+}
+
+describe("parseProject", () => {
+	it("accepts the fixture and returns the same state it was given", () => {
+		const input = baseProject();
+		const result = parseProject(input);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(serializeProject(result.value)).toEqual(input);
+		}
+		expect(isProject(input)).toBe(true);
+	});
+
+	it("rejects unknown keys rather than silently dropping them", () => {
+		const input = baseProject();
+		(input.song as JsonRecord).swing = 0.5;
+		expectIssue(parseProject(input), "invalid_shape");
+	});
+
+	it("refuses a future schema version instead of coercing it to v1", () => {
+		const input = baseProject();
+		input.metadata.schemaVersion = SCHEMA_VERSION + 1;
+		const result = parseProject(input);
+		expectIssue(result, "unsupported_schema_version");
+		expect(result.ok).toBe(false);
+	});
+
+	it("refuses pre-v1 prototype documents", () => {
+		const input = baseProject();
+		input.metadata.schemaVersion = 0;
+		expectIssue(parseProject(input), "unsupported_schema_version");
+	});
+
+	it("rejects non-finite numbers", () => {
+		const tempo = baseProject();
+		tempo.song.tempo = Number.POSITIVE_INFINITY;
+		expectIssue(parseProject(tempo), "invalid_shape");
+
+		const volume = baseProject();
+		volume.song.tracks[0].mixer.volume = Number.NaN;
+		expectIssue(parseProject(volume), "invalid_shape");
+	});
+
+	it("rejects floating-point musical time", () => {
+		const input = baseProject();
+		input.clips[0].content.events[0].startTicks = 24.5;
+		expectIssue(parseProject(input), "invalid_shape");
+	});
+
+	it("rejects parameter values outside their declared range", () => {
+		const input = baseProject();
+		input.song.tracks[0].mixer.volume = 40;
+		expectIssue(parseProject(input), "invalid_shape");
+	});
+
+	it("rejects a placement that references a missing clip", () => {
+		const input = baseProject();
+		input.song.placements[0].clipId = ids("clip");
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+
+	it("rejects a placement of a clip owned by a different track", () => {
+		const input = baseProject();
+		const otherTrack = { ...input.song.tracks[0], id: ids("track"), order: 1 };
+		input.song.tracks.push(otherTrack as MutableTrack);
+		input.song.placements[0].trackId = otherTrack.id;
+		expectIssue(parseProject(input), "cross_owner_reference");
+	});
+
+	it("rejects a clip owned by a missing track", () => {
+		const input = baseProject();
+		const missingTrack = ids("track");
+		input.clips[0].trackId = missingTrack;
+		input.song.placements[0].trackId = missingTrack;
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+
+	it("rejects duplicate entity ids anywhere in the aggregate", () => {
+		const input = baseProject();
+		input.clips.push({ ...input.clips[0] });
+		expectIssue(parseProject(input), "duplicate_id");
+	});
+
+	it("rejects non-serial track order", () => {
+		const input = baseProject();
+		input.song.tracks[0].order = 3;
+		expectIssue(parseProject(input), "invalid_order");
+	});
+
+	it("rejects non-serial insert chains", () => {
+		const input = baseProject();
+		input.song.tracks[0].devices = [
+			device(0, "reverb"),
+			device(0, "delay"),
+		] as MutableTrack["devices"];
+		expectIssue(parseProject(input), "invalid_order");
+	});
+
+	it("rejects a send to a missing return bus", () => {
+		const input = baseProject();
+		input.song.tracks[0].sends = [
+			{ returnId: ids("return"), level: 0.5, preFader: false },
+		];
+		expectIssue(parseProject(input), "dangling_reference");
+	});
+
+	it("rejects two sends from one track to the same return bus", () => {
+		const input = baseProject();
+		const returnId = ids("return");
+		input.song.returns = [
+			{
+				id: returnId,
+				name: "Reverb",
+				order: 0,
+				devices: [],
+				mixer: { volume: 0, pan: 0, muted: false },
+			},
+		];
+		input.song.tracks[0].sends = [
+			{ returnId, level: 0.5, preFader: false },
+			{ returnId, level: 0.2, preFader: false },
+		];
+		expectIssue(parseProject(input), "duplicate_id");
+	});
+
+	it("rejects an instrument or note that references a missing asset or pad", () => {
+		const missingAsset = baseProject();
+		if (missingAsset.song.tracks[0].instrument) {
+			missingAsset.song.tracks[0].instrument.assetId = ids("asset");
+		}
+		expectIssue(parseProject(missingAsset), "dangling_reference");
+
+		const missingPad = baseProject();
+		missingPad.clips[0].content.events[0].trigger = {
+			kind: "pad",
+			padId: ids("pad"),
+		};
+		expectIssue(parseProject(missingPad), "dangling_reference");
+	});
+
+	it("rejects a note that starts outside its clip", () => {
+		const input = baseProject();
+		input.clips[0].content.events[0].startTicks = input.clips[0].lengthTicks;
+		expectIssue(parseProject(input), "invalid_musical_time");
+	});
+
+	it("rejects automation targeting a missing track, unknown parameter, or fixed parameter", () => {
+		const missingTrack = baseProject();
+		missingTrack.song.automation = [
+			lane(ids("automation"), ids("track"), "track.volume"),
+		];
+		expectIssue(parseProject(missingTrack), "dangling_reference");
+
+		const unknownParameter = baseProject();
+		unknownParameter.song.automation = [
+			lane(
+				ids("automation"),
+				unknownParameter.song.tracks[0].id,
+				"track.mystery",
+			),
+		];
+		expectIssue(parseProject(unknownParameter), "invalid_automation");
+
+		const fixedParameter = baseProject();
+		fixedParameter.song.automation = [
+			lane(ids("automation"), fixedParameter.song.tracks[0].id, "song.tempo"),
+		];
+		expectIssue(parseProject(fixedParameter), "invalid_automation");
+	});
+
+	it("rejects automation points that are unordered or out of range", () => {
+		const unordered = baseProject();
+		const unorderedLane = lane(
+			ids("automation"),
+			unordered.song.tracks[0].id,
+			"track.volume",
+		);
+		unorderedLane.points = [
+			{ tick: 192, value: 0 },
+			{ tick: 0, value: -6 },
+		];
+		unordered.song.automation = [unorderedLane];
+		expectIssue(parseProject(unordered), "invalid_automation");
+
+		const outOfRange = baseProject();
+		const outOfRangeLane = lane(
+			ids("automation"),
+			outOfRange.song.tracks[0].id,
+			"track.volume",
+		);
+		outOfRangeLane.points = [{ tick: 0, value: 40 }];
+		outOfRange.song.automation = [outOfRangeLane];
+		expectIssue(parseProject(outOfRange), "invalid_parameter");
+	});
+
+	it("rejects inconsistent project metadata", () => {
+		const timestamps = baseProject();
+		timestamps.metadata.modifiedAt = timestamps.metadata.createdAt - 1;
+		expectIssue(parseProject(timestamps), "invalid_metadata");
+
+		const collaborators = baseProject();
+		collaborators.metadata.collaboratorIds = ["user_a", "user_a"];
+		expectIssue(parseProject(collaborators), "duplicate_id");
+	});
+
+	it("does not mutate its input when parsing fails", () => {
+		const input = baseProject();
+		input.song.placements[0].clipId = ids("clip");
+		const snapshot = JSON.parse(JSON.stringify(input));
+
+		const result = parseProject(input);
+
+		expect(result.ok).toBe(false);
+		expect(input).toEqual(snapshot);
+		expect("value" in result).toBe(false);
+	});
+
+	it("reports every failing invariant at once rather than the first", () => {
+		const input = baseProject();
+		input.song.tracks[0].order = 5;
+		input.song.placements[0].clipId = ids("clip");
+		const result = parseProject(input);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.issues.length).toBeGreaterThanOrEqual(2);
+		}
+	});
+
+	it("throws a described DomainValidationError from assertProject", () => {
+		const input = baseProject();
+		input.metadata.schemaVersion = 99;
+		expect(() => assertProject(input)).toThrow(DomainValidationError);
+		try {
+			assertProject(input);
+		} catch (error) {
+			expect(error).toBeInstanceOf(DomainValidationError);
+			expect((error as DomainValidationError).issues[0].code).toBe(
+				"unsupported_schema_version",
+			);
+			expect((error as DomainValidationError).message).toMatch(
+				/newer than the supported version/,
+			);
+		}
+	});
+
+	it("rejects values that are not objects at all", () => {
+		for (const value of [null, undefined, 42, "project", []]) {
+			expect(parseProject(value).ok).toBe(false);
+		}
+	});
+});
+
+describe("persistence tier parsers", () => {
+	it("parses metadata, song, and clip documents separately", () => {
+		const input = baseProject();
+		expect(parseProjectMetadata(input.metadata).ok).toBe(true);
+		expect(parseSong(input.song).ok).toBe(true);
+		expect(parseClip(input.clips[0]).ok).toBe(true);
+	});
+
+	it("applies the same invariants to a standalone song document", () => {
+		const input = baseProject();
+		input.song.tracks[0].order = 4;
+		expectIssue(parseSong(input.song), "invalid_order");
+	});
+
+	it("refuses a future schema version on the metadata document", () => {
+		const input = baseProject();
+		input.metadata.schemaVersion = SCHEMA_VERSION + 5;
+		expectIssue(
+			parseProjectMetadata(input.metadata),
+			"unsupported_schema_version",
+		);
+	});
+});
+
+function device(
+	order: number,
+	type: string,
+): JsonRecord & {
+	id: string;
+	order: number;
+} {
+	return {
+		id: ids("device"),
+		type,
+		order,
+		bypassed: false,
+		parameters: {},
+		preset: null,
+	};
+}
+
+function lane(
+	id: string,
+	trackId: string,
+	parameterId: string,
+): MutableAutomation {
+	return {
+		id,
+		target: { scope: "track", trackId, parameterId },
+		interpolation: "linear",
+		points: [{ tick: 0, value: 0 }],
+	};
+}

--- a/src/domain/parse.ts
+++ b/src/domain/parse.ts
@@ -1,0 +1,637 @@
+import type { z } from "zod";
+import {
+	type Clip,
+	clipSchema,
+	type Device,
+	type Project,
+	type ProjectMetadata,
+	projectMetadataSchema,
+	projectSchema,
+	SCHEMA_VERSION,
+	type Song,
+	songSchema,
+	type Track,
+} from "./entities";
+import { getParameterDefinition, isParameterValueInRange } from "./parameters";
+
+/**
+ * Parsing and cross-entity integrity (PRD section 9.5).
+ *
+ * `parseProject` is the only way to obtain a `Project`. It validates shape,
+ * schema version, and every relationship, and either returns a complete valid
+ * project or a list of issues — it never mutates its input and never returns
+ * partially repaired state.
+ */
+
+export type DomainIssueCode =
+	| "invalid_shape"
+	| "unsupported_schema_version"
+	| "duplicate_id"
+	| "dangling_reference"
+	| "cross_owner_reference"
+	| "invalid_order"
+	| "invalid_parameter"
+	| "invalid_automation"
+	| "invalid_musical_time"
+	| "invalid_metadata";
+
+export interface DomainIssue {
+	readonly code: DomainIssueCode;
+	readonly path: ReadonlyArray<string | number>;
+	readonly message: string;
+}
+
+export type ParseResult<T> =
+	| { readonly ok: true; readonly value: T }
+	| { readonly ok: false; readonly issues: readonly DomainIssue[] };
+
+export class DomainValidationError extends Error {
+	readonly issues: readonly DomainIssue[];
+
+	constructor(message: string, issues: readonly DomainIssue[]) {
+		super(`${message}: ${issues.map(formatIssue).join("; ")}`);
+		this.name = "DomainValidationError";
+		this.issues = issues;
+	}
+}
+
+export function formatIssue(issue: DomainIssue): string {
+	const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+	return `[${issue.code}] ${path}: ${issue.message}`;
+}
+
+function issue(
+	code: DomainIssueCode,
+	path: ReadonlyArray<string | number>,
+	message: string,
+): DomainIssue {
+	return { code, path, message };
+}
+
+function fromZod(error: z.ZodError): DomainIssue[] {
+	return error.issues.map((zodIssue) =>
+		issue(
+			"invalid_shape",
+			zodIssue.path as (string | number)[],
+			zodIssue.message,
+		),
+	);
+}
+
+function parseWith<T>(
+	schema: { safeParse: (input: unknown) => z.ZodSafeParseResult<T> },
+	input: unknown,
+): ParseResult<T> {
+	const result = schema.safeParse(input);
+	return result.success
+		? { ok: true, value: result.data }
+		: { ok: false, issues: fromZod(result.error) };
+}
+
+/** Parses one `projects/{projectId}` metadata document. */
+export function parseProjectMetadata(
+	input: unknown,
+): ParseResult<ProjectMetadata> {
+	const versionIssues = checkSchemaVersion(input, []);
+	if (versionIssues.length > 0) {
+		return { ok: false, issues: versionIssues };
+	}
+	return parseWith(projectMetadataSchema, input);
+}
+
+/** Parses one `projects/{projectId}/song/current` document. */
+export function parseSong(input: unknown): ParseResult<Song> {
+	const result = parseWith(songSchema, input);
+	if (!result.ok) {
+		return result;
+	}
+	const issues = checkSongIntegrity(result.value, ["song"]);
+	return issues.length > 0 ? { ok: false, issues } : result;
+}
+
+/** Parses one `projects/{projectId}/clips/{clipId}` document. */
+export function parseClip(input: unknown): ParseResult<Clip> {
+	return parseWith(clipSchema, input);
+}
+
+/** Parses and fully validates a whole project aggregate. */
+export function parseProject(input: unknown): ParseResult<Project> {
+	const versionIssues = checkSchemaVersion(
+		(input as { metadata?: unknown } | null | undefined)?.metadata,
+		["metadata"],
+	);
+	if (versionIssues.length > 0) {
+		return { ok: false, issues: versionIssues };
+	}
+	const shape = parseWith(projectSchema, input);
+	if (!shape.ok) {
+		return shape;
+	}
+	const issues = checkProjectIntegrity(shape.value);
+	return issues.length > 0 ? { ok: false, issues } : shape;
+}
+
+/** Parses a project, throwing `DomainValidationError` when it is invalid. */
+export function assertProject(input: unknown): Project {
+	const result = parseProject(input);
+	if (!result.ok) {
+		throw new DomainValidationError("Invalid schema-v1 project", result.issues);
+	}
+	return result.value;
+}
+
+export function isProject(input: unknown): input is Project {
+	return parseProject(input).ok;
+}
+
+/**
+ * A future schema version is reported rather than parsed, so a newer document
+ * is never silently coerced into v1 shape and overwritten (PRJ-04).
+ */
+function checkSchemaVersion(
+	metadata: unknown,
+	path: ReadonlyArray<string | number>,
+): DomainIssue[] {
+	if (typeof metadata !== "object" || metadata === null) {
+		return [];
+	}
+	const version = (metadata as { schemaVersion?: unknown }).schemaVersion;
+	if (typeof version !== "number" || !Number.isInteger(version)) {
+		return [];
+	}
+	if (version > SCHEMA_VERSION) {
+		return [
+			issue(
+				"unsupported_schema_version",
+				[...path, "schemaVersion"],
+				`Schema version ${version} is newer than the supported version ${SCHEMA_VERSION}; refusing to read or overwrite it`,
+			),
+		];
+	}
+	if (version < SCHEMA_VERSION) {
+		return [
+			issue(
+				"unsupported_schema_version",
+				[...path, "schemaVersion"],
+				`Schema version ${version} predates schema v1 and is not migrated`,
+			),
+		];
+	}
+	return [];
+}
+
+/** Every cross-entity invariant in PRD section 9.5. */
+export function checkProjectIntegrity(project: Project): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	const seenIds = new Set<string>();
+
+	issues.push(...checkMetadata(project.metadata));
+	issues.push(...checkSongIntegrity(project.song, ["song"], seenIds));
+
+	const trackIds = new Map(
+		project.song.tracks.map((track) => [track.id, track]),
+	);
+	const assetIds = new Set(project.song.assets.map((asset) => asset.id));
+	const clipIds = new Map<string, Clip>();
+
+	project.clips.forEach((clip, index) => {
+		const path = ["clips", index] as const;
+		claimId(seenIds, clip.id, [...path, "id"], issues);
+		clipIds.set(clip.id, clip);
+		const owner = trackIds.get(clip.trackId);
+		if (!owner) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "trackId"],
+					`Clip ${clip.id} references missing track ${clip.trackId}`,
+				),
+			);
+		}
+		issues.push(...checkClipContent(clip, owner, assetIds, [...path], seenIds));
+	});
+
+	project.song.placements.forEach((placement, index) => {
+		const path = ["song", "placements", index] as const;
+		const clip = clipIds.get(placement.clipId);
+		if (!clip) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "clipId"],
+					`Placement ${placement.id} references missing clip ${placement.clipId}`,
+				),
+			);
+			return;
+		}
+		if (clip.trackId !== placement.trackId) {
+			issues.push(
+				issue(
+					"cross_owner_reference",
+					[...path, "trackId"],
+					`Placement ${placement.id} puts clip ${clip.id} (owned by track ${clip.trackId}) on track ${placement.trackId}`,
+				),
+			);
+		}
+	});
+
+	return issues;
+}
+
+/**
+ * Song-level integrity. Callers that also hold clips pass their `seenIds` set
+ * so duplicate IDs are detected across the whole aggregate.
+ */
+export function checkSongIntegrity(
+	song: Song,
+	path: ReadonlyArray<string | number>,
+	seenIds: Set<string> = new Set(),
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	const assetIds = new Set<string>();
+	const returnIds = new Set<string>();
+	const tracks = new Map<string, Track>();
+
+	song.assets.forEach((asset, index) => {
+		claimId(seenIds, asset.id, [...path, "assets", index, "id"], issues);
+		assetIds.add(asset.id);
+	});
+
+	song.returns.forEach((bus, index) => {
+		claimId(seenIds, bus.id, [...path, "returns", index, "id"], issues);
+		returnIds.add(bus.id);
+		issues.push(
+			...checkDeviceChain(
+				bus.devices,
+				[...path, "returns", index, "devices"],
+				seenIds,
+			),
+		);
+	});
+	issues.push(
+		...checkOrdering(
+			song.returns.map((bus) => bus.order),
+			[...path, "returns"],
+			"return buses",
+		),
+	);
+
+	issues.push(
+		...checkDeviceChain(
+			song.master.devices,
+			[...path, "master", "devices"],
+			seenIds,
+		),
+	);
+
+	song.tracks.forEach((track, index) => {
+		const trackPath = [...path, "tracks", index] as const;
+		claimId(seenIds, track.id, [...trackPath, "id"], issues);
+		tracks.set(track.id, track);
+		issues.push(
+			...checkDeviceChain(track.devices, [...trackPath, "devices"], seenIds),
+		);
+		issues.push(...checkInstrument(track, trackPath, assetIds, seenIds));
+
+		const usedReturns = new Set<string>();
+		track.sends.forEach((send, sendIndex) => {
+			const sendPath = [...trackPath, "sends", sendIndex] as const;
+			if (!returnIds.has(send.returnId)) {
+				issues.push(
+					issue(
+						"dangling_reference",
+						[...sendPath, "returnId"],
+						`Track ${track.id} sends to missing return bus ${send.returnId}`,
+					),
+				);
+			}
+			if (usedReturns.has(send.returnId)) {
+				issues.push(
+					issue(
+						"duplicate_id",
+						[...sendPath, "returnId"],
+						`Track ${track.id} has more than one send to return bus ${send.returnId}`,
+					),
+				);
+			}
+			usedReturns.add(send.returnId);
+		});
+	});
+	issues.push(
+		...checkOrdering(
+			song.tracks.map((track) => track.order),
+			[...path, "tracks"],
+			"tracks",
+		),
+	);
+
+	song.sections.forEach((section, index) => {
+		claimId(seenIds, section.id, [...path, "sections", index, "id"], issues);
+	});
+
+	song.placements.forEach((placement, index) => {
+		const placementPath = [...path, "placements", index] as const;
+		claimId(seenIds, placement.id, [...placementPath, "id"], issues);
+		if (!tracks.has(placement.trackId)) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...placementPath, "trackId"],
+					`Placement ${placement.id} references missing track ${placement.trackId}`,
+				),
+			);
+		}
+	});
+
+	song.automation.forEach((lane, index) => {
+		const lanePath = [...path, "automation", index] as const;
+		claimId(seenIds, lane.id, [...lanePath, "id"], issues);
+		issues.push(...checkAutomationLane(lane, lanePath, tracks, returnIds));
+	});
+
+	return issues;
+}
+
+function checkMetadata(metadata: ProjectMetadata): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	if (metadata.modifiedAt < metadata.createdAt) {
+		issues.push(
+			issue(
+				"invalid_metadata",
+				["metadata", "modifiedAt"],
+				"modifiedAt precedes createdAt",
+			),
+		);
+	}
+	const seen = new Set<string>();
+	metadata.collaboratorIds.forEach((collaboratorId, index) => {
+		if (seen.has(collaboratorId)) {
+			issues.push(
+				issue(
+					"duplicate_id",
+					["metadata", "collaboratorIds", index],
+					`Collaborator ${collaboratorId} is listed more than once`,
+				),
+			);
+		}
+		seen.add(collaboratorId);
+	});
+	return issues;
+}
+
+function checkInstrument(
+	track: Track,
+	path: ReadonlyArray<string | number>,
+	assetIds: ReadonlySet<string>,
+	seenIds: Set<string>,
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	const instrument = track.instrument;
+	if (!instrument) {
+		return issues;
+	}
+	if (instrument.kind === "sampler" && instrument.assetId !== null) {
+		if (!assetIds.has(instrument.assetId)) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "instrument", "assetId"],
+					`Track ${track.id} references missing asset ${instrument.assetId}`,
+				),
+			);
+		}
+	}
+	if (instrument.kind === "drumMachine") {
+		instrument.pads.forEach((pad, index) => {
+			const padPath = [...path, "instrument", "pads", index] as const;
+			claimId(seenIds, pad.id, [...padPath, "id"], issues);
+			if (pad.assetId !== null && !assetIds.has(pad.assetId)) {
+				issues.push(
+					issue(
+						"dangling_reference",
+						[...padPath, "assetId"],
+						`Drum pad ${pad.id} references missing asset ${pad.assetId}`,
+					),
+				);
+			}
+		});
+	}
+	return issues;
+}
+
+function checkClipContent(
+	clip: Clip,
+	owner: Track | undefined,
+	assetIds: ReadonlySet<string>,
+	path: ReadonlyArray<string | number>,
+	seenIds: Set<string>,
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	if (clip.content.kind === "audioLoop") {
+		if (!assetIds.has(clip.content.assetId)) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "content", "assetId"],
+					`Clip ${clip.id} references missing asset ${clip.content.assetId}`,
+				),
+			);
+		}
+		return issues;
+	}
+	const padIds = new Set(
+		owner?.instrument?.kind === "drumMachine"
+			? owner.instrument.pads.map((pad) => pad.id)
+			: [],
+	);
+	clip.content.events.forEach((event, index) => {
+		const eventPath = [...path, "content", "events", index] as const;
+		claimId(seenIds, event.id, [...eventPath, "id"], issues);
+		if (event.startTicks >= clip.lengthTicks) {
+			issues.push(
+				issue(
+					"invalid_musical_time",
+					[...eventPath, "startTicks"],
+					`Note ${event.id} starts at ${event.startTicks} which is outside its ${clip.lengthTicks}-tick clip`,
+				),
+			);
+		}
+		if (event.trigger.kind === "pad" && !padIds.has(event.trigger.padId)) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...eventPath, "trigger", "padId"],
+					`Note ${event.id} triggers pad ${event.trigger.padId}, which its track does not own`,
+				),
+			);
+		}
+	});
+	return issues;
+}
+
+function checkDeviceChain(
+	devices: readonly Device[],
+	path: ReadonlyArray<string | number>,
+	seenIds: Set<string>,
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	devices.forEach((device, index) => {
+		claimId(seenIds, device.id, [...path, index, "id"], issues);
+		for (const [parameterId, value] of Object.entries(device.parameters)) {
+			const definition = getParameterDefinition(
+				`${device.type}.${parameterId}`,
+			);
+			if (definition && !isParameterValueInRange(definition, value)) {
+				issues.push(
+					issue(
+						"invalid_parameter",
+						[...path, index, "parameters", parameterId],
+						`Value ${value} is outside the declared range ${definition.min}..${definition.max}`,
+					),
+				);
+			}
+		}
+	});
+	issues.push(
+		...checkOrdering(
+			devices.map((device) => device.order),
+			path,
+			"devices",
+		),
+	);
+	return issues;
+}
+
+/** Insert chains and track lists are serial: orders are 0..n-1 exactly once. */
+function checkOrdering(
+	orders: readonly number[],
+	path: ReadonlyArray<string | number>,
+	label: string,
+): DomainIssue[] {
+	const sorted = [...orders].sort((a, b) => a - b);
+	const contiguous = sorted.every((order, index) => order === index);
+	return contiguous
+		? []
+		: [
+				issue(
+					"invalid_order",
+					path,
+					`Order values for ${label} must be 0..${orders.length - 1} without gaps or duplicates, received [${orders.join(", ")}]`,
+				),
+			];
+}
+
+function checkAutomationLane(
+	lane: Song["automation"][number],
+	path: ReadonlyArray<string | number>,
+	tracks: ReadonlyMap<string, Track>,
+	returnIds: ReadonlySet<string>,
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	const target = lane.target;
+
+	if ("trackId" in target) {
+		const track = tracks.get(target.trackId);
+		if (!track) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "target", "trackId"],
+					`Automation ${lane.id} targets missing track ${target.trackId}`,
+				),
+			);
+		} else if (target.scope === "trackDevice") {
+			const device = track.devices.find(
+				(entry) => entry.id === target.deviceId,
+			);
+			if (!device) {
+				issues.push(
+					issue(
+						"dangling_reference",
+						[...path, "target", "deviceId"],
+						`Automation ${lane.id} targets missing device ${target.deviceId} on track ${track.id}`,
+					),
+				);
+			}
+		} else if (target.scope === "send") {
+			const send = track.sends.find(
+				(entry) => entry.returnId === target.returnId,
+			);
+			if (!send) {
+				issues.push(
+					issue(
+						"dangling_reference",
+						[...path, "target", "returnId"],
+						`Automation ${lane.id} targets a send to ${target.returnId} that track ${track.id} does not have`,
+					),
+				);
+			}
+		}
+	}
+
+	if (target.scope === "return" && !returnIds.has(target.returnId)) {
+		issues.push(
+			issue(
+				"dangling_reference",
+				[...path, "target", "returnId"],
+				`Automation ${lane.id} targets missing return bus ${target.returnId}`,
+			),
+		);
+	}
+
+	const definition = getParameterDefinition(target.parameterId);
+	if (!definition) {
+		issues.push(
+			issue(
+				"invalid_automation",
+				[...path, "target", "parameterId"],
+				`Automation ${lane.id} targets unknown parameter "${target.parameterId}"`,
+			),
+		);
+	} else if (!definition.automatable) {
+		issues.push(
+			issue(
+				"invalid_automation",
+				[...path, "target", "parameterId"],
+				`Parameter "${definition.id}" does not support automation`,
+			),
+		);
+	}
+
+	let previousTick = -1;
+	lane.points.forEach((point, index) => {
+		if (point.tick <= previousTick) {
+			issues.push(
+				issue(
+					"invalid_automation",
+					[...path, "points", index, "tick"],
+					`Automation points must be ordered by strictly increasing tick, received ${point.tick} after ${previousTick}`,
+				),
+			);
+		}
+		previousTick = point.tick;
+		if (definition && !isParameterValueInRange(definition, point.value)) {
+			issues.push(
+				issue(
+					"invalid_parameter",
+					[...path, "points", index, "value"],
+					`Value ${point.value} is outside the declared range ${definition.min}..${definition.max} for "${definition.id}"`,
+				),
+			);
+		}
+	});
+
+	return issues;
+}
+
+function claimId(
+	seenIds: Set<string>,
+	id: string,
+	path: ReadonlyArray<string | number>,
+	issues: DomainIssue[],
+): void {
+	if (seenIds.has(id)) {
+		issues.push(issue("duplicate_id", path, `Duplicate entity id ${id}`));
+	}
+	seenIds.add(id);
+}

--- a/src/domain/parse.ts
+++ b/src/domain/parse.ts
@@ -109,9 +109,21 @@ export function parseSong(input: unknown): ParseResult<Song> {
 	return issues.length > 0 ? { ok: false, issues } : result;
 }
 
-/** Parses one `projects/{projectId}/clips/{clipId}` document. */
+/**
+ * Parses one `projects/{projectId}/clips/{clipId}` document.
+ *
+ * A clip document carries no track or asset context, so this applies every
+ * invariant that a clip can be judged on alone. Owner-dependent rules (pad
+ * ownership, audio-loop asset) are checked in the aggregate path, which holds
+ * the track and asset sets.
+ */
 export function parseClip(input: unknown): ParseResult<Clip> {
-	return parseWith(clipSchema, input);
+	const result = parseWith(clipSchema, input);
+	if (!result.ok) {
+		return result;
+	}
+	const issues = checkClipInvariants(result.value, []);
+	return issues.length > 0 ? { ok: false, issues } : result;
 }
 
 /** Parses and fully validates a whole project aggregate. */
@@ -208,7 +220,8 @@ export function checkProjectIntegrity(project: Project): DomainIssue[] {
 				),
 			);
 		}
-		issues.push(...checkClipContent(clip, owner, assetIds, [...path], seenIds));
+		issues.push(...checkClipInvariants(clip, [...path], seenIds));
+		issues.push(...checkClipOwnership(clip, owner, assetIds, [...path]));
 	});
 
 	project.song.placements.forEach((placement, index) => {
@@ -419,12 +432,48 @@ function checkInstrument(
 	return issues;
 }
 
-function checkClipContent(
+/**
+ * Clip-local integrity: everything a clip document can be judged on without its
+ * owning track or the song's assets. Both `parseClip` and the aggregate path run
+ * this, so the two entry points agree on what a valid clip is.
+ *
+ * Aggregate callers pass their `seenIds` set so event IDs are also unique across
+ * the whole project.
+ */
+export function checkClipInvariants(
+	clip: Clip,
+	path: ReadonlyArray<string | number>,
+	seenIds: Set<string> = new Set(),
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	if (clip.content.kind !== "notes") {
+		return issues;
+	}
+	clip.content.events.forEach((event, index) => {
+		const eventPath = [...path, "content", "events", index] as const;
+		claimId(seenIds, event.id, [...eventPath, "id"], issues);
+		if (event.startTicks >= clip.lengthTicks) {
+			issues.push(
+				issue(
+					"invalid_musical_time",
+					[...eventPath, "startTicks"],
+					`Note ${event.id} starts at ${event.startTicks} which is outside its ${clip.lengthTicks}-tick clip`,
+				),
+			);
+		}
+	});
+	return issues;
+}
+
+/**
+ * Clip integrity that depends on the clip's owner and the song's assets, and so
+ * is only decidable in the aggregate path.
+ */
+function checkClipOwnership(
 	clip: Clip,
 	owner: Track | undefined,
 	assetIds: ReadonlySet<string>,
 	path: ReadonlyArray<string | number>,
-	seenIds: Set<string>,
 ): DomainIssue[] {
 	const issues: DomainIssue[] = [];
 	if (clip.content.kind === "audioLoop") {
@@ -446,16 +495,6 @@ function checkClipContent(
 	);
 	clip.content.events.forEach((event, index) => {
 		const eventPath = [...path, "content", "events", index] as const;
-		claimId(seenIds, event.id, [...eventPath, "id"], issues);
-		if (event.startTicks >= clip.lengthTicks) {
-			issues.push(
-				issue(
-					"invalid_musical_time",
-					[...eventPath, "startTicks"],
-					`Note ${event.id} starts at ${event.startTicks} which is outside its ${clip.lengthTicks}-tick clip`,
-				),
-			);
-		}
 		if (event.trigger.kind === "pad" && !padIds.has(event.trigger.padId)) {
 			issues.push(
 				issue(

--- a/src/domain/parse.ts
+++ b/src/domain/parse.ts
@@ -307,8 +307,8 @@ export function checkSongIntegrity(
 		issues.push(...checkInstrument(track, trackPath, assetIds, seenIds));
 
 		const usedReturns = new Set<string>();
-		track.sends.forEach((send, sendIndex) => {
-			const sendPath = [...trackPath, "sends", sendIndex] as const;
+		track.sendConfig.forEach((send, sendIndex) => {
+			const sendPath = [...trackPath, "sendConfig", sendIndex] as const;
 			if (!returnIds.has(send.returnId)) {
 				issues.push(
 					issue(
@@ -593,7 +593,7 @@ function checkAutomationLane(
 				);
 			}
 		} else if (target.scope === "send") {
-			const send = track.sends.find(
+			const send = track.sendConfig.find(
 				(entry) => entry.returnId === target.returnId,
 			);
 			if (!send) {

--- a/src/domain/project.property.test.ts
+++ b/src/domain/project.property.test.ts
@@ -1,0 +1,174 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import type { Clip, Project, Track } from "./entities";
+import {
+	bars,
+	createAsset,
+	createEmptySong,
+	createFactoryContext,
+	createNoteClip,
+	createNoteEvent,
+	createPlacement,
+	createProjectMetadata,
+	createSamplerInstrument,
+	createTrack,
+} from "./factories";
+import { createSeededIdFactory } from "./ids";
+import { parseProject } from "./parse";
+import { serializeProject, stringifyProject } from "./serialize";
+import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "./time";
+
+/**
+ * Property-oriented coverage: rather than one hand-written example per rule,
+ * these generate whole projects and assert that validation and serialization
+ * hold for every shape the generator produces. The seed is fixed so a failure
+ * is reproducible.
+ */
+
+const RUN_OPTIONS = { numRuns: 100, seed: 20_260_724 } as const;
+
+interface ProjectShape {
+	seed: number;
+	tempo: number;
+	trackCount: number;
+	clipBars: number;
+	notesPerClip: number;
+	placementsPerTrack: number;
+}
+
+const shapeArbitrary: fc.Arbitrary<ProjectShape> = fc.record({
+	seed: fc.integer({ min: 0, max: 1_000_000 }),
+	tempo: fc.integer({ min: 20, max: 300 }),
+	trackCount: fc.integer({ min: 0, max: 6 }),
+	clipBars: fc.integer({ min: 1, max: 4 }),
+	notesPerClip: fc.integer({ min: 0, max: 8 }),
+	placementsPerTrack: fc.integer({ min: 0, max: 4 }),
+});
+
+function buildProject(shape: ProjectShape): Project {
+	const context = createFactoryContext({
+		ids: createSeededIdFactory(`property-${shape.seed}`),
+		now: 1_700_000_000_000,
+	});
+
+	const asset = createAsset(context, {
+		name: "Generated sample",
+		storageRef: `samples/generated/${shape.seed}.wav`,
+	});
+
+	const tracks: Track[] = [];
+	const clips: Clip[] = [];
+	const placements = [];
+
+	for (let index = 0; index < shape.trackCount; index += 1) {
+		const track = createTrack(context, {
+			name: `Track ${index + 1}`,
+			order: index,
+			instrument: createSamplerInstrument(asset.id),
+		});
+		tracks.push(track);
+
+		const clip = createNoteClip(context, {
+			trackId: track.id,
+			name: `Clip ${index + 1}`,
+			lengthTicks: shape.clipBars * TICKS_PER_BAR,
+			events: Array.from({ length: shape.notesPerClip }, (_, noteIndex) =>
+				createNoteEvent(context, {
+					startTicks:
+						(noteIndex * TICKS_PER_SIXTEENTH) %
+						(shape.clipBars * TICKS_PER_BAR),
+					durationTicks: TICKS_PER_SIXTEENTH,
+					pitch: 36 + (noteIndex % 12),
+					velocity: 0.1 + (noteIndex % 9) / 10,
+				}),
+			),
+		});
+		clips.push(clip);
+
+		for (let slot = 0; slot < shape.placementsPerTrack; slot += 1) {
+			placements.push(
+				createPlacement(context, {
+					clipId: clip.id,
+					trackId: track.id,
+					startTicks: bars(slot * shape.clipBars),
+					durationTicks: bars(shape.clipBars),
+				}),
+			);
+		}
+	}
+
+	return {
+		metadata: createProjectMetadata(context, {
+			ownerId: `user_${shape.seed}`,
+			name: `Generated ${shape.seed}`,
+		}),
+		song: {
+			...createEmptySong(shape.tempo),
+			assets: [asset],
+			tracks,
+			placements,
+		},
+		clips,
+	};
+}
+
+describe("generated projects", () => {
+	it("always satisfy every invariant", () => {
+		fc.assert(
+			fc.property(shapeArbitrary, (shape) => {
+				const result = parseProject(buildProject(shape));
+				expect(result.ok, JSON.stringify(result.ok ? [] : result.issues)).toBe(
+					true,
+				);
+			}),
+			RUN_OPTIONS,
+		);
+	});
+
+	it("round trip through JSON without changing their serialization", () => {
+		fc.assert(
+			fc.property(shapeArbitrary, (shape) => {
+				const project = buildProject(shape);
+				const json = JSON.parse(stringifyProject(project));
+				const result = parseProject(json);
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					expect(serializeProject(result.value)).toEqual(
+						serializeProject(project),
+					);
+				}
+			}),
+			RUN_OPTIONS,
+		);
+	});
+
+	it("report an issue, never throw, when a referenced entity disappears", () => {
+		fc.assert(
+			fc.property(
+				shapeArbitrary.filter((shape) => shape.trackCount > 0),
+				(shape) => {
+					const project = buildProject(shape);
+					const broken = {
+						...project,
+						song: { ...project.song, tracks: project.song.tracks.slice(1) },
+					};
+					const result = parseProject(broken);
+					expect(result.ok).toBe(false);
+					if (!result.ok) {
+						expect(result.issues.length).toBeGreaterThan(0);
+					}
+				},
+			),
+			RUN_OPTIONS,
+		);
+	});
+
+	it("reject arbitrary non-project values without throwing", () => {
+		fc.assert(
+			fc.property(fc.anything(), (value) => {
+				expect(parseProject(value).ok).toBe(false);
+			}),
+			RUN_OPTIONS,
+		);
+	});
+});

--- a/src/domain/serialize.test.ts
+++ b/src/domain/serialize.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { createReferenceProject, createSliceFixtureProject } from "./fixtures";
+import { assertProject, parseProject } from "./parse";
+import { serializeProject, stringifyProject } from "./serialize";
+
+describe("schema-v1 serialization", () => {
+	it("round trips through JSON-compatible values", () => {
+		const project = createSliceFixtureProject();
+		const json = JSON.parse(stringifyProject(project));
+		const reparsed = assertProject(json);
+
+		expect(serializeProject(reparsed)).toEqual(serializeProject(project));
+		expect(stringifyProject(reparsed)).toBe(stringifyProject(project));
+	});
+
+	it("emits only JSON primitives, arrays, and plain objects", () => {
+		const serialized = serializeProject(createSliceFixtureProject());
+		walk(serialized, (value) => {
+			const type = typeof value;
+			if (value === null || type === "string" || type === "boolean") {
+				return;
+			}
+			expect(type).toBe("number");
+			expect(Number.isFinite(value as number)).toBe(true);
+		});
+	});
+
+	it("is byte-identical for two independently built copies of a fixture", () => {
+		expect(stringifyProject(createSliceFixtureProject())).toBe(
+			stringifyProject(createSliceFixtureProject()),
+		);
+	});
+
+	it("does not depend on collection insertion order", () => {
+		const project = createSliceFixtureProject();
+		const shuffled = assertProject({
+			...project,
+			song: {
+				...project.song,
+				tracks: [...project.song.tracks].reverse(),
+				placements: [...project.song.placements].reverse(),
+			},
+			clips: [...project.clips].reverse(),
+		});
+
+		expect(stringifyProject(shuffled)).toBe(stringifyProject(project));
+	});
+
+	it("does not depend on object key order", () => {
+		const project = createSliceFixtureProject();
+		const rekeyed = JSON.parse(
+			JSON.stringify(serializeProject(project), (_key, value) =>
+				isPlainObject(value) ? reverseKeys(value) : value,
+			),
+		);
+		const result = parseProject(rekeyed);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(stringifyProject(result.value)).toBe(stringifyProject(project));
+		}
+	});
+
+	it("round trips a ten-minute, fifty-track reference arrangement", () => {
+		const project = createReferenceProject();
+		const round = assertProject(JSON.parse(stringifyProject(project)));
+		expect(stringifyProject(round)).toBe(stringifyProject(project));
+	});
+});
+
+function walk(value: unknown, visit: (leaf: unknown) => void): void {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			walk(item, visit);
+		}
+		return;
+	}
+	if (isPlainObject(value)) {
+		for (const item of Object.values(value)) {
+			walk(item, visit);
+		}
+		return;
+	}
+	visit(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === "object" && value !== null && value.constructor === Object
+	);
+}
+
+function reverseKeys(value: Record<string, unknown>): Record<string, unknown> {
+	const reversed: Record<string, unknown> = {};
+	for (const key of Object.keys(value).reverse()) {
+		reversed[key] = value[key];
+	}
+	return reversed;
+}

--- a/src/domain/serialize.ts
+++ b/src/domain/serialize.ts
@@ -1,0 +1,377 @@
+import type {
+	Asset,
+	AutomationLane,
+	Clip,
+	Device,
+	DrumPad,
+	Instrument,
+	NoteEvent,
+	Placement,
+	Project,
+	ProjectMetadata,
+	ReturnBus,
+	Section,
+	Send,
+	Song,
+	Track,
+} from "./entities";
+
+/**
+ * Deterministic schema-v1 serialization.
+ *
+ * The same project always produces byte-identical JSON: keys are written in a
+ * fixed order and every collection is sorted by stable, meaningful keys rather
+ * than by insertion order. That makes round trips, diffs, remote-echo
+ * comparison, and fixture assertions reliable.
+ */
+
+export type JsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JsonValue[]
+	| { [key: string]: JsonValue };
+
+export type JsonObject = { [key: string]: JsonValue };
+
+export function serializeProject(project: Project): JsonObject {
+	return {
+		metadata: serializeProjectMetadata(project.metadata),
+		song: serializeSong(project.song),
+		clips: sortBy(project.clips, (clip) => [clip.id]).map(serializeClip),
+	};
+}
+
+/** Stable JSON text; equal projects always produce an equal string. */
+export function stringifyProject(project: Project): string {
+	return JSON.stringify(serializeProject(project));
+}
+
+export function serializeProjectMetadata(
+	metadata: ProjectMetadata,
+): JsonObject {
+	return {
+		id: metadata.id,
+		schemaVersion: metadata.schemaVersion,
+		revision: metadata.revision,
+		name: metadata.name,
+		ownerId: metadata.ownerId,
+		collaboratorIds: [...metadata.collaboratorIds].sort(compareStrings),
+		createdAt: metadata.createdAt,
+		modifiedAt: metadata.modifiedAt,
+		template: metadata.template,
+		genre: metadata.genre,
+	};
+}
+
+export function serializeSong(song: Song): JsonObject {
+	return {
+		tempo: song.tempo,
+		timeSignature: {
+			numerator: song.timeSignature.numerator,
+			denominator: song.timeSignature.denominator,
+		},
+		tracks: sortBy(song.tracks, (track) => [track.order, track.id]).map(
+			serializeTrack,
+		),
+		returns: sortBy(song.returns, (bus) => [bus.order, bus.id]).map(
+			serializeReturnBus,
+		),
+		master: {
+			volume: song.master.volume,
+			devices: serializeDevices(song.master.devices),
+		},
+		sections: sortBy(song.sections, (section) => [
+			section.startTicks,
+			section.id,
+		]).map(serializeSection),
+		placements: sortBy(song.placements, (placement) => [
+			placement.startTicks,
+			placement.trackId,
+			placement.id,
+		]).map(serializePlacement),
+		automation: sortBy(song.automation, (lane) => [
+			automationSortKey(lane),
+			lane.id,
+		]).map(serializeAutomationLane),
+		assets: sortBy(song.assets, (asset) => [asset.id]).map(serializeAsset),
+	};
+}
+
+export function serializeClip(clip: Clip): JsonObject {
+	return {
+		id: clip.id,
+		trackId: clip.trackId,
+		name: clip.name,
+		color: clip.color,
+		lengthTicks: clip.lengthTicks,
+		content:
+			clip.content.kind === "notes"
+				? {
+						kind: clip.content.kind,
+						events: sortBy(clip.content.events, (event) => [
+							event.startTicks,
+							event.id,
+						]).map(serializeNoteEvent),
+					}
+				: {
+						kind: clip.content.kind,
+						assetId: clip.content.assetId,
+						sourceTempo: clip.content.sourceTempo,
+						startOffsetTicks: clip.content.startOffsetTicks,
+					},
+	};
+}
+
+function serializeNoteEvent(event: NoteEvent): JsonObject {
+	return {
+		id: event.id,
+		trigger:
+			event.trigger.kind === "pitch"
+				? { kind: event.trigger.kind, pitch: event.trigger.pitch }
+				: { kind: event.trigger.kind, padId: event.trigger.padId },
+		startTicks: event.startTicks,
+		durationTicks: event.durationTicks,
+		velocity: event.velocity,
+		probability: event.probability,
+	};
+}
+
+function serializeTrack(track: Track): JsonObject {
+	return {
+		id: track.id,
+		name: track.name,
+		color: track.color,
+		order: track.order,
+		type: track.type,
+		instrument: track.instrument ? serializeInstrument(track.instrument) : null,
+		devices: serializeDevices(track.devices),
+		sends: sortBy(track.sends, (send) => [send.returnId]).map(serializeSend),
+		mixer: {
+			volume: track.mixer.volume,
+			pan: track.mixer.pan,
+			muted: track.mixer.muted,
+			soloed: track.mixer.soloed,
+		},
+	};
+}
+
+function serializeInstrument(instrument: Instrument): JsonObject {
+	switch (instrument.kind) {
+		case "sampler":
+			return {
+				kind: instrument.kind,
+				assetId: instrument.assetId,
+				parameters: serializeParameters(instrument.parameters),
+			};
+		case "synth":
+			return {
+				kind: instrument.kind,
+				parameters: serializeParameters(instrument.parameters),
+			};
+		case "drumMachine":
+			return {
+				kind: instrument.kind,
+				pads: instrument.pads.map(serializeDrumPad),
+				parameters: serializeParameters(instrument.parameters),
+			};
+	}
+}
+
+function serializeDrumPad(pad: DrumPad): JsonObject {
+	return {
+		id: pad.id,
+		name: pad.name,
+		assetId: pad.assetId,
+		chokeGroup: pad.chokeGroup,
+		parameters: serializeParameters(pad.parameters),
+		mixer: {
+			volume: pad.mixer.volume,
+			pan: pad.mixer.pan,
+			muted: pad.mixer.muted,
+		},
+	};
+}
+
+function serializeDevices(devices: readonly Device[]): JsonValue[] {
+	return sortBy(devices, (device) => [device.order, device.id]).map(
+		serializeDevice,
+	);
+}
+
+function serializeDevice(device: Device): JsonObject {
+	return {
+		id: device.id,
+		type: device.type,
+		order: device.order,
+		bypassed: device.bypassed,
+		parameters: serializeParameters(device.parameters),
+		preset: device.preset
+			? {
+					id: device.preset.id,
+					name: device.preset.name,
+					source: device.preset.source,
+				}
+			: null,
+	};
+}
+
+function serializeSend(send: Send): JsonObject {
+	return {
+		returnId: send.returnId,
+		level: send.level,
+		preFader: send.preFader,
+	};
+}
+
+function serializeReturnBus(bus: ReturnBus): JsonObject {
+	return {
+		id: bus.id,
+		name: bus.name,
+		order: bus.order,
+		devices: serializeDevices(bus.devices),
+		mixer: {
+			volume: bus.mixer.volume,
+			pan: bus.mixer.pan,
+			muted: bus.mixer.muted,
+		},
+	};
+}
+
+function serializeSection(section: Section): JsonObject {
+	return {
+		id: section.id,
+		name: section.name,
+		color: section.color,
+		startTicks: section.startTicks,
+		durationTicks: section.durationTicks,
+	};
+}
+
+function serializePlacement(placement: Placement): JsonObject {
+	return {
+		id: placement.id,
+		clipId: placement.clipId,
+		trackId: placement.trackId,
+		startTicks: placement.startTicks,
+		durationTicks: placement.durationTicks,
+		clipOffsetTicks: placement.clipOffsetTicks,
+		looped: placement.looped,
+	};
+}
+
+function serializeAutomationLane(lane: AutomationLane): JsonObject {
+	return {
+		id: lane.id,
+		target: serializeAutomationTarget(lane.target),
+		interpolation: lane.interpolation,
+		points: [...lane.points]
+			.sort((a, b) => a.tick - b.tick)
+			.map((point) => ({ tick: point.tick, value: point.value })),
+	};
+}
+
+function serializeAutomationTarget(
+	target: AutomationLane["target"],
+): JsonObject {
+	switch (target.scope) {
+		case "track":
+			return {
+				scope: target.scope,
+				trackId: target.trackId,
+				parameterId: target.parameterId,
+			};
+		case "trackDevice":
+			return {
+				scope: target.scope,
+				trackId: target.trackId,
+				deviceId: target.deviceId,
+				parameterId: target.parameterId,
+			};
+		case "send":
+			return {
+				scope: target.scope,
+				trackId: target.trackId,
+				returnId: target.returnId,
+				parameterId: target.parameterId,
+			};
+		case "return":
+			return {
+				scope: target.scope,
+				returnId: target.returnId,
+				parameterId: target.parameterId,
+			};
+		case "master":
+			return { scope: target.scope, parameterId: target.parameterId };
+	}
+}
+
+function automationSortKey(lane: AutomationLane): string {
+	const target = lane.target;
+	switch (target.scope) {
+		case "track":
+			return `track:${target.trackId}:${target.parameterId}`;
+		case "trackDevice":
+			return `trackDevice:${target.trackId}:${target.deviceId}:${target.parameterId}`;
+		case "send":
+			return `send:${target.trackId}:${target.returnId}:${target.parameterId}`;
+		case "return":
+			return `return:${target.returnId}:${target.parameterId}`;
+		case "master":
+			return `master:${target.parameterId}`;
+	}
+}
+
+function serializeAsset(asset: Asset): JsonObject {
+	return {
+		id: asset.id,
+		kind: asset.kind,
+		name: asset.name,
+		storageRef: asset.storageRef,
+		url: asset.url,
+		durationSeconds: asset.durationSeconds,
+		sampleRate: asset.sampleRate,
+		channelCount: asset.channelCount,
+		provenance: {
+			source: asset.provenance.source,
+			licence: asset.provenance.licence,
+			attribution: asset.provenance.attribution,
+		},
+	};
+}
+
+function serializeParameters(
+	parameters: Readonly<Record<string, number>>,
+): JsonObject {
+	const serialized: JsonObject = {};
+	for (const key of Object.keys(parameters).sort(compareStrings)) {
+		serialized[key] = parameters[key];
+	}
+	return serialized;
+}
+
+type SortKey = ReadonlyArray<string | number>;
+
+function sortBy<T>(items: readonly T[], key: (item: T) => SortKey): T[] {
+	return [...items].sort((a, b) => compareKeys(key(a), key(b)));
+}
+
+function compareKeys(a: SortKey, b: SortKey): number {
+	for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+		const left = a[index];
+		const right = b[index];
+		if (left === right) {
+			continue;
+		}
+		if (typeof left === "number" && typeof right === "number") {
+			return left - right;
+		}
+		return compareStrings(String(left), String(right));
+	}
+	return 0;
+}
+
+function compareStrings(a: string, b: string): number {
+	return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/src/domain/serialize.ts
+++ b/src/domain/serialize.ts
@@ -147,7 +147,9 @@ function serializeTrack(track: Track): JsonObject {
 		type: track.type,
 		instrument: track.instrument ? serializeInstrument(track.instrument) : null,
 		devices: serializeDevices(track.devices),
-		sends: sortBy(track.sends, (send) => [send.returnId]).map(serializeSend),
+		sendConfig: sortBy(track.sendConfig, (send) => [send.returnId]).map(
+			serializeSend,
+		),
 		mixer: {
 			volume: track.mixer.volume,
 			pan: track.mixer.pan,

--- a/src/domain/time.test.ts
+++ b/src/domain/time.test.ts
@@ -1,0 +1,117 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import {
+	BEATS_PER_BAR,
+	barsBeatsSixteenthsToTicks,
+	barsToTicks,
+	formatBarsBeatsSixteenths,
+	isTicks,
+	minutesToTicks,
+	PPQ,
+	parseBarsBeatsSixteenths,
+	roundToTicks,
+	secondsToTicks,
+	sixteenthsToTicks,
+	TICKS_PER_BAR,
+	TICKS_PER_EIGHTH_TRIPLET,
+	TICKS_PER_QUARTER,
+	TICKS_PER_SIXTEENTH,
+	tickSchema,
+	ticksToBarsBeatsSixteenths,
+	ticksToSeconds,
+	toTicks,
+} from "./time";
+
+describe("musical time", () => {
+	it("uses the PRD section 9.5 resolution", () => {
+		expect(PPQ).toBe(192);
+		expect(TICKS_PER_QUARTER).toBe(192);
+		expect(TICKS_PER_SIXTEENTH).toBe(48);
+		expect(TICKS_PER_EIGHTH_TRIPLET).toBe(64);
+		expect(BEATS_PER_BAR).toBe(4);
+		expect(TICKS_PER_BAR).toBe(768);
+	});
+
+	it("keeps a ten-minute arrangement at 240 BPM under 500,000 ticks", () => {
+		expect(minutesToTicks(10, 240)).toBe(460_800);
+		expect(minutesToTicks(10, 240)).toBeLessThan(500_000);
+	});
+
+	it("rejects floating-point and non-finite musical time", () => {
+		expect(isTicks(48)).toBe(true);
+		expect(isTicks(48.5)).toBe(false);
+		expect(isTicks(-1)).toBe(false);
+		expect(isTicks(Number.NaN)).toBe(false);
+		expect(isTicks(Number.POSITIVE_INFINITY)).toBe(false);
+		expect(() => toTicks(0.5)).toThrow(/non-negative safe integer/);
+		expect(() => roundToTicks(Number.NaN)).toThrow(/non-finite/);
+		expect(tickSchema.safeParse(24.5).success).toBe(false);
+		expect(tickSchema.safeParse(-1).success).toBe(false);
+		expect(tickSchema.safeParse(24).success).toBe(true);
+	});
+
+	it("converts between ticks and seconds at a given tempo", () => {
+		expect(ticksToSeconds(TICKS_PER_QUARTER, 120)).toBeCloseTo(0.5, 10);
+		expect(ticksToSeconds(TICKS_PER_BAR, 120)).toBeCloseTo(2, 10);
+		expect(secondsToTicks(2, 120)).toBe(TICKS_PER_BAR);
+		expect(() => ticksToSeconds(96, 0)).toThrow(/positive finite/);
+	});
+
+	it("converts bars, beats, and sixteenths without losing ticks", () => {
+		expect(barsToTicks(2)).toBe(1_536);
+		expect(sixteenthsToTicks(3)).toBe(144);
+		expect(ticksToBarsBeatsSixteenths(0)).toEqual({
+			bars: 0,
+			beats: 0,
+			sixteenths: 0,
+			ticks: 0,
+		});
+		expect(ticksToBarsBeatsSixteenths(TICKS_PER_BAR + 96 + 24)).toEqual({
+			bars: 1,
+			beats: 0,
+			sixteenths: 2,
+			ticks: 24,
+		});
+		expect(
+			barsBeatsSixteenthsToTicks({ bars: 1, beats: 2, sixteenths: 3 }),
+		).toBe(TICKS_PER_BAR + 2 * TICKS_PER_QUARTER + 3 * TICKS_PER_SIXTEENTH);
+	});
+
+	it("formats and parses Tone.js bars:beats:sixteenths", () => {
+		expect(formatBarsBeatsSixteenths(0)).toBe("0:0:0");
+		expect(formatBarsBeatsSixteenths(TICKS_PER_BAR + TICKS_PER_SIXTEENTH)).toBe(
+			"1:0:1",
+		);
+		expect(formatBarsBeatsSixteenths(24)).toBe("0:0:0.5");
+		expect(parseBarsBeatsSixteenths("1:0:1")).toBe(
+			TICKS_PER_BAR + TICKS_PER_SIXTEENTH,
+		);
+		expect(() => parseBarsBeatsSixteenths("1:0")).toThrow(
+			/bars:beats:sixteenths/,
+		);
+		expect(() => parseBarsBeatsSixteenths("a:b:c")).toThrow(
+			/Invalid musical position/,
+		);
+	});
+
+	it("round trips any tick position through bars/beats/16ths", () => {
+		fc.assert(
+			fc.property(fc.integer({ min: 0, max: 500_000 }), (ticks) => {
+				const position = ticksToBarsBeatsSixteenths(ticks);
+				expect(barsBeatsSixteenthsToTicks(position)).toBe(ticks);
+			}),
+		);
+	});
+
+	it("round trips any tick position through seconds at any supported tempo", () => {
+		fc.assert(
+			fc.property(
+				fc.integer({ min: 0, max: 500_000 }),
+				fc.integer({ min: 20, max: 300 }),
+				(ticks, bpm) => {
+					expect(secondsToTicks(ticksToSeconds(ticks, bpm), bpm)).toBe(ticks);
+				},
+			),
+		);
+	});
+});

--- a/src/domain/time.ts
+++ b/src/domain/time.ts
@@ -1,0 +1,171 @@
+import { z } from "zod";
+
+/**
+ * Musical time (PRD section 9.5 invariant 2).
+ *
+ * Persistent musical time is always an integer tick count at 192 PPQ — the
+ * same resolution Tone.js's transport uses, so scheduling needs no conversion.
+ * Seconds, pixels, and bars/beats/16ths are derived views computed here and
+ * never stored.
+ */
+
+/** Pulses per quarter note. Changing this after schema v1 is a migration. */
+export const PPQ = 192;
+
+export const TICKS_PER_QUARTER = PPQ;
+export const TICKS_PER_EIGHTH = PPQ / 2;
+export const TICKS_PER_SIXTEENTH = PPQ / 4;
+export const TICKS_PER_EIGHTH_TRIPLET = PPQ / 3;
+
+/** The alpha time signature is fixed at 4/4 (PRD section 9.4). */
+export const BEATS_PER_BAR = 4;
+export const TICKS_PER_BAR = TICKS_PER_QUARTER * BEATS_PER_BAR;
+export const SIXTEENTHS_PER_BEAT = TICKS_PER_QUARTER / TICKS_PER_SIXTEENTH;
+
+/** A non-negative integer tick position or length. */
+export const tickSchema = z.int().min(0).brand<"ticks">();
+export type Ticks = z.infer<typeof tickSchema>;
+
+/** A strictly positive integer tick length (durations are never zero). */
+export const durationTickSchema = z.int().min(1).brand<"ticks">();
+
+/** Is `value` a valid tick count: an integer, finite, and non-negative? */
+export function isTicks(value: unknown): value is Ticks {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+/** Narrows a number to `Ticks`, throwing on floating-point musical time. */
+export function toTicks(value: number): Ticks {
+	if (!isTicks(value)) {
+		throw new TypeError(
+			`Musical time must be a non-negative safe integer of ticks, received ${value}`,
+		);
+	}
+	return value;
+}
+
+/** Rounds an arbitrary tick-valued number to the nearest storable tick. */
+export function roundToTicks(value: number): Ticks {
+	if (!Number.isFinite(value)) {
+		throw new TypeError(`Cannot round non-finite musical time: ${value}`);
+	}
+	return toTicks(Math.max(0, Math.round(value)));
+}
+
+export function beatsToTicks(beats: number): Ticks {
+	return roundToTicks(beats * TICKS_PER_QUARTER);
+}
+
+export function ticksToBeats(ticks: number): number {
+	return ticks / TICKS_PER_QUARTER;
+}
+
+export function barsToTicks(bars: number): Ticks {
+	return roundToTicks(bars * TICKS_PER_BAR);
+}
+
+export function ticksToBars(ticks: number): number {
+	return ticks / TICKS_PER_BAR;
+}
+
+export function sixteenthsToTicks(sixteenths: number): Ticks {
+	return roundToTicks(sixteenths * TICKS_PER_SIXTEENTH);
+}
+
+export function ticksToSixteenths(ticks: number): number {
+	return ticks / TICKS_PER_SIXTEENTH;
+}
+
+/** Seconds are a derived view: they depend on tempo and are never stored. */
+export function ticksToSeconds(ticks: number, bpm: number): number {
+	assertTempo(bpm);
+	return (ticks / TICKS_PER_QUARTER) * (60 / bpm);
+}
+
+export function secondsToTicks(seconds: number, bpm: number): Ticks {
+	assertTempo(bpm);
+	return roundToTicks((seconds * bpm * TICKS_PER_QUARTER) / 60);
+}
+
+export function minutesToTicks(minutes: number, bpm: number): Ticks {
+	return secondsToTicks(minutes * 60, bpm);
+}
+
+function assertTempo(bpm: number): void {
+	if (!Number.isFinite(bpm) || bpm <= 0) {
+		throw new TypeError(
+			`Tempo must be a positive finite number, received ${bpm}`,
+		);
+	}
+}
+
+/**
+ * Zero-based bars/beats/16ths, matching Tone.js's `bars:beats:sixteenths`
+ * notation, plus any ticks left over inside the 16th.
+ */
+export interface BarsBeatsSixteenths {
+	bars: number;
+	beats: number;
+	sixteenths: number;
+	ticks: number;
+}
+
+export function ticksToBarsBeatsSixteenths(ticks: number): BarsBeatsSixteenths {
+	const total = toTicks(ticks);
+	const bars = Math.floor(total / TICKS_PER_BAR);
+	const withinBar = total - bars * TICKS_PER_BAR;
+	const beats = Math.floor(withinBar / TICKS_PER_QUARTER);
+	const withinBeat = withinBar - beats * TICKS_PER_QUARTER;
+	const sixteenths = Math.floor(withinBeat / TICKS_PER_SIXTEENTH);
+	return {
+		bars,
+		beats,
+		sixteenths,
+		ticks: withinBeat - sixteenths * TICKS_PER_SIXTEENTH,
+	};
+}
+
+export function barsBeatsSixteenthsToTicks(
+	position: Partial<BarsBeatsSixteenths>,
+): Ticks {
+	const { bars = 0, beats = 0, sixteenths = 0, ticks = 0 } = position;
+	return roundToTicks(
+		bars * TICKS_PER_BAR +
+			beats * TICKS_PER_QUARTER +
+			sixteenths * TICKS_PER_SIXTEENTH +
+			ticks,
+	);
+}
+
+/** Formats ticks as Tone.js-style `bars:beats:sixteenths`. */
+export function formatBarsBeatsSixteenths(ticks: number): string {
+	const position = ticksToBarsBeatsSixteenths(ticks);
+	const sixteenths = position.sixteenths + position.ticks / TICKS_PER_SIXTEENTH;
+	return `${position.bars}:${position.beats}:${trimNumber(sixteenths)}`;
+}
+
+/** Parses Tone.js-style `bars:beats:sixteenths` back into ticks. */
+export function parseBarsBeatsSixteenths(value: string): Ticks {
+	const parts = value.split(":");
+	if (parts.length !== 3) {
+		throw new TypeError(
+			`Expected "bars:beats:sixteenths", received "${value}"`,
+		);
+	}
+	const [bars, beats, sixteenths] = parts.map((part) => {
+		const parsed = Number(part);
+		if (!Number.isFinite(parsed) || parsed < 0) {
+			throw new TypeError(`Invalid musical position "${value}"`);
+		}
+		return parsed;
+	});
+	return roundToTicks(
+		bars * TICKS_PER_BAR +
+			beats * TICKS_PER_QUARTER +
+			sixteenths * TICKS_PER_SIXTEENTH,
+	);
+}
+
+function trimNumber(value: number): string {
+	return Number.isInteger(value) ? `${value}` : `${Number(value.toFixed(6))}`;
+}

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -1,5 +1,16 @@
 import type { Timestamp } from "firebase/firestore";
 
+/**
+ * Prototype project types — superseded by the canonical schema-v1 domain model
+ * in `src/domain`.
+ *
+ * These index-based types (a pattern's sequence index implies a track) are not
+ * schema v1 and are not persisted by it. They remain only because the current
+ * editor, player, and Firestore service still read them; the `FND-009` slice
+ * migrates those consumers onto `src/domain` and deletes this file. Do not add
+ * new fields or new consumers here.
+ */
+
 export type Note = string | null;
 
 export interface Envelope {


### PR DESCRIPTION
## Summary

Replaces the index-based prototype types with the authoritative code-first TypeScript and runtime-validation domain model for schema v1: project metadata, song, tracks, clips, placements, note events, devices, drum pads, automation lanes, sections, returns, and assets, under `src/domain/`.

This is the contract-owning task for the domain schema (backlog "Landing work" rule 4): it lands before `FND-003` (command/history kernel), `FND-004` (Firebase repository), `FND-005` (selection/projections), and `FND-007` (audio graph) start, and those tasks build on the types, factories, and invariants introduced here.

Delivered in `src/domain/`:

- `ids.ts` - branded, type-prefixed nanoid IDs (`trk_`, `clp_`, `evt_`, ...) from one shared factory, with a deterministic seeded variant for tests.
- `time.ts` - integer musical time at 192 PPQ with bar/beat/16th and seconds conversion helpers.
- `entities.ts` - the core entity types (Project, Song, Track, Device, Drum pad, Automation lane, Clip, Placement, Note event, Section, Asset, Revision).
- `parameters.ts` - the shared parameter-definition mechanism (range, unit, default, clamping, automation capability), scoped to only the parameters the `FND-009` vertical slice needs.
- `parse.ts` - runtime parsing/validation that rejects malformed, non-finite, dangling, cross-owner, and future-schema-version state without partial mutation.
- `serialize.ts` - deterministic schema-v1 serialization that round-trips through JSON-compatible values.
- `factories.ts` / `fixtures.ts` - factories for independent valid blank and fixture projects, with no Firebase types in the domain layer.
- Test suites (`*.test.ts`) plus `project.property.test.ts` for property-oriented invariant coverage, including projects at the ten-minute duration bound, and `boundaries.test.ts` asserting the domain has no Firebase dependency.

## PRD requirements (`docs/backlog.md` FND-002)

- [PRJ-04 - Versioned data](../docs/prd.md) - every stored project declares a schema version and can be migrated forward; schema v1 is the first production schema.
- [PRD 9.4 - Core domain entities](../docs/prd.md) - the required conceptual boundaries and the section 9.4 prefixed-ID format (`trk_`, `clp_`, `plc_`, `evt_`, `dev_`, `pad_`, `aut_`, `sec_`, `ret_`, `ast_`, `rev_`).
- [PRD 9.5 - Domain invariants](../docs/prd.md) - stable IDs never array positions, integer ticks at 192 PPQ, clip content separate from placement, shared validation/clamping, structural commands leave the project valid or make no change, audio objects never in project state, valid placement/automation references, ordered serial insert chains.
- Phase 0 exit criteria (`docs/prd.md` section 12) - schema-v1 code passes unit, round-trip, and repository-adjacent tests as part of the foundation slice.

## Acceptance checkboxes met (from `docs/backlog.md` FND-002)

- [x] Branded IDs use the PRD section 9.4 prefixed nanoid format (`trk_`, `clp_`, `evt_`, ...), produced by one shared factory with a deterministic seeded variant for tests. (`src/domain/ids.ts`, `src/domain/ids.test.ts`)
- [x] Musical time is integer ticks at 192 PPQ, with conversion helpers for bars/beats/16ths and seconds, and no floating-point musical time in persistent state. (`src/domain/time.ts`, `src/domain/time.test.ts`)
- [x] The parameter-definition mechanism is implemented - range, unit, default, clamping policy, and automation capability declared once and read by UI, command validation, audio, and assistant tools. Only the parameters the `FND-009` slice needs are defined; per-device instrument and effect values are left to Phase 1. (`src/domain/parameters.ts`, `src/domain/parameters.test.ts`)
- [x] Parsing rejects malformed, non-finite, dangling, cross-owner, and future-version state without partial mutation. (`src/domain/parse.ts`, `src/domain/parse.test.ts`)
- [x] Deterministic schema-v1 serialization round trips through JSON-compatible values. (`src/domain/serialize.ts`, `src/domain/serialize.test.ts`)
- [x] Factories produce independent valid blank and fixture projects without Firebase types leaking into the domain. (`src/domain/factories.ts`, `src/domain/fixtures.ts`, `src/domain/boundaries.test.ts`)
- [x] Unit and property-oriented tests cover every invariant in PRD section 9.5 and projects at ten-minute bounds. (`src/domain/project.property.test.ts`, plus targeted cases across the other `*.test.ts` files)

## Review

This branch went through an Opus review round in the implementation workflow (`.claude/agents/solid-groove-reviewer.md`), which adversarially checked the acceptance criteria, invariant coverage, and resource/contract boundaries against the code rather than the implementer's summary. Round-one findings on `parseClip` alignment with the clip aggregate and gaps in invariant test coverage were addressed in a follow-up commit (`FND-002: align parseClip with the aggregate and cover untested invariants`) before this branch was sent for a second review pass.

## Test plan

- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] `bun run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy2J3mWcuxuoqvPtNfP8SQ)_