### PR TITLE
Resolve Phase 0 ambiguities blocking autonomous implementation

### DIFF
--- a/.claude/agents/solid-groove-implementer.md
+++ b/.claude/agents/solid-groove-implementer.md
@@ -1,0 +1,43 @@
+---
+name: solid-groove-implementer
+description: Implements one Solid Groove backlog task end to end — product code, tests, fixtures and docs — against the PRD acceptance criteria. Use for any FND/LOOP/ARR/EXP task from docs/backlog.md.
+model: sonnet
+---
+
+You implement exactly one task from `docs/backlog.md`. You will be told which.
+
+## Sources of truth
+
+- `docs/prd.md` is authoritative for product behavior and acceptance criteria. Your task block links the specific requirements it must satisfy.
+- `docs/backlog.md` is authoritative for scope, dependencies and the task's acceptance checkboxes.
+- `CLAUDE.md` is authoritative for stack conventions, SolidJS patterns and commands.
+- The design mocks in `docs/design` are authoritative for visual language. Screens without a mock are extrapolated from the documented design DNA — do not invent a second visual language.
+
+Read your task's linked PRD sections before writing code. Do not widen scope beyond the task: a discovery that belongs to another task is reported in your result, not implemented.
+
+## Hard rules
+
+- **Never alter a published contract as incidental work.** The domain schema, command registry, parameter definitions, persistence layout, selection model, audio projection and rendering projection are contracts. If your task genuinely cannot be completed without changing one, stop and report it as a blocker rather than changing it.
+- **No prototype compatibility.** Schema v1 is the first production schema. Prototype documents and types may be discarded.
+- **Never commit `package-lock.json`.** This project uses Bun. Use `bun install`.
+- Domain mutations go through validated commands. No component mutates stored project state directly.
+- Tests fail before the implementation and pass after, at the lowest useful layer.
+
+## Definition of done
+
+Before you report success, all of these must hold:
+
+- Every acceptance checkbox in your task block is genuinely satisfied, including the failure and empty states relevant to the slice.
+- `bun run typecheck`, `bun run test` and `bun run check` pass. Tasks touching browser, Firebase, audio, performance or export behavior also run their task-specific suites.
+- Audio resources and reactive subscriptions are disposed; accessibility and persistence effects are considered and tested where applicable.
+- No unrelated formatting, dependency, generated-file or refactor churn is in the diff.
+
+## Working method
+
+1. Create a branch named `claude/<task-id-lowercase>` off the base branch you are given.
+2. Implement the task, with tests, fixtures and any documentation the task requires.
+3. Run the full check suite and fix what it surfaces.
+4. Commit and push the branch.
+5. Report: the branch name, a summary of the approach, the commands you ran with their real results, which acceptance checkboxes you consider met, and anything you could not complete.
+
+Report outcomes faithfully. If a test fails or a checkbox is unmet, say so plainly with the output — a reviewer will check, and an inflated report costs more than an honest one.

--- a/.claude/agents/solid-groove-reviewer.md
+++ b/.claude/agents/solid-groove-reviewer.md
@@ -1,0 +1,30 @@
+---
+name: solid-groove-reviewer
+description: Adversarially reviews one Solid Groove task branch against its PRD acceptance criteria and backlog checkboxes before a PR is opened. Returns a blocking/non-blocking verdict.
+model: opus
+---
+
+You review one implementation branch against the task it claims to complete. You did not write it, and your job is not to be agreeable.
+
+## What you are checking
+
+1. **Does it actually satisfy the acceptance criteria?** Read the task block in `docs/backlog.md` and every PRD requirement it links. Check each checkbox against the code, not against the implementer's summary. An implementer's claim that a box is met is a hypothesis to verify.
+2. **Are the tests real?** A test that would pass with the implementation deleted or stubbed is not coverage. Check that failure paths, empty states and boundaries are tested, not just the happy path.
+3. **Did it violate a contract?** The domain schema, command registry, parameter definitions, persistence layout, selection model, audio projection and rendering projection are contracts owned by specific tasks. A task that quietly widened one is a blocking finding even if the code is good.
+4. **The Solid Groove invariants.** PRD section 9.5 — stable prefixed IDs never array positions, integer ticks at 192 PPQ, clip content separate from placement, shared validation and clamping, structural commands leave the project valid or make no change, audio objects never in project state.
+5. **Resource lifecycle.** Audio nodes, schedules, subscriptions, timers and pending loads have owners and idempotent disposal. This project's largest architectural risk is leaked contexts and Tone objects.
+6. **Scope.** Unrelated refactors, dependency changes, generated-file churn or a `package-lock.json` are findings.
+
+## How to review
+
+Fetch the branch and read the actual diff. Run the test suite yourself — do not take reported results on trust. Where a claim is checkable in seconds, check it.
+
+Weigh findings by consequence. A wrong PPQ constant or an index used as identity is blocking because every dependent task inherits it. A slightly awkward variable name is not a finding at all — do not pad the review.
+
+Before you call something blocking, construct the concrete failure: the input or state, and the wrong output, crash or corruption that follows. If you cannot, it is a note, not a blocker.
+
+## Verdict
+
+Approve when the task's criteria are met and nothing blocking remains. Approving work that does not meet its criteria is the expensive failure here — a foundation defect surfaces at the integration gate, after several dependent tasks have built on it. Blocking correct work is merely slow.
+
+For each blocking finding give: file and line, what is wrong, the concrete failure it causes, and what would resolve it. Be specific enough that a fix agent can act without re-deriving your reasoning.

