### PR TITLE
Make the Phase 0 workflow's task filter usable from every caller

### DIFF
--- a/.claude/workflows/solid-groove-phase-0.js
+++ b/.claude/workflows/solid-groove-phase-0.js
@@ -61,27 +61,53 @@ const TASKS = [
   { id: 'FND-009', phase: 'Slice', title: 'Foundation vertical slice gate' },
 ]
 
-// Fail loud on a malformed subset request. `args` passed as a JSON-encoded
-// string ('["FND-001"]') rather than a real array is not an array, so the old
-// `Array.isArray(args) ? ... : null` silently degraded "run one task" into
-// "run the entire phase" — which is exactly what happened once, opening PRs
-// for six tasks that were never asked for. A bad filter must stop the run.
-if (args !== undefined && args !== null && !Array.isArray(args)) {
+// Normalise the subset request, and fail loud on anything malformed.
+//
+// The rule that matters: a filter the script cannot understand must stop the
+// run, never degrade into "run every task". An earlier version used
+// `Array.isArray(args) ? ... : null`, so a non-array `args` fell through to
+// null and ran the entire phase — that once opened PRs for six tasks nobody
+// asked for.
+//
+// Rejecting every non-array outright was too strict, though: some callers hand
+// `args` to the script already JSON-encoded ('["FND-001"]'), which made the
+// subset feature unusable rather than merely safe. So decode that form
+// explicitly. A string that is not a JSON array, and any other non-array type,
+// still throws.
+const parseTaskIds = (raw) => {
+  if (raw === undefined || raw === null) return null
+  if (Array.isArray(raw)) return raw
+  if (typeof raw === 'string') {
+    let decoded
+    try {
+      decoded = JSON.parse(raw)
+    } catch {
+      throw new Error(
+        `args must be an array of task ids; got a string that is not JSON: ${raw}`,
+      )
+    }
+    if (!Array.isArray(decoded)) {
+      throw new Error(
+        `args must be an array of task ids; the string decoded to ${typeof decoded}: ${raw}`,
+      )
+    }
+    return decoded
+  }
   throw new Error(
-    `args must be an array of task ids, got ${typeof args}: ${JSON.stringify(args)}. ` +
-      'Pass a real JSON array (args: ["FND-001"]), not a JSON-encoded string — ' +
-      'a stringified list reaches the script as one string and would run every task.',
+    `args must be an array of task ids, got ${typeof raw}: ${JSON.stringify(raw)}.`,
   )
 }
+
+const taskIds = parseTaskIds(args)
 const known = new Set(TASKS.map((t) => t.id))
-const unknown = (args ?? []).filter((id) => !known.has(id))
+const unknown = (taskIds ?? []).filter((id) => !known.has(id))
 if (unknown.length) {
   throw new Error(
     `args contains unknown task id(s): ${unknown.join(', ')}. Known ids: ${[...known].join(', ')}.`,
   )
 }
 
-const only = Array.isArray(args) && args.length ? new Set(args) : null
+const only = taskIds && taskIds.length ? new Set(taskIds) : null
 const task = (id) => TASKS.find((t) => t.id === id)
 const wanted = (id) => !only || only.has(id)
 

--- a/.claude/workflows/solid-groove-phase-0.js
+++ b/.claude/workflows/solid-groove-phase-0.js
@@ -3,7 +3,7 @@ export const meta = {
   description:
     'Implement Solid Groove Phase 0 (FND-001..009) — Sonnet implements, Opus reviews every branch before its PR opens',
   whenToUse:
-    'Run to execute Phase 0 of docs/backlog.md. Pass args to run a subset, e.g. args: ["FND-001","FND-002"].',
+    'Run to execute Phase 0 of docs/backlog.md. Name tasks to run a subset, either positionally (solid-groove-phase-0 FND-003 FND-004) or as args: ["FND-003","FND-004"]. Omit them entirely to run the whole phase. Named tasks still execute in dependency order, not the order given.',
   phases: [
     { title: 'Tooling', detail: 'FND-001 — test, CI and emulator foundation' },
     { title: 'Contracts', detail: 'FND-002 domain schema, then command kernel, repository and projections', model: 'opus' },
@@ -64,38 +64,67 @@ const TASKS = [
 // Normalise the subset request, and fail loud on anything malformed.
 //
 // The rule that matters: a filter the script cannot understand must stop the
-// run, never degrade into "run every task". An earlier version used
+// run, never degrade into "run every task". An early version used
 // `Array.isArray(args) ? ... : null`, so a non-array `args` fell through to
 // null and ran the entire phase — that once opened PRs for six tasks nobody
-// asked for.
+// asked for. Every branch below either yields a non-empty id list or throws.
 //
-// Rejecting every non-array outright was too strict, though: some callers hand
-// `args` to the script already JSON-encoded ('["FND-001"]'), which made the
-// subset feature unusable rather than merely safe. So decode that form
-// explicitly. A string that is not a JSON array, and any other non-array type,
-// still throws.
-const parseTaskIds = (raw) => {
-  if (raw === undefined || raw === null) return null
+// Three accepted forms, because callers differ in what they can send:
+//
+//   real array          ["FND-003", "FND-004"]
+//   JSON-encoded array  '["FND-003","FND-004"]'   the Workflow tool's transport
+//                                                 stringifies args, so this is
+//                                                 what usually arrives
+//   positional list     'FND-003 FND-004'         what a slash-command run
+//                       'FND-003,FND-004'         sends, since the Skill tool
+//                                                 passes args as one string
+//
+// Ids are matched case-insensitively; they are validated against TASKS below,
+// so a typo is still an error rather than a silently dropped filter.
+const normaliseId = (id) => (typeof id === 'string' ? id.trim().toUpperCase() : id)
+
+const toIdList = (raw) => {
   if (Array.isArray(raw)) return raw
-  if (typeof raw === 'string') {
+  if (typeof raw !== 'string') {
+    throw new Error(`args must be task ids, got ${typeof raw}: ${JSON.stringify(raw)}.`)
+  }
+
+  const trimmed = raw.trim()
+  if (!trimmed) return []
+
+  // A leading bracket or brace means the caller meant JSON. Honour that reading
+  // so a malformed JSON filter is reported as malformed JSON, rather than being
+  // split on whitespace into tokens that fail later as "unknown task id".
+  if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
     let decoded
     try {
-      decoded = JSON.parse(raw)
+      decoded = JSON.parse(trimmed)
     } catch {
-      throw new Error(
-        `args must be an array of task ids; got a string that is not JSON: ${raw}`,
-      )
+      throw new Error(`args looks like JSON but does not parse: ${raw}`)
     }
     if (!Array.isArray(decoded)) {
-      throw new Error(
-        `args must be an array of task ids; the string decoded to ${typeof decoded}: ${raw}`,
-      )
+      throw new Error(`args must be a list of task ids; it decoded to ${typeof decoded}: ${raw}`)
     }
     return decoded
   }
-  throw new Error(
-    `args must be an array of task ids, got ${typeof raw}: ${JSON.stringify(raw)}.`,
-  )
+
+  return trimmed.split(/[\s,]+/)
+}
+
+// Only an *absent* filter means "run everything". A filter that is present but
+// empty — '', '   ', [], '[]' — is ambiguous: it reads equally as "run nothing"
+// and as "a list I meant to populate and did not", and the second is how the
+// six-unwanted-PRs run happened. Refuse it and make the caller say which.
+const parseTaskIds = (raw) => {
+  if (raw === undefined || raw === null) return null
+  const ids = toIdList(raw).map(normaliseId)
+  if (!ids.length) {
+    throw new Error(
+      'args was present but empty, which is ambiguous. Omit args entirely to run the ' +
+        'whole phase, or name the tasks to run, e.g. "FND-003 FND-004".',
+    )
+  }
+  return ids
 }
 
 const taskIds = parseTaskIds(args)
@@ -107,7 +136,8 @@ if (unknown.length) {
   )
 }
 
-const only = taskIds && taskIds.length ? new Set(taskIds) : null
+// parseTaskIds returns null or a non-empty list, so this needs no length check.
+const only = taskIds ? new Set(taskIds) : null
 const task = (id) => TASKS.find((t) => t.id === id)
 const wanted = (id) => !only || only.has(id)
 


### PR DESCRIPTION
## Summary

The Phase 0 workflow accepts a subset of tasks to run, but in practice the filter could only be expressed one way, and that way was not the way callers actually send it. Every attempt to run part of the phase died at the argument guard in under 300ms, leaving the unfiltered run — all nine tasks — as the only invocation that worked.

Two commits, both in `.claude/workflows/solid-groove-phase-0.js`. No product code is touched.

## Why the guard was rejecting valid requests

The guard exists for a good reason, recorded in its own comment: a filter the script cannot parse must **stop the run**, never quietly degrade into "run every task". An early version used `Array.isArray(args) ? ... : null`, so a non-array `args` fell through to `null` and ran the whole phase — that is how a past run opened PRs for six tasks nobody asked for.

The problem was the remedy, not the rule. Rejecting every non-array outright assumed callers can send a real JS array, and two of them cannot:

- The **Workflow tool's transport** stringifies `args`, so a genuine array literal arrives as `'["FND-003"]'` regardless of how it was passed.
- The **Skill tool** passes `args` as a single string, so a slash-command run sends `'FND-003 FND-004'`.

Both were rejected. The feature was not merely safe, it was unreachable.

## What now parses

| Form | Example | Status |
|---|---|---|
| Real array | `["FND-003","FND-004"]` | unchanged |
| JSON-encoded array | `'["FND-003","FND-004"]'` | **now accepted** |
| Positional list | `FND-003 FND-004` / `FND-003,FND-004` | **now accepted** |
| Absent | — | unchanged, runs the whole phase |

Ids may be separated by spaces or commas and are matched case-insensitively. A leading `[` or `{` is read as a deliberate JSON filter, so malformed JSON is reported as malformed JSON rather than being split on whitespace into tokens that fail later as "unknown task id".

The safety property is intact. Ids are still validated against the task table, so a typo stops the run instead of silently narrowing it, and every parse branch either yields a non-empty id list or throws.

## Behaviour change

One, called out because it is a real change and not a strict widening:

**A filter that is present but empty — `''`, `'   '`, `[]`, `'[]'` — now throws.** Previously `[]` fell through to "run everything".

Without this the script would carry two inconsistent rules, with `''` throwing while `[]` silently ran all nine tasks. Present-but-empty is ambiguous: it reads equally as "run nothing" and as "a list I meant to populate and did not", and the second is precisely the failure that produced six unwanted PRs. Only an *absent* filter now means the full phase. The error says so:

```
args was present but empty, which is ambiguous. Omit args entirely to run the
whole phase, or name the tasks to run, e.g. "FND-003 FND-004".
```

Reverting just this is a one-line change if the old reading is preferred.

## Ordering is unchanged

Naming tasks does not reorder them. `FND-008 FND-003` runs FND-008 first because of the dependency graph encoded in the script, not because it was typed first. `meta.whenToUse` now says so, since the opposite is a natural assumption.

## Verification

- Parser extracted verbatim from the committed file — not retyped — and exercised over 22 cases: the four accepted forms above, plus typos, a typo mixed among valid ids, prose, broken JSON, JSON objects, numbers, and the four present-but-empty values. Every existing call form produces byte-identical task selection to before; every malformed input throws.
- Full file syntax-checked inside the runtime's async wrapper, which its top-level `return`/`await` require.
- No test-suite or lint impact: `biome.json` already excludes `.claude`, and this file has no test coverage. `bun run test` was therefore not a meaningful gate here and I did not treat it as one.

The live Phase 0 run was launched before these edits and is unaffected — the runtime loads the script at launch, so it is executing the source as it stood then.