### PR TITLE
Point the Phase 0 workflow at main and get CI green

### DIFF
--- a/.claude/workflows/solid-groove-phase-0.js
+++ b/.claude/workflows/solid-groove-phase-0.js
@@ -18,7 +18,7 @@ export const meta = {
 // dependent task and surfaces late; everything else runs on Sonnet. Review is
 // always Opus, at high effort, and runs before any PR is opened.
 const CONTRACT_TASKS = ['FND-002', 'FND-003', 'FND-004']
-const BASE_BRANCH = 'claude/dynamic-workflow-clarity-tvo8hv'
+const BASE_BRANCH = 'main'
 const MAX_REVIEW_ROUNDS = 2
 
 // The agent registry is read once at session start, so `agentType` cannot resolve

--- a/bun.lock
+++ b/bun.lock
@@ -2327,7 +2327,6 @@
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,15 +19,36 @@ export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
 	reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+	// The suite runs against the dev server, so the first test to reach a route
+	// pays for compiling that route's chunks on demand — the dashboard pulls in
+	// the Firebase SDK, which is measurably slow the first time. Cold locally
+	// that leaves the anonymous-start assertion at ~4.8s against Playwright's 5s
+	// default, i.e. passing by 200ms and certain to tip over on a slower runner.
+	// Give assertions real headroom; it costs nothing when they pass promptly.
+	expect: {
+		timeout: 15_000,
+	},
 	use: {
 		baseURL,
 		trace: "on-first-retry",
 	},
 	webServer: {
-		command: "bun run dev",
+		// `--host 127.0.0.1` pins the dev server to IPv4. Without it vinxi binds
+		// whatever `localhost` resolves to, and on a dual-stack host (GitHub
+		// runners resolve localhost to both 127.0.0.1 and ::1) that can be the
+		// IPv6 address while `url` below polls IPv4 — the server comes up, nothing
+		// ever answers on 127.0.0.1, and the run dies on the webServer timeout.
+		command: "bun run dev --host 127.0.0.1",
 		url: baseURL,
 		reuseExistingServer: !process.env.CI,
-		timeout: 60_000,
+		// A cold start takes a few seconds locally, but CI runners are slower and
+		// build from an empty Vite cache, so allow real headroom.
+		timeout: 120_000,
+		// Vinxi's startup banner and any boot error go to stdout, which Playwright
+		// discards by default — a webServer timeout is then unattributable from the
+		// CI log alone. Pipe it so the next failure explains itself.
+		stdout: "pipe",
+		stderr: "pipe",
 		env: {
 			VITE_MOCK_BACKEND: "true",
 		},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,15 @@ export default defineConfig({
 		conditions: ["development", "browser"],
 	},
 	test: {
-		exclude: [...configDefaults.exclude, "e2e/**", "tests/emulator/**"],
+		// `.claude/**` keeps the runner out of git worktrees, which the agent
+		// workflow creates under `.claude/worktrees/`. Each is a full checkout,
+		// so without this a stray worktree's suites are collected alongside the
+		// real ones and fail against the main checkout's paths.
+		exclude: [
+			...configDefaults.exclude,
+			"e2e/**",
+			"tests/emulator/**",
+			".claude/**",
+		],
 	},
 });


### PR DESCRIPTION
## Summary

Started as a one-line retarget of the Phase 0 workflow, then widened to fixing every CI failure so `main` is a clean base for the next run.

## 1. Retarget the workflow

`BASE_BRANCH` in `.claude/workflows/solid-groove-phase-0.js` moves from `claude/dynamic-workflow-clarity-tvo8hv` to `main`. That integration branch has been merged into `main`, taking FND-001, FND-002 and FND-006 with it. Everything downstream interpolates the constant, so the worktree ground rules, the review prompt's diff target, and the PR stage's base all follow. `git grep dynamic-workflow-clarity` now returns nothing.

## 2. Unbreak the lockfile

`bun.lock` carried a duplicate `"postcss/nanoid"` entry from the FND-002/FND-006 merges. Bun refuses to parse the file at all — `InvalidPackageKey: failed to parse lockfile` — then fails on `--frozen-lockfile`. Every job depends on the install step, so this alone made CI unrunnable.

Both copies were byte-identical, so dropping the second changes no resolution. `bun install --frozen-lockfile` now exits 0 and leaves the lockfile untouched.

## 3. Fix the browser suite

Two separate causes behind `Timed out waiting 60000ms from config.webServer`:

- **Bind address.** The dev server binds whatever `localhost` resolves to. GitHub runners resolve it to both `127.0.0.1` and `::1`, so it can listen on IPv6 while `webServer.url` polls IPv4 and never gets an answer — the server is up, nothing responds, the run dies at 60s. Pinned to `--host 127.0.0.1`. This is the one fix I could not reproduce locally: this container resolves `localhost` to IPv4 only, so the mismatch cannot occur here. The change removes the ambiguity either way.
- **Diagnosability.** Vinxi's banner and any boot error go to stdout, which Playwright discards by default. That is why the original failure was unattributable from the CI log. Now piped.

Timeout also raised to 120s for headroom on a slower runner.

## 4. Remove a latent e2e flake

Assertions now get 15s. Against the dev server, the first test to reach a route pays to compile that route's chunks, and `/dashboard` pulls in the Firebase SDK. Measured from a cold Vite cache, the anonymous-start assertion took **4.8s against Playwright's 5s default** — passing by 200ms, and certain to tip over on a slower runner.

## 5. Keep vitest out of worktrees

`.claude/**` is excluded from the vitest run. Workflow worktrees live under `.claude/worktrees/` and each is a full checkout, so a stray worktree's suites were collected alongside the real ones and failed against the main checkout's paths — four failing files unrelated to the repo's own tests. Same blind spot `biome.json` had. The emulator config anchors its `include` to `tests/emulator/**` and needs no equivalent change.

## Verification

Run locally, from a cold Vite cache where relevant:

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` | exit 0, lockfile unchanged |
| `bun run typecheck` | pass |
| `bun run check:ci` | pass, 111 files |
| `bun run test` | 27 files, 187 tests pass |
| `bun run test:emulator` | 9 tests pass |
| Chromium e2e, cold cache | 2 tests pass |

Firefox and WebKit need CI's own browser installs and are unverified here.