--- a/.claude/workflows/solid-groove-phase-0.js
+++ b/.claude/workflows/solid-groove-phase-0.js
@@ -1,0 +1,237 @@
+export const meta = {
+  name: 'solid-groove-phase-0',
+  description:
+    'Implement Solid Groove Phase 0 (FND-001..009) — Sonnet implements, Opus reviews every branch before its PR opens',
+  whenToUse:
+    'Run to execute Phase 0 of docs/backlog.md. Pass args to run a subset, e.g. args: ["FND-001","FND-002"].',
+  phases: [
+    { title: 'Tooling', detail: 'FND-001 — test, CI and emulator foundation' },
+    { title: 'Contracts', detail: 'FND-002 domain schema, then command kernel, repository and projections', model: 'opus' },
+    { title: 'Runtime', detail: 'FND-006 AudioRuntime and FND-008 renderer harness' },
+    { title: 'Graph', detail: 'FND-007 stable ID-keyed audio graph' },
+    { title: 'Slice', detail: 'FND-009 vertical slice gate' },
+  ],
+}
+
+// Model policy, per the decision recorded in docs/prd.md section 16:
+// contract-owning tasks run on Opus because an error there propagates into every
+// dependent task and surfaces late; everything else runs on Sonnet. Review is
+// always Opus, at high effort, and runs before any PR is opened.
+const CONTRACT_TASKS = ['FND-002', 'FND-003', 'FND-004']
+const BASE_BRANCH = 'claude/dynamic-workflow-clarity-tvo8hv'
+const MAX_REVIEW_ROUNDS = 2
+
+const TASKS = [
+  { id: 'FND-001', phase: 'Tooling', title: 'Test and development foundation' },
+  { id: 'FND-002', phase: 'Contracts', title: 'Canonical schema-v1 domain model' },
+  { id: 'FND-003', phase: 'Contracts', title: 'Command, transaction, and history kernel' },
+  { id: 'FND-004', phase: 'Contracts', title: 'Firebase schema-v1 repository' },
+  { id: 'FND-005', phase: 'Contracts', title: 'Selection and consumer projections' },
+  { id: 'FND-006', phase: 'Runtime', title: 'Single-context AudioRuntime and diagnostics' },
+  { id: 'FND-007', phase: 'Graph', title: 'Stable ID-keyed audio graph' },
+  { id: 'FND-008', phase: 'Runtime', title: 'Arrangement renderer spike and measurement harness' },
+  { id: 'FND-009', phase: 'Slice', title: 'Foundation vertical slice gate' },
+]
+
+const only = Array.isArray(args) && args.length ? new Set(args) : null
+const task = (id) => TASKS.find((t) => t.id === id)
+const wanted = (id) => !only || only.has(id)
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  required: ['branch', 'summary', 'checksRun', 'unmet'],
+  properties: {
+    branch: { type: 'string', description: 'Branch the work was pushed to' },
+    summary: { type: 'string', description: 'What was implemented and how' },
+    checksRun: {
+      type: 'array',
+      description: 'Commands actually run, with their real outcome',
+      items: {
+        type: 'object',
+        required: ['command', 'passed'],
+        properties: {
+          command: { type: 'string' },
+          passed: { type: 'boolean' },
+          detail: { type: 'string' },
+        },
+      },
+    },
+    unmet: {
+      type: 'array',
+      description: 'Acceptance checkboxes NOT satisfied, with the reason. Empty if all met.',
+      items: { type: 'string' },
+    },
+    outOfScope: {
+      type: 'array',
+      description: 'Discoveries belonging to another task, not implemented here',
+      items: { type: 'string' },
+    },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['approved', 'blocking'],
+  properties: {
+    approved: { type: 'boolean' },
+    blocking: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['file', 'issue', 'failure', 'resolution'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'number' },
+          issue: { type: 'string' },
+          failure: { type: 'string', description: 'Concrete input/state to wrong output or corruption' },
+          resolution: { type: 'string' },
+        },
+      },
+    },
+    notes: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const implPrompt = (t, base) => `Implement backlog task ${t.id} - ${t.title}.
+
+Read its task block in docs/backlog.md and every PRD requirement the block links, then implement it in full: product code, tests, fixtures and any documentation the task requires.
+
+Branch from ${base} and name your branch claude/${t.id.toLowerCase()}. Commit and push it. Do not open a pull request — a reviewer runs before the PR is opened.
+
+Report the branch name, what you did, the commands you ran with their real results, and any acceptance checkbox you could not satisfy.`
+
+const reviewPrompt = (t, impl, round) => `Review branch ${impl.branch} against backlog task ${t.id} - ${t.title}.${
+  round > 1 ? `\n\nThis is review round ${round}; a previous round returned blocking findings that the implementer has since addressed. Verify the fixes rather than assuming them.` : ''
+}
+
+Fetch the branch and read the actual diff against ${BASE_BRANCH}. Run the test suite yourself.
+
+The implementer reported:
+${impl.summary}
+
+Commands it claims to have run: ${impl.checksRun.map((c) => `${c.command} -> ${c.passed ? 'pass' : 'FAIL'}`).join('; ') || 'none reported'}
+Checkboxes it reports unmet: ${impl.unmet.length ? impl.unmet.join('; ') : 'none'}
+
+Treat all of that as claims to verify, not findings to accept.`
+
+const fixPrompt = (t, impl, review) => `Address blocking review findings on branch ${impl.branch} for backlog task ${t.id} - ${t.title}.
+
+Check the branch out, fix every finding below, re-run the full check suite, and push to the same branch. Do not rewrite unrelated code and do not widen scope.
+
+${review.blocking
+  .map((b, i) => `${i + 1}. ${b.file}${b.line ? `:${b.line}` : ''} — ${b.issue}\n   Failure: ${b.failure}\n   Suggested resolution: ${b.resolution}`)
+  .join('\n\n')}
+
+Report the same structured result as the original implementation, describing the branch as it now stands.`
+
+const prPrompt = (t, impl) => `Open a pull request for branch ${impl.branch} into ${BASE_BRANCH}.
+
+Check the repository for a PR template and mirror its structure if one exists. Title it "${t.id} - ${t.title}". In the body, describe the change, link the task's PRD requirements, list the acceptance checkboxes met, and state that the branch passed an Opus review round in the implementation workflow.
+
+Return the pull request URL.`
+
+// One task: implement (Sonnet, or Opus for contracts) -> review (Opus) -> fix ->
+// re-review, then open the PR. Each stage runs in its own worktree; the branch is
+// how state travels between them, which is why every stage pushes.
+async function runTask(t) {
+  const model = CONTRACT_TASKS.includes(t.id) ? 'opus' : 'sonnet'
+
+  let impl = await agent(implPrompt(t, BASE_BRANCH), {
+    model,
+    agentType: 'solid-groove-implementer',
+    label: `impl:${t.id}`,
+    phase: t.phase,
+    isolation: 'worktree',
+    schema: IMPL_SCHEMA,
+  })
+  if (!impl) return { id: t.id, status: 'failed', reason: 'implementer returned nothing' }
+
+  let review = null
+  for (let round = 1; round <= MAX_REVIEW_ROUNDS; round++) {
+    review = await agent(reviewPrompt(t, impl, round), {
+      model: 'opus',
+      effort: 'high',
+      agentType: 'solid-groove-reviewer',
+      label: `review:${t.id}#${round}`,
+      phase: t.phase,
+      isolation: 'worktree',
+      schema: REVIEW_SCHEMA,
+    })
+    if (!review) return { id: t.id, status: 'failed', reason: 'reviewer returned nothing', branch: impl.branch }
+    if (review.approved) break
+
+    log(`${t.id}: review round ${round} returned ${review.blocking.length} blocking finding(s)`)
+    if (round === MAX_REVIEW_ROUNDS) break
+
+    const fixed = await agent(fixPrompt(t, impl, review), {
+      model,
+      agentType: 'solid-groove-implementer',
+      label: `fix:${t.id}#${round}`,
+      phase: t.phase,
+      isolation: 'worktree',
+      schema: IMPL_SCHEMA,
+    })
+    if (fixed) impl = fixed
+  }
+
+  if (!review.approved) {
+    log(`${t.id}: NOT approved after ${MAX_REVIEW_ROUNDS} rounds — branch ${impl.branch} left open, no PR`)
+    return { id: t.id, status: 'blocked', branch: impl.branch, blocking: review.blocking, unmet: impl.unmet }
+  }
+
+  const pr = await agent(prPrompt(t, impl), { model: 'sonnet', label: `pr:${t.id}`, phase: t.phase })
+  return { id: t.id, status: 'approved', branch: impl.branch, pr, notes: review.notes ?? [], outOfScope: impl.outOfScope ?? [] }
+}
+
+const results = []
+const record = (r) => { if (r) results.push(r) }
+const landed = (id) => results.some((r) => r.id === id && r.status === 'approved')
+
+// Gate G0. Everything else depends on the tooling existing.
+phase('Tooling')
+if (wanted('FND-001')) {
+  record(await runTask(task('FND-001')))
+  if (!landed('FND-001')) {
+    log('FND-001 did not land — stopping. Every Phase 0 task depends on it.')
+    return { results, stoppedAt: 'FND-001' }
+  }
+}
+
+// FND-002 owns the domain contract and must land before its dependents start.
+// FND-006 and FND-008 own separate boundaries and run alongside it.
+phase('Contracts')
+const contractRound = await parallel([
+  () => (wanted('FND-002') ? runTask(task('FND-002')) : null),
+  () => (wanted('FND-006') ? runTask(task('FND-006')) : null),
+  () => (wanted('FND-008') ? runTask(task('FND-008')) : null),
+])
+for (const r of contractRound) record(r)
+
+if (wanted('FND-002') && !landed('FND-002')) {
+  log('FND-002 did not land — stopping before dependent contract work.')
+  return { results, stoppedAt: 'FND-002' }
+}
+
+// Dependents of the domain schema, concurrent with each other.
+const dependents = await parallel([
+  () => (wanted('FND-003') ? runTask(task('FND-003')) : null),
+  () => (wanted('FND-004') ? runTask(task('FND-004')) : null),
+  () => (wanted('FND-005') ? runTask(task('FND-005')) : null),
+])
+for (const r of dependents) record(r)
+
+phase('Graph')
+if (wanted('FND-007')) record(await runTask(task('FND-007')))
+
+// Gate G2. The slice proves the boundaries together, so it runs last and alone.
+phase('Slice')
+if (wanted('FND-009')) record(await runTask(task('FND-009')))
+
+const approved = results.filter((r) => r.status === 'approved')
+log(`Phase 0: ${approved.length}/${results.length} tasks approved and raised as PRs`)
+
+return {
+  results,
+  approved: approved.map((r) => `${r.id} ${r.pr ?? r.branch}`),
+  blocked: results.filter((r) => r.status !== 'approved').map((r) => `${r.id} (${r.status})`),
+}

--- a/.claude/workflows/solid-groove-phase-0.js
+++ b/.claude/workflows/solid-groove-phase-0.js
@@ -21,6 +21,13 @@ const CONTRACT_TASKS = ['FND-002', 'FND-003', 'FND-004']
 const BASE_BRANCH = 'claude/dynamic-workflow-clarity-tvo8hv'
 const MAX_REVIEW_ROUNDS = 2
 
+// The agent registry is read once at session start, so `agentType` cannot resolve
+// a definition added during the same session. Each agent reads its own definition
+// from the repo instead — one source of truth, and it works on a cold session.
+const IMPLEMENTER = '.claude/agents/solid-groove-implementer.md'
+const REVIEWER = '.claude/agents/solid-groove-reviewer.md'
+const brief = (path) => `Read \`${path}\` and follow it as your operating instructions for this task.\n\n`
+
 const TASKS = [
   { id: 'FND-001', phase: 'Tooling', title: 'Test and development foundation' },
   { id: 'FND-002', phase: 'Contracts', title: 'Canonical schema-v1 domain model' },
@@ -92,7 +99,7 @@ const REVIEW_SCHEMA = {
   },
 }
 
-const implPrompt = (t, base) => `Implement backlog task ${t.id} - ${t.title}.
+const implPrompt = (t, base) => `${brief(IMPLEMENTER)}Implement backlog task ${t.id} - ${t.title}.
 
 Read its task block in docs/backlog.md and every PRD requirement the block links, then implement it in full: product code, tests, fixtures and any documentation the task requires.
 
@@ -100,7 +107,7 @@ Branch from ${base} and name your branch claude/${t.id.toLowerCase()}. Commit an
 
 Report the branch name, what you did, the commands you ran with their real results, and any acceptance checkbox you could not satisfy.`
 
-const reviewPrompt = (t, impl, round) => `Review branch ${impl.branch} against backlog task ${t.id} - ${t.title}.${
+const reviewPrompt = (t, impl, round) => `${brief(REVIEWER)}Review branch ${impl.branch} against backlog task ${t.id} - ${t.title}.${
   round > 1 ? `\n\nThis is review round ${round}; a previous round returned blocking findings that the implementer has since addressed. Verify the fixes rather than assuming them.` : ''
 }
 
@@ -114,7 +121,7 @@ Checkboxes it reports unmet: ${impl.unmet.length ? impl.unmet.join('; ') : 'none
 
 Treat all of that as claims to verify, not findings to accept.`
 
-const fixPrompt = (t, impl, review) => `Address blocking review findings on branch ${impl.branch} for backlog task ${t.id} - ${t.title}.
+const fixPrompt = (t, impl, review) => `${brief(IMPLEMENTER)}Address blocking review findings on branch ${impl.branch} for backlog task ${t.id} - ${t.title}.
 
 Check the branch out, fix every finding below, re-run the full check suite, and push to the same branch. Do not rewrite unrelated code and do not widen scope.
 
@@ -138,7 +145,6 @@ async function runTask(t) {
 
   let impl = await agent(implPrompt(t, BASE_BRANCH), {
     model,
-    agentType: 'solid-groove-implementer',
     label: `impl:${t.id}`,
     phase: t.phase,
     isolation: 'worktree',
@@ -151,7 +157,6 @@ async function runTask(t) {
     review = await agent(reviewPrompt(t, impl, round), {
       model: 'opus',
       effort: 'high',
-      agentType: 'solid-groove-reviewer',
       label: `review:${t.id}#${round}`,
       phase: t.phase,
       isolation: 'worktree',
@@ -165,7 +170,6 @@ async function runTask(t) {
 
     const fixed = await agent(fixPrompt(t, impl, review), {
       model,
-      agentType: 'solid-groove-implementer',
       label: `fix:${t.id}#${round}`,
       phase: t.phase,
       isolation: 'worktree',

--- a/.claude/workflows/solid-groove-phase-0.js
+++ b/.claude/workflows/solid-groove-phase-0.js
@@ -61,6 +61,26 @@ const TASKS = [
   { id: 'FND-009', phase: 'Slice', title: 'Foundation vertical slice gate' },
 ]
 
+// Fail loud on a malformed subset request. `args` passed as a JSON-encoded
+// string ('["FND-001"]') rather than a real array is not an array, so the old
+// `Array.isArray(args) ? ... : null` silently degraded "run one task" into
+// "run the entire phase" — which is exactly what happened once, opening PRs
+// for six tasks that were never asked for. A bad filter must stop the run.
+if (args !== undefined && args !== null && !Array.isArray(args)) {
+  throw new Error(
+    `args must be an array of task ids, got ${typeof args}: ${JSON.stringify(args)}. ` +
+      'Pass a real JSON array (args: ["FND-001"]), not a JSON-encoded string — ' +
+      'a stringified list reaches the script as one string and would run every task.',
+  )
+}
+const known = new Set(TASKS.map((t) => t.id))
+const unknown = (args ?? []).filter((id) => !known.has(id))
+if (unknown.length) {
+  throw new Error(
+    `args contains unknown task id(s): ${unknown.join(', ')}. Known ids: ${[...known].join(', ')}.`,
+  )
+}
+
 const only = Array.isArray(args) && args.length ? new Set(args) : null
 const task = (id) => TASKS.find((t) => t.id === id)
 const wanted = (id) => !only || only.has(id)

--- a/.claude/workflows/solid-groove-phase-0.js
+++ b/.claude/workflows/solid-groove-phase-0.js
@@ -28,6 +28,27 @@ const IMPLEMENTER = '.claude/agents/solid-groove-implementer.md'
 const REVIEWER = '.claude/agents/solid-groove-reviewer.md'
 const brief = (path) => `Read \`${path}\` and follow it as your operating instructions for this task.\n\n`
 
+// Worktree ground rules. Two traps, both of which have already bitten a run:
+// a worktree starts at the commit that was HEAD when the session began, not at
+// the base branch tip; and git refuses to check out a branch that is already
+// checked out in the main worktree, so `git checkout ${BASE_BRANCH}` always
+// fails here. Branch from the remote ref instead. Absolute /home/user/solid-groove
+// paths resolve to the main repo, not to the worktree, so they read stale-free
+// files while git operates somewhere else entirely — always work from your own root.
+const WORKTREE = `## Your worktree
+
+You are in a git worktree, not the main checkout. Two things follow:
+
+- \`cd "$(git rev-parse --show-toplevel)"\` first, and use paths relative to that root. An absolute \`/home/user/solid-groove/...\` path points at a different checkout and will silently mislead you.
+- Your worktree starts at an older commit, and \`${BASE_BRANCH}\` cannot be checked out here because the main worktree holds it. Always branch from the remote ref:
+  \`\`\`
+  git fetch origin ${BASE_BRANCH}
+  git checkout -b <branch> origin/${BASE_BRANCH}
+  \`\`\`
+  Confirm before you start work: \`git merge-base --is-ancestor origin/${BASE_BRANCH} HEAD\` must succeed. Never pipe a git command through \`tail\` or \`head\` in an \`&&\` chain — it hides the exit code and a failed checkout looks like a success.
+
+`
+
 const TASKS = [
   { id: 'FND-001', phase: 'Tooling', title: 'Test and development foundation' },
   { id: 'FND-002', phase: 'Contracts', title: 'Canonical schema-v1 domain model' },
@@ -103,7 +124,7 @@ const implPrompt = (t, base) => `${brief(IMPLEMENTER)}Implement backlog task ${t
 
 Read its task block in docs/backlog.md and every PRD requirement the block links, then implement it in full: product code, tests, fixtures and any documentation the task requires.
 
-Branch from ${base} and name your branch claude/${t.id.toLowerCase()}. Commit and push it. Do not open a pull request — a reviewer runs before the PR is opened.
+${WORKTREE}Name your branch claude/${t.id.toLowerCase()} and create it from origin/${base} as described above. Commit and push it with \`git push -u origin claude/${t.id.toLowerCase()}\`. Do not open a pull request — a reviewer runs before the PR is opened.
 
 Report the branch name, what you did, the commands you ran with their real results, and any acceptance checkbox you could not satisfy.`
 
@@ -111,7 +132,7 @@ const reviewPrompt = (t, impl, round) => `${brief(REVIEWER)}Review branch ${impl
   round > 1 ? `\n\nThis is review round ${round}; a previous round returned blocking findings that the implementer has since addressed. Verify the fixes rather than assuming them.` : ''
 }
 
-Fetch the branch and read the actual diff against ${BASE_BRANCH}. Run the test suite yourself.
+${WORKTREE}Fetch and check out the branch under review with \`git fetch origin ${impl.branch} && git checkout -b review-${t.id.toLowerCase()} origin/${impl.branch}\`, then read the actual diff against origin/${BASE_BRANCH}. Run the test suite yourself.
 
 The implementer reported:
 ${impl.summary}
@@ -123,7 +144,7 @@ Treat all of that as claims to verify, not findings to accept.`
 
 const fixPrompt = (t, impl, review) => `${brief(IMPLEMENTER)}Address blocking review findings on branch ${impl.branch} for backlog task ${t.id} - ${t.title}.
 
-Check the branch out, fix every finding below, re-run the full check suite, and push to the same branch. Do not rewrite unrelated code and do not widen scope.
+${WORKTREE}Check the branch out with \`git fetch origin ${impl.branch} && git checkout -b ${impl.branch} origin/${impl.branch}\`, fix every finding below, re-run the full check suite, and push to the same branch. Do not rewrite unrelated code and do not widen scope.
 
 ${review.blocking
   .map((b, i) => `${i + 1}. ${b.file}${b.line ? `:${b.line}` : ''} — ${b.issue}\n   Failure: ${b.failure}\n   Suggested resolution: ${b.resolution}`)

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,10 @@ package-lock.json
 .DS_Store
 
 # misc config
-.claude/
+# Shared agent and workflow definitions are checked in; local settings are not.
+.claude/*
+!.claude/agents/
+!.claude/workflows/
 
 # big fat blobs
 public/samples

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
 	"files": {
-		"includes": ["**", "!**/.claude", "!**/.output", "!**/.vinxi"]
+		"includes": ["**", "!.claude", "!.output", "!.vinxi"]
 	}
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -9,27 +9,36 @@
 
 ## 1. How agents use this backlog
 
-This file is the operational source of truth for implementation order and ownership. The PRD remains authoritative for product behavior and acceptance criteria. A task does not weaken or replace any linked PRD requirement.
+This file is the **specification and index** for implementation order: what each task covers, what it depends on, which PRD requirements it satisfies, and what "done" means for it. The PRD remains authoritative for product behavior and acceptance criteria. A task does not weaken or replace any linked PRD requirement.
 
-### Status values
+This file is **not** the live status board. Task blocks below are not edited to record progress.
 
-- `todo`: not claimed and dependencies may or may not be complete.
-- `in-progress`: owned by exactly one agent and actively being implemented.
-- `blocked`: work started but cannot continue; the task records the concrete blocker.
-- `review`: implementation is complete but requires contract, product, or integration review.
-- `done`: merged implementation and tests satisfy every task checkbox.
-- `parked`: intentionally outside the current release phase; do not claim.
+### Tracking: one GitHub issue per task
 
-### Claim and completion protocol
+Each task in this backlog has one GitHub issue in `afternoon/solid-groove`, titled with the task ID (for example `FND-002 - Canonical schema-v1 domain model`). The issue is the live record.
 
-1. Before changing product code, set the task's `Status` to `in-progress` and replace `unassigned` with the agent identifier. Coordinate that claim on the shared branch before doing substantial work; Git history records when ownership changed.
-2. Claim only one implementation task at a time. Do not claim a task until every dependency is `done` unless the task explicitly permits parallel discovery work.
-3. The owning agent is the only agent that edits its task block. Cross-task discoveries are recorded under `Notes` in the affected task or proposed as a new task instead of silently expanding scope.
-4. Keep changes vertical and mergeable. Product code, tests, fixtures, documentation, and the final backlog update belong in the same implementation commit or PR.
-5. To finish, check every acceptance box, set `Status` to `done`, and replace `Evidence: pending` with the relevant test commands and durable artifact paths. Git history is the completion record; do not put a commit hash into the commit itself.
-6. Use `blocked` only with a named unmet dependency or decision. Include what was tried and the smallest action needed to unblock it.
-7. An agent must not alter a published domain, command, persistence, selection, audio-projection, or rendering-projection contract as incidental feature work. Create or claim a contract-change task and update all contract tests and consumers together.
-8. Do not preserve compatibility with prototype project data. Schema v1 is the first production schema; migrations are required only for persisted changes after v1 is established.
+- **Status** is the issue's state and labels: open/closed, plus `blocked`, `needs-review`, or `parked` where they apply. `parked` tasks in section 9 get an issue only when the product owner unparks them.
+- **Ownership** is the issue assignee. An agent picking up a task assigns itself before changing product code.
+- **Progress, blockers, and discoveries** are issue comments. A blocker names the unmet dependency or decision, what was tried, and the smallest action that would unblock it. A cross-task discovery goes in a comment on the affected task's issue, or becomes a new issue — never a silent scope expansion.
+- **Evidence** — the test commands that were run and the paths to durable artifacts — goes in the closing comment and in the PR description.
+- The task's acceptance checkboxes are copied into the issue body when it is created, and are ticked there rather than in this file.
+
+Phase 0 task blocks have had their `Status`, `Owner`, and `Evidence` fields removed accordingly. The section 3 decision blocks, later-phase blocks, and parked blocks still carry them; those fields are historical, and once a phase is prepared for implementation its issues govern. `Dependencies` and `PRD` stay on every block — they are the work graph and the requirement trace, not status.
+
+This removes the write contention that made the old in-file claim protocol unworkable: parallel agents never edit a shared Markdown file to announce themselves, and the record survives a bad merge.
+
+### Landing work
+
+1. **One PR per task**, branched off the active feature branch, each agent working in its own git worktree so parallel implementations do not collide on the filesystem. A broken task never blocks review of an unrelated one.
+2. Keep the change vertical and self-contained: product code, tests, fixtures, and documentation for that task in one PR. The PR body links its issue and states the evidence.
+3. Do not claim a task until every dependency is closed, unless the task explicitly permits parallel discovery work.
+4. A **contract-owning task lands before its dependents start.** Domain schema, command registry, parameter definitions, persistence layout, selection, audio projection, and rendering projection are contracts; an agent must not alter a published one as incidental feature work. Changing a landed contract is its own issue, updating every contract test and consumer together.
+5. Git history is the completion record. Do not put a commit hash into the commit itself.
+6. Do not preserve compatibility with prototype project data. Schema v1 is the first production schema; migrations are required only for persisted changes after v1 is established.
+
+### Fanning out
+
+The `Dependencies:` line on every task is the machine-readable work graph. An orchestrator topologically sorts it, holds live in-flight state during a run, and opens or updates the GitHub issues; implementation agents receive a single task and never need to read another agent's state. The release gates in section 2 are the synchronization points — everything inside a gate may run concurrently, and nothing crosses a gate until it closes.
 
 ### Definition of done for every task
 
@@ -134,32 +143,32 @@ Decide the trusted-creator/source allowlist and how a creator or video enters it
 
 ### FND-001 - Test and development foundation
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: none`<br>
-`PRD: 9.1, 10, 14`<br>
-`Evidence: pending`
+`PRD: 9.1, 10, 14`
 
 Establish the shared tooling all later agents use: runtime schema validation, browser E2E tests, Firebase Emulator tests, deterministic IDs/time, and fixture builders. Prefer Zod for runtime schemas and Playwright for Chromium, Firefox, and WebKit unless a concrete incompatibility is documented before implementation.
 
+This task owns its own infrastructure. It creates `.github/workflows` for CI and adds the missing `emulators` block to `firebase.json`, whose current `database.rules.json` reference points at a file that does not exist and must be either supplied or removed.
+
 - [ ] Dependencies and Bun scripts are committed without introducing `package-lock.json`.
-- [ ] Unit, component, browser, and Firebase Emulator suites have isolated example tests and documented commands.
-- [ ] CI runs typecheck, non-mutating formatting/lint checks, unit tests, and the appropriate integration suites.
-- [ ] Test helpers provide deterministic clocks, IDs, Firebase setup/teardown, and browser-safe fixture loading.
+- [ ] A non-mutating `check:ci` script exists. The current `check` runs `biome check --write`, which cannot be used as a CI gate; `check` may keep its auto-fix behavior for local use.
+- [ ] Unit, component, browser, and Firebase Emulator suites have isolated example tests and documented commands. `firebase.json` gains a working emulator configuration and its dangling `database.rules.json` reference is resolved.
+- [ ] CI workflows run typecheck, `check:ci`, unit tests, and the appropriate integration suites on Chromium and Firefox as gating browsers, with WebKit run as a non-gating signal per the PRD supported-environment policy.
+- [ ] Test helpers provide deterministic clocks, deterministic prefixed IDs matching the PRD section 9.4 format, Firebase setup/teardown, and browser-safe fixture loading.
 - [ ] Existing tests still pass, and generated sample work is not needlessly repeated by every test command.
 
 ### FND-002 - Canonical schema-v1 domain model
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-001`<br>
-`PRD: PRJ-04; 9.4-9.5; Phase 0`<br>
-`Evidence: pending`
+`PRD: PRJ-04; 9.4-9.5; Phase 0`
 
 Replace index-based prototype types with the authoritative code-first TypeScript and runtime schemas for project metadata, song, tracks, clips, placements, events, devices, returns, automation, sections, and assets.
 
-- [ ] Stable branded IDs and integer musical time at a documented PPQ are used for persistent relationships.
-- [ ] Parameter definitions share ranges, defaults, units, clamping policy, and automation capability across consumers.
+This task owns the domain contract. It lands before `FND-003`, `FND-004`, `FND-005`, and `FND-007` start.
+
+- [ ] Branded IDs use the PRD section 9.4 prefixed nanoid format (`trk_`, `clp_`, `evt_`, …), produced by one shared factory with a deterministic seeded variant for tests.
+- [ ] Musical time is integer ticks at 192 PPQ, with conversion helpers for bars/beats/16ths and seconds, and no floating-point musical time in persistent state.
+- [ ] The parameter-definition mechanism is implemented — range, unit, default, clamping policy, and automation capability declared once and read by UI, command validation, audio, and assistant tools. Only the parameters the `FND-009` slice needs are defined; per-device instrument and effect values are authored in Phase 1 and must not be invented here.
 - [ ] Parsing rejects malformed, non-finite, dangling, cross-owner, and future-version state without partial mutation.
 - [ ] Deterministic schema-v1 serialization round trips through JSON-compatible values.
 - [ ] Factories produce independent valid blank and fixture projects without Firebase types leaking into the domain.
@@ -167,11 +176,8 @@ Replace index-based prototype types with the authoritative code-first TypeScript
 
 ### FND-003 - Command, transaction, and history kernel
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-002`<br>
-`PRD: CLP-04; 8 Undo and redo; 9.6`<br>
-`Evidence: pending`
+`PRD: CLP-04; 8 Undo and redo; 9.6`
 
 Implement one typed command registry used by pointer UI, shortcuts, and later AI actions, with validation, atomic transactions, summaries, undo, and redo.
 
@@ -183,16 +189,14 @@ Implement one typed command registry used by pointer UI, shortcuts, and later AI
 
 ### FND-004 - Firebase schema-v1 repository
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-002`<br>
-`PRD: PRJ-01, PRJ-02, PRJ-03, PRJ-04; 9.1, 9.9; Phase 0`<br>
-`Evidence: pending`
+`PRD: PRJ-01, PRJ-02, PRJ-03, PRJ-04; 9.1, 9.9; Phase 0`
 
-Implement the v1 Firestore document/chunk layout and repository boundary. Prototype `latestSnapshot` documents may be discarded and require no migration.
+Implement the PRD section 9.9 three-tier Firestore layout and the repository boundary: `projects/{projectId}` metadata, `projects/{projectId}/song/current`, and `projects/{projectId}/clips/{clipId}`. Prototype `latestSnapshot` documents may be discarded and require no migration.
 
-- [ ] The checked-in mapping documents collection paths, document shapes, ownership, schema version, revision, timestamps, and chunking boundaries in code.
-- [ ] Project metadata is queryable without loading full song state; no document can grow indefinitely toward the Firestore size limit.
+- [ ] The checked-in mapping documents collection paths, document shapes, ownership, schema version, revision, and timestamps in code, matching the section 9.9 tiers.
+- [ ] The song document has a documented size budget asserted against the 50-track ten-minute reference fixture, and the per-track `arrangement/{trackId}` chunk overflow path is implemented and tested rather than left as a described intention. This task owns the exact budget and chunk boundary.
+- [ ] Project metadata is queryable for the dashboard without loading song state or clip content; note edits write one clip document rather than rewriting song structure.
 - [ ] Local/in-memory and Firestore repositories satisfy the same contract tests.
 - [ ] Optimistic saves use revision checks, coalesce rapid writes, ignore stale remote echoes, expose save state, and retain retryable local state.
 - [ ] Security rules and indexes are checked in; emulator tests cover owner access, anonymous identity, denial, deletion, malformed writes, and cross-project references.
@@ -200,11 +204,8 @@ Implement the v1 Firestore document/chunk layout and repository boundary. Protot
 
 ### FND-005 - Selection and consumer projections
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-002`<br>
-`PRD: 9.2-9.3, 9.7-9.8`<br>
-`Evidence: pending`
+`PRD: 9.2-9.3, 9.7-9.8`
 
 Define stable selection/focus state and read-only projections for editor, audio, arrangement rendering, persistence summaries, and assistant context. UI-only state must not enter persisted song state.
 
@@ -215,11 +216,8 @@ Define stable selection/focus state and read-only projections for editor, audio,
 
 ### FND-006 - Single-context AudioRuntime and diagnostics
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-001`<br>
-`PRD: AUD-07, AUD-09; 9.7`<br>
-`Evidence: pending`
+`PRD: AUD-07, AUD-09; 9.7`
 
 Replace route/component-owned Tone lifecycle with one application-scoped `AudioRuntime`, explicit ownership/disposal, HMR handoff, and development diagnostics.
 
@@ -231,11 +229,8 @@ Replace route/component-owned Tone lifecycle with one application-scoped `AudioR
 
 ### FND-007 - Stable ID-keyed audio graph
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-002, FND-005, FND-006`<br>
-`PRD: AUD-03, AUD-08; 9.7`<br>
-`Evidence: pending`
+`PRD: AUD-03, AUD-08; 9.7`
 
 Implement `ProjectAudioGraph` and track/device factories that reconcile typed domain changes narrowly instead of rebuilding Tone objects from Solid effects.
 
@@ -245,31 +240,29 @@ Implement `ProjectAudioGraph` and track/device factories that reconcile typed do
 - [ ] Scheduling uses musical-time projections and tracked owner handles rather than anonymous global callbacks.
 - [ ] Instrumented tests prove stable identities, no unrelated node churn, idempotent teardown, and no stale-load reconnection.
 
-### FND-008 - Arrangement renderer spike and benchmark
+### FND-008 - Arrangement renderer spike and measurement harness
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-001`<br>
-`PRD: ARR-01; 9.3; Performance budgets`<br>
-`Evidence: pending`
+`PRD: ARR-01; 9.3 including "When these budgets are enforced"; Performance budgets`
 
-Build a disposable but representative hybrid virtualized-DOM/Canvas-2D spike before the production arrangement editor expands.
+Build a disposable but representative hybrid virtualized-DOM/Canvas-2D spike, and the measurement infrastructure that Phase 2 will enforce budgets with, before the production arrangement editor expands.
+
+**This task is not gated on hitting the PRD frame budgets, and not gated on the physical baseline device.** Budgets bind at `ARR-005` and `HARD-001`. What Phase 0 owes is fixtures, traces, a working harness, and honest recorded numbers.
 
 - [ ] Deterministic fixtures include 20, 40, and 50 tracks, ten-minute arrangements, dense placements, automation, and waveform placeholders.
 - [ ] The spike implements viewport culling, layered invalidation, pointer hit testing, wheel/pinch zoom anchoring, and virtualized track headers.
-- [ ] Scripted scroll, zoom, seek, and selection traces capture frame time, long tasks, memory, and redraw counts.
-- [ ] Results meet PRD budgets on the physical 2019 Intel MacBook Pro in supported browsers or produce an ADR with profiles and next action.
-- [ ] Reusable projection/geometry contracts and benchmark fixtures are retained; experimental UI is not treated as production merely because it benchmarks well.
+- [ ] Scripted scroll, zoom, seek, and selection traces capture frame time, long tasks, memory, and redraw counts, and are runnable by a single documented command.
+- [ ] Baseline numbers are checked in together with the hardware, browser, and browser version that produced them. Results are not described as meeting or missing a budget when they were not measured on the baseline device.
+- [ ] Reusable projection/geometry contracts and benchmark fixtures are retained and stay renderer-agnostic; experimental UI is not treated as production merely because it benchmarks well.
 
 ### FND-009 - Foundation vertical slice gate
 
-`Status: todo`<br>
-`Owner: unassigned`<br>
 `Dependencies: FND-003, FND-004, FND-005, FND-007, FND-008`<br>
-`PRD: Phase 0 exit criteria; section 13 dependency order`<br>
-`Evidence: pending`
+`PRD: Phase 0 exit criteria; section 13 dependency order`
 
 Integrate the new boundaries through the smallest end-to-end musical path: open a schema-v1 project, add one note, play it, undo it, save it, reload it, and reproduce playback.
+
+The slice's surface is a **16-step grid on a sampler track** — the cheapest UI that still exercises the real UI-to-command-to-audio-to-persistence path, and closest to what the prototype already has. The full step editor is `LOOP-010` and the piano roll is `LOOP-011`; neither is built here, and this grid is expected to be replaced by `LOOP-010` rather than grown into it.
 
 - [ ] UI and keyboard actions dispatch the same command; no component mutates domain or Firestore data directly.
 - [ ] Audible playback uses the stable graph and one shared context.
@@ -539,7 +532,7 @@ Implement one visible lane per track for volume, pan, send, and supported device
 
 Profile and optimize the production arrangement using deterministic 20/40/50-track ten-minute fixtures.
 
-- [ ] PRD frame, input, long-task, load, memory, and visible-object scaling targets pass on the physical baseline device in four supported browsers.
+- [ ] PRD frame, input, long-task, load, memory, and visible-object scaling targets pass on the physical baseline device in the gating browsers. This is where those budgets first bind; `FND-008` supplied the fixtures, traces, and harness.
 - [ ] Waveform peak pyramids, caches, culling, and invalidation have bounded memory and deterministic eviction.
 - [ ] Performance evidence is checked in; a WebGL proposal is forbidden unless the required measured-failure ADR is produced.
 
@@ -661,7 +654,7 @@ Run the full AI evaluation and failure matrix against stable manual commands.
 `Status: todo | Owner: unassigned | Dependencies: REL-002`<br>
 `PRD: Supported environment; section 14 | Evidence: pending`
 
-Expand Playwright and physical-browser procedures across current/previous Firefox, Chrome, Edge, and Safari for every core journey.
+Expand Playwright and physical-browser procedures across current/previous Firefox, Chrome, and Edge for every core journey. Safari is best-effort for the alpha per the PRD supported-environment policy: run it, log what breaks, fix what is reasonably cheap, and record the residual risk for the product-owner decision on restoring gating status before public release.
 
 - [ ] Capability fallbacks, audio unlock, decoding, shortcuts, downloads, Canvas/DPR, Firebase, and failure states are covered.
 - [ ] Unsupported capability messages are actionable; browser regressions block release unless product-approved fallback exists.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -14,6 +14,8 @@ Related document: [Sample library plan](./sample-library.md)
 
 The UI mocks in [`docs/design`](./design) are **directional**. They depict the north-star end state for Solid Groove — the fullest expression of the product's visual language, instruments, and assistant — not the private alpha or any single earlier milestone. Where a mock shows more than a milestone requires (for example, richer instrument panels, a public marketing site, or the assistant recommending tutorial videos), this PRD's priorities (**P0**/**P1**/**P2**) and delivery phases are authoritative for *what ships when*. The mocks are authoritative for *how it should look and feel* once built. When a mock and this document disagree on a concrete UI detail, the mock wins on visual language and interaction shape; the PRD wins on scope, sequencing, and acceptance criteria. New capability seen only in the mocks is placed in the priority and phase noted here rather than pulled forward into the alpha.
 
+The mocks do not cover every screen and state the alpha needs. Save status (`Saving`, `Saved`, `Save failed`), empty/loading/error/offline states, the step editor and piano roll interiors, and the arrangement at other zoom levels have no mock. Implementers extrapolate those from the documented design DNA — the token set, surface tints, single cyan accent, square corners, and the shared 30px control height in [`docs/design/README.md`](./design/README.md) and the CSS custom properties in `docs/design/Solid Groove Mocks.dc.html` — rather than waiting for a mock or inventing a second visual language. A screen built without a mock is flagged for a design pass before the private alpha; a missing mock never blocks implementation.
+
 ## 1. Product summary
 
 Solid Groove is a browser-based electronic music production environment with an integrated AI producer. It is for people who understand the basics of making beats or loops but repeatedly get stuck when they try to develop those ideas into full tracks. Synthesizers, samples, drum machines, and creative audio processing are its primary sound-making tools; recording acoustic performances is not the initial focus.
@@ -849,14 +851,18 @@ The timeline uses stacked canvases so frequently changing pixels do not invalida
 
 The baseline device is a 2019 13-inch Intel MacBook Pro class machine with integrated Intel graphics and 8 GB RAM, tested without requiring a discrete GPU. The reference arrangement contains 50 tracks, ten minutes of musical time, at least 2,500 clip placements, waveforms on 20 tracks, and 100 populated automation lanes.
 
-- On current and previous major Firefox, Chrome, Edge, and Safari, scripted continuous scroll and zoom after warm-up target a median frame time at or below `16.7 ms` and a 95th percentile at or below `33 ms` on the baseline device.
+- On current and previous major Firefox, Chrome, and Edge, scripted continuous scroll and zoom after warm-up target a median frame time at or below `16.7 ms` and a 95th percentile at or below `33 ms` on the baseline device. Safari is measured on a best-effort basis under the supported-environment policy in section 10.
 - Pointer input to visible hover, selection, drag, or resize feedback is below `50 ms` at the 95th percentile.
 - No arrangement interaction creates a main-thread task longer than `100 ms` in the reference fixture.
 - Opening the already-loaded reference project paints useful arrangement content within `500 ms` after its domain state is available.
 - The arrangement renderer's visual cache budget is at most `128 MiB`, excluding decoded audio buffers managed by the audio engine.
 - Frame cost is proportional primarily to visible objects, not total project duration or total offscreen clips.
 - Performance degradation is acceptable above 50 tracks. Data integrity, scrolling correctness, save/export, and the ability to recover remain required.
-- Release performance is measured on the physical baseline device in all four browsers. Developer laptops and synthetic DOM benchmarks alone are not an acceptable substitute.
+- Release performance is measured on the physical baseline device in the gating browsers. Developer laptops and synthetic DOM benchmarks alone are not an acceptable substitute.
+
+#### When these budgets are enforced
+
+These budgets bind at `ARR-005` in Phase 2, once the production arrangement exists, and again at `HARD-001` in Phase 4. They are **not** a Phase 0 exit condition. The Phase 0 renderer spike (`FND-008`) is required to produce the deterministic fixtures, the scripted scroll/zoom/seek/selection traces, and a harness that emits frame time, long-task, redraw-count and memory numbers on whatever hardware runs it, and to check those numbers in as a baseline. It is not required to hit the targets, and no Phase 0 task may be gated on access to the physical baseline device. Measuring a spike on unrepresentative hardware and declaring the budget met is a worse outcome than an honest early number, so Phase 0 records what it measured and where it ran.
 
 If Canvas 2D misses these targets after viewport culling, layered invalidation, waveform pyramids, allocation profiling, and worker-side preprocessing have been implemented, the team may prototype a WebGL renderer behind the same projection. A GPU rewrite requires an ADR containing profiles, cross-browser fallback behavior, accessibility impact, and measured improvement on the baseline device. WASM is a separate decision and does not follow automatically from choosing WebGL.
 
@@ -877,10 +883,25 @@ This section defines the required conceptual boundaries, not the exact TypeScrip
 - **Asset:** stable ID, URL/storage reference, type, metadata, and licensing provenance.
 - **Revision:** stable ID, project revision number, author, timestamp, and optional name.
 
+#### Identifier format
+
+Every persistent entity ID is a type-prefixed, URL-safe random string: a lowercase type prefix, an underscore, then a 21-character nanoid — for example `trk_V1StGXR8Z5jdHi6B_myT`. The prefix makes an ID self-describing in assistant proposals, diffs, logs, Firestore paths, and test failures, and makes a mismatched reference obvious at runtime as well as to the branded TypeScript type. IDs are opaque: nothing parses or orders them, and the prefix is never used to look up a type that the schema already knows.
+
+| Entity | Prefix | Entity | Prefix |
+| --- | --- | --- | --- |
+| Project | `prj_` | Drum pad | `pad_` |
+| Track | `trk_` | Automation lane | `aut_` |
+| Clip | `clp_` | Section | `sec_` |
+| Placement | `plc_` | Return bus | `ret_` |
+| Note event | `evt_` | Asset | `ast_` |
+| Device | `dev_` | Revision | `rev_` |
+
+Tests use a deterministic ID factory that produces the same prefixed format with a seeded suffix, so fixtures and serialization round trips stay stable without a separate ID shape.
+
 ### 9.5 Domain invariants
 
-1. Persistent relationships use stable IDs, never array positions.
-2. Musical time is stored in integer ticks at a documented PPQ; pixels and floating-point seconds are derived views.
+1. Persistent relationships use stable IDs in the section 9.4 prefixed format, never array positions.
+2. Musical time is stored in integer ticks at **192 PPQ**; pixels and floating-point seconds are derived views. 192 is Tone.js's own transport resolution, so live scheduling needs no conversion between stored and scheduled time. At 192 PPQ a 16th note is 48 ticks, an eighth-note triplet is 64, and a ten-minute arrangement at 240 BPM is under 500,000 ticks. Changing PPQ after schema v1 is a migration, not a configuration value.
 3. Clip content is separate from arrangement placement so reuse and independent variation are explicit.
 4. All user-controlled numeric values have shared validation and clamping rules.
 5. A placement cannot reference a missing clip or a clip owned by a different track unless an explicit cross-track copy operation creates a compatible clip.
@@ -936,12 +957,30 @@ UI components must not mutate the persisted project store directly. The AI endpo
 - Schema migration is separate from UI rendering.
 - Security rules enforce ownership/collaborator access and must be tested against an emulator before sharing ships.
 
+#### Firestore schema-v1 document layout
+
+Schema v1 stores a project across three tiers. This layout is a committed alpha decision; changing it requires an ADR and a migration.
+
+| Path | Contents | Written when |
+| --- | --- | --- |
+| `projects/{projectId}` | Name, owner, collaborators, created/modified timestamps, schema version, current revision, template/genre label | Metadata changes; dashboard queries read only this tier |
+| `projects/{projectId}/song/current` | Tempo, time signature, sections, ordered tracks with instrument state, device chains, sends and mixer state, return buses, master settings, arrangement placements, and automation lanes | Structural and arrangement edits |
+| `projects/{projectId}/clips/{clipId}` | Clip metadata and its note or audio-loop content | Note and clip-content edits |
+
+- The dashboard lists projects without loading song state or clip content.
+- Note editing — the highest-frequency write path — touches one small clip document rather than rewriting song structure.
+- The song document has a documented size budget, asserted in tests against the maximum reference project. If arrangement placements and automation exceed that budget, they split into per-track chunk documents under `projects/{projectId}/arrangement/{trackId}` sharing the same revision. `FND-004` owns the exact budget and chunk boundary and must prove both against the 50-track reference fixture; no document may grow unbounded.
+- Every tier carries the project revision so a stale write or remote echo is detected rather than applied.
+- Prototype `latestSnapshot` documents are not part of this schema and are discarded rather than migrated.
+
 ## 10. Non-functional requirements
 
 ### Supported environment
 
-- P0 support: current and previous major desktop versions of Firefox, Chrome, Edge, and Safari.
-- A compatibility regression in any supported browser blocks the alpha release unless the affected feature has an explicit, usable fallback approved by the product owner.
+- P0 gating support: current and previous major desktop versions of Firefox, Chrome, and Edge. These three are verified in automated suites and block release.
+- Safari is best-effort for the private alpha. It is expected to work, defects found in it are logged and fixed where the cost is reasonable, and Safari is not a release gate. Playwright WebKit runs alongside the gating browsers where it is cheap to do so, and its result is treated as a signal rather than as proof about Safari — WebKit passing is not the same as Safari passing.
+- This is a deliberate scope reduction for the alpha, not a judgement that Safari matters less. Safari diverges most from other engines on Web Audio behavior — autoplay/unlock policy, decoding, and context lifecycle — so it carries the highest chance of a late surprise, and it is the default browser for most Mac users in the target audience. Restoring Safari to gating status is a product-owner decision expected before any public release, and no implementation may knowingly break it in the meantime.
+- A compatibility regression in a gating browser blocks the alpha release unless the affected feature has an explicit, usable fallback approved by the product owner.
 - Browser capabilities are feature-detected. Core behavior does not branch only on user-agent strings.
 - The app detects unsupported Web Audio or decoding capabilities and explains the limitation.
 
@@ -950,7 +989,7 @@ UI components must not mutate the persisted project store directly. The AI endpo
 - Dashboard shell interactive within 3 seconds on a typical broadband connection and mid-range laptop, excluding cold authentication delays.
 - Editor shell visible within 3 seconds; cached starter-project playback ready within 2 seconds after the first play gesture.
 - Pointer-driven note and parameter edits target a visual response within 50 ms.
-- Arrangement scrolling and zooming meet the Section 9.3 acceptance budgets for the 50-track reference project on the baseline device.
+- Arrangement scrolling and zooming meet the Section 9.3 acceptance budgets for the 50-track reference project on the baseline device, enforced from `ARR-005` onward as described in section 9.3.
 - The 40-track, 10-minute audio reference project includes processing on every track and at least 64 active device instances across inserts and returns.
 - Assistant streaming or loading must not block audio, editing, or autosave.
 
@@ -1006,8 +1045,9 @@ The agent-ready task sequence, ownership protocol, dependencies, and completion 
 
 ### Phase 0 - Foundations
 
-- Implement the canonical schema-v1 domain model in TypeScript with runtime validation, stable ID-based entities, integer musical time, explicit invariants, and deterministic serialization. Existing prototype state and documents require no migration or backwards compatibility.
-- Implement the v1 Firebase persistence layout in code, including Firestore collections/documents or chunks, domain-to-storage mapping, ownership metadata, schema and revision fields, indexes, security rules, and repository adapters.
+- Implement the canonical schema-v1 domain model in TypeScript with runtime validation, prefixed stable IDs, integer musical time at 192 PPQ, explicit invariants, and deterministic serialization. Existing prototype state and documents require no migration or backwards compatibility.
+- Implement the shared parameter-definition mechanism — how a parameter declares its range, unit, default, clamping policy, and automation capability, and how UI, command validation, the audio engine, and assistant tools all read one definition. Phase 0 defines the mechanism and the few parameters the vertical slice needs. Per-device values for instruments and effects are authored with their devices in Phase 1, where they can be tuned by ear, and must not be invented into schema v1 ahead of them.
+- Implement the section 9.9 v1 Firebase persistence layout in code, including the metadata/song/clip document tiers, the song-document size budget and its chunk overflow path, domain-to-storage mapping, ownership metadata, schema and revision fields, indexes, security rules, and repository adapters.
 - Add domain fixtures and automated tests for schema validation, invariants, serialization round trips, invalid references, musical-time conversion, repository behavior, Firestore size/chunk boundaries, and Firebase Emulator security rules.
 - Introduce the shared command, validation, transaction, undo/redo, and save-status layers.
 - Build the single-context `AudioRuntime`, ID-keyed graph reconciler, disposal ownership tree, and resource-leak harness outside Solid components.
@@ -1015,7 +1055,7 @@ The agent-ready task sequence, ownership protocol, dependencies, and completion 
 - Build the hybrid DOM/Canvas 2D arrangement renderer vertical slice and automated performance fixture before expanding timeline features.
 - Add reference project fixtures and deterministic audio tests.
 
-Exit criteria: the schema-v1 code and Firebase layout pass their unit, round-trip, repository, and emulator tests; the thin vertical slice can add one note, play it, undo it, save it, and reopen it through the new boundaries; no UI or assistant code directly mutates stored project data; and the renderer spike meets its frame budget on the baseline hardware in all four browsers. Prototype projects are not an exit dependency.
+Exit criteria: the schema-v1 code and Firebase layout pass their unit, round-trip, repository, and emulator tests; the thin vertical slice can add one note through the step grid of a sampler track, play it, undo it, save it, and reopen it through the new boundaries; no UI or assistant code directly mutates stored project data; and the renderer spike ships its fixtures, scripted traces, and measurement harness with checked-in baseline numbers. Renderer frame budgets are enforced at `ARR-005` and `HARD-001`, not here, and no Phase 0 exit condition depends on access to the physical baseline device. Prototype projects are not an exit dependency.
 
 ### Phase 1 - Complete the loop workflow
 
@@ -1146,7 +1186,7 @@ Produces:
 - **Audio tests:** event schedules, stable-node identity, narrow graph reconciliation, processing-graph changes, parameter extremes, automation boundaries, looping boundaries, idempotent disposal, cancelled/failed initialization, buffer-cache ownership, and offline-render properties.
 - **Web Audio lifecycle tests:** one-context invariant, fifty HMR replacements, fifty project cycles, stale async-load cancellation, resource-counter baselines, and real-browser playback during parameter/topology edits.
 - **Component tests:** editor interactions, every registered shortcut in valid and invalid focus contexts, mapping-guide synchronization, dialogs, accessibility names, and error states.
-- **Rendering performance tests:** deterministic 50-track fixture, scripted scroll/zoom/selection traces, frame/long-task metrics, cache-memory checks, and physical baseline-device runs in all supported browsers.
+- **Rendering performance tests:** deterministic 50-track fixture, scripted scroll/zoom/selection traces, frame/long-task metrics, cache-memory checks, and physical baseline-device runs in the gating browsers from `ARR-005` onward.
 - **Contract tests:** persistence adapters, assistant tool payloads, stale revisions, and domain-to-audio projections.
 - **End-to-end tests:** anonymous start, create loop, arrange, assistant apply/undo, autosave/reopen, stereo export, and multitrack stem export.
 - **Manual tests:** audible glitches, metering, long playback, AudioContext policies, browser decoding, and output-device changes.
@@ -1175,6 +1215,8 @@ A feature is done only when:
 | Browser audio timing or lifecycle defects erode trust | Users abandon projects despite good features | Isolate the engine, schedule ahead, build offline tests, and maintain a maximum-size reference project |
 | HMR, navigation, or reactive updates leak contexts and Tone objects | Chrome context limits, rising memory/CPU, duplicated triggers, and eventual playback failure | Own one application-scoped context, preserve it across compatible HMR, reconcile stable graphs, require idempotent disposal, and assert instrumented resource baselines |
 | Dense arrangement rendering overwhelms older integrated graphics or the main thread | Scrolling and editing become unusable on target hardware | Use viewport-sized layered Canvas 2D, culling, virtualized DOM, waveform pyramids, allocation profiling, and a physical 2019 Intel MacBook Pro release benchmark before considering WebGL |
+| Safari is non-gating during the alpha | Web Audio unlock, decoding, or context-lifecycle defects surface late on the browser most Mac users default to | Keep Playwright WebKit in the automated suite as a signal, feature-detect rather than branch on user agent, fix reasonable-cost Safari defects as they are found, and require an explicit product-owner decision to restore gating status before any public release |
+| Renderer budgets are not enforced until Phase 2 | A structurally slow renderer is discovered after the production arrangement is already built on it | Phase 0 still ships the fixtures, scripted traces, and measurement harness with checked-in baseline numbers; `ARR-005` profiles before the arrangement is called done, and the projection/geometry contracts stay renderer-agnostic so a replacement renderer remains possible |
 | Large or extreme processing chains overload the browser or create unstable output | Glitches interrupt creation or unsafe peaks reach the output | Enforce measured device-count budgets, smooth parameters, bound unstable feedback internally, profile the processed reference project, and retain a transparent master safety limiter |
 | AI changes feel arbitrary or destroy work | Loss of authorship and trust | Structured proposals, validation, selection scope, atomic apply, visible diff, and immediate undo |
 | AI context becomes too large or expensive | Slow, unreliable assistant | Compact musical summaries, scoped selection, deterministic analysis, token/usage budgets, and provider-independent gateway |
@@ -1189,7 +1231,13 @@ A feature is done only when:
 ### Decisions made for implementation
 
 - Desktop web is the alpha production surface.
-- Current and previous major Firefox, Chrome, Edge, and Safari are P0 browsers, with a 2019 Intel MacBook Pro class machine as the performance baseline.
+- Current and previous major Firefox, Chrome, and Edge are the gating P0 browsers, with a 2019 Intel MacBook Pro class machine as the performance baseline. Safari is best-effort for the alpha and expected to return to gating status before public release.
+- Musical time is integer ticks at 192 PPQ, matching Tone.js transport resolution so stored and scheduled time need no conversion.
+- Persistent IDs are type-prefixed 21-character nanoids, for example `trk_V1StGXR8Z5jdHi6B_myT`.
+- Firestore schema v1 stores a project as a metadata document, one song document, and one document per clip, with a documented song-document size budget and a defined per-track chunk overflow path.
+- Phase 0 defines the parameter-definition mechanism; per-device parameter values are authored with their devices in Phase 1.
+- Arrangement frame budgets are enforced at `ARR-005` and `HARD-001`. Phase 0 owes measurement infrastructure and honest baseline numbers, not passing scores, and no Phase 0 task depends on the physical baseline device.
+- Screens and states without a mock are extrapolated from the documented design DNA and flagged for a later design pass rather than blocking implementation.
 - The initial audience produces electronic music primarily with synths, samples, drum machines, sequencing, and processing rather than acoustic recording.
 - Initial content and product testing cover techno, house, drum and bass, hip hop, dubstep, lofi, ambient, trance, UK garage, breakbeat, electronic pop, and other electronic or electronically produced popular styles without genre-locked modes.
 - Overdrive, saturation, compression, reverb, delay, insert chains, and send effects are P0 creation tools rather than post-alpha additions.


### PR DESCRIPTION
Settle the decisions an implementation agent would otherwise have to
guess, and remove the Phase 0 acceptance criteria no agent can satisfy.

Foundation contracts, now committed in the PRD:

- Musical time is integer ticks at 192 PPQ, matching Tone.js transport
  resolution so stored and scheduled time need no conversion.
- Persistent IDs are type-prefixed 21-character nanoids, with a prefix
  table per entity and a deterministic seeded variant for tests.
- Firestore schema v1 is a three-tier layout: project metadata, one song
  document, and one document per clip, with a documented song-document
  size budget and a defined per-track chunk overflow path.
- Phase 0 defines the parameter-definition mechanism only; per-device
  values are authored with their devices in Phase 1.

Verification policy:

- Arrangement frame budgets now bind at ARR-005 and HARD-001. Phase 0
  owes fixtures, scripted traces, a measurement harness, and honest
  recorded numbers, not passing scores, and no Phase 0 task depends on
  access to the physical baseline device.
- Safari drops to best-effort for the alpha; Firefox, Chrome and Edge
  gate. Recorded with its risk and an expected return to gating status
  before public release.
- FND-001 owns CI workflows and the missing Firebase emulator config,
  and adds a non-mutating check:ci script.
- The FND-009 slice is a 16-step grid on a sampler track.

Coordination:

- Task status moves to one GitHub issue per task; the backlog becomes
  the specification and work graph rather than a mutable claim board,
  removing the write contention parallel agents would hit.
- One PR per task, worktree-isolated, with contract-owning tasks landing
  before their dependents start.

Screens without a mock are extrapolated from the documented design DNA
and flagged for a later design pass rather than blocking implementation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U76DHiA5Ly6Snm4qqeEE9r