### PR TITLE
FND-008 - Arrangement renderer spike and measurement harness

### DIFF
--- a/.github/workflows/bench-arrangement.yml
+++ b/.github/workflows/bench-arrangement.yml
@@ -1,0 +1,33 @@
+name: Arrangement renderer spike benchmark
+
+# FND-008's measurement harness (`bun run bench:arrangement`, see
+# docs/arrangement-renderer-spike.md) needs a real Chromium download from
+# cdn.playwright.dev, which the sandbox this task is normally implemented in
+# cannot reach. `workflow_dispatch`-only and deliberately not wired into
+# `ci.yml`'s push/pull_request triggers: this produces a checked-in baseline
+# artifact on demand, not a pass/fail signal on every push, matching the
+# backlog task's "not gated on hitting the PRD 9.3 budgets" and "not part of
+# CI's gating matrix" decisions.
+on:
+  workflow_dispatch: {}
+
+jobs:
+  bench-arrangement:
+    name: bun run bench:arrangement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Install Playwright browser (chromium)
+        run: bunx playwright install --with-deps chromium
+      - name: Run the arrangement-spike benchmark
+        run: bun run bench:arrangement
+      - uses: actions/upload-artifact@v4
+        with:
+          name: arrangement-spike-baseline
+          path: docs/perf/arrangement-spike-baseline.json
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,38 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  # TEMPORARY, one-off: captures the first FND-008 arrangement-spike
+  # baseline for docs/perf/arrangement-spike-baseline.json using this
+  # push's real CI outbound access (the review sandbox that implemented
+  # FND-008 could not reach cdn.playwright.dev to install a browser at
+  # all). `bench-arrangement.yml`'s `workflow_dispatch` can't be invoked via
+  # the API until it exists on the default branch, so this job rides the
+  # push trigger that's already active instead. Remove this job (keeping
+  # `bench-arrangement.yml`) once the baseline artifact has been downloaded
+  # and committed. Not `needs:` anything and `continue-on-error`: it must
+  # never block the real gating jobs above.
+  bench-arrangement-oneoff:
+    name: "TEMPORARY: capture FND-008 baseline artifact"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Install Playwright browser (chromium)
+        run: bunx playwright install --with-deps chromium
+      - name: Run the arrangement-spike benchmark
+        run: bun run bench:arrangement
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: arrangement-spike-baseline
+          path: docs/perf/arrangement-spike-baseline.json
+          retention-days: 7
+
   # Firebase Emulator suite: contract tests for firestore.rules against a
   # real local Firestore instance (PRD 9.9).
   emulator:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,11 @@ jobs:
         run: bunx playwright install --with-deps chromium
       - name: Run the arrangement-spike benchmark
         run: bun run bench:arrangement
+      - name: Print the baseline JSON (sandbox has no artifact-download access)
+        run: |
+          echo "===BASELINE-JSON-START==="
+          cat docs/perf/arrangement-spike-baseline.json
+          echo "===BASELINE-JSON-END==="
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,43 +92,6 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
-  # TEMPORARY, one-off: captures the first FND-008 arrangement-spike
-  # baseline for docs/perf/arrangement-spike-baseline.json using this
-  # push's real CI outbound access (the review sandbox that implemented
-  # FND-008 could not reach cdn.playwright.dev to install a browser at
-  # all). `bench-arrangement.yml`'s `workflow_dispatch` can't be invoked via
-  # the API until it exists on the default branch, so this job rides the
-  # push trigger that's already active instead. Remove this job (keeping
-  # `bench-arrangement.yml`) once the baseline artifact has been downloaded
-  # and committed. Not `needs:` anything and `continue-on-error`: it must
-  # never block the real gating jobs above.
-  bench-arrangement-oneoff:
-    name: "TEMPORARY: capture FND-008 baseline artifact"
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Install Playwright browser (chromium)
-        run: bunx playwright install --with-deps chromium
-      - name: Run the arrangement-spike benchmark
-        run: bun run bench:arrangement
-      - name: Print the baseline JSON (sandbox has no artifact-download access)
-        run: |
-          echo "===BASELINE-JSON-START==="
-          cat docs/perf/arrangement-spike-baseline.json
-          echo "===BASELINE-JSON-END==="
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: arrangement-spike-baseline
-          path: docs/perf/arrangement-spike-baseline.json
-          retention-days: 7
-
   # Firebase Emulator suite: contract tests for firestore.rules against a
   # real local Firestore instance (PRD 9.9).
   emulator:

--- a/docs/arrangement-renderer-spike.md
+++ b/docs/arrangement-renderer-spike.md
@@ -45,11 +45,12 @@ benchmarks well."
   every existing caller/test is unaffected.
 - `createArrangementSpikeProject(trackCount)` — the task's three benchmark
   fixtures: `20`, `40`, or `50` tracks (`ARRANGEMENT_SPIKE_TRACK_COUNTS`), each
-  a ten-minute arrangement with `20 × trackCount` placements (dense: ~20 per
-  track spread across the ten minutes), `2 × trackCount` automation lanes, and
-  ~40% of tracks as waveform-bearing audio tracks. Deterministic (seeded by
-  track count) and validated by `parseProject`, like every other domain
-  fixture.
+  a ten-minute arrangement with `50 × trackCount` placements (50 per track
+  spread across the ten minutes — the same per-track density as the PRD 9.3
+  reference arrangement, so the 50-track case reaches its "at least 2,500
+  clip placements"), `2 × trackCount` automation lanes, and ~40% of tracks as
+  waveform-bearing audio tracks. Deterministic (seeded by track count) and
+  validated by `parseProject`, like every other domain fixture.
 - `createArrangementSpikeFixtures()` — all three, keyed by track count, for
   tests or tooling that want to iterate over the full matrix.
 
@@ -94,10 +95,17 @@ This is `playwright test --config=playwright.bench.config.ts` (a
    selection** — for 120 animation frames apiece, through the same public API
    a real gesture would use (`window.__arrangementSpike`,
    `ArrangementSpikeHandle` in `ArrangementSpike.tsx`).
-3. Collects, per trace: frame count, median and p95 frame time, long-task
-   count and total duration (Chromium-only `PerformanceObserver`
-   `"longtask"` entries — Firefox/WebKit simply report zero), redraw counts
-   per layer, and JS heap usage where the browser exposes it
+3. Collects, per trace: frame count; median and p95 **frame time**
+   (`medianFrameMs`/`p95FrameMs` — the wall-clock interval between
+   consecutive presented animation frames, the basis PRD 9.3's budget
+   ("median frame time at or below 16.7 ms, p95 at or below 33 ms") is
+   stated against, spanning rasterization/compositing/layout/reactive work
+   as well as the draw call itself); median and p95 **draw time**
+   (`medianDrawMs`/`p95DrawMs` — just the synchronous canvas draw-command
+   issue duration, a strict lower bound on frame cost, not frame time);
+   long-task count and total duration (Chromium-only `PerformanceObserver`
+   `"longtask"` entries — Firefox/WebKit simply report zero); redraw counts
+   per layer; and JS heap usage where the browser exposes it
    (`performance.memory`, Chromium-only).
 4. Writes everything to `docs/perf/arrangement-spike-baseline.json`, tagged
    with the browser and the hardware (`os.cpus()`, `os.totalmem()`,

--- a/docs/arrangement-renderer-spike.md
+++ b/docs/arrangement-renderer-spike.md
@@ -123,19 +123,34 @@ on the physical baseline device.
 
 ## Baseline status
 
-**No baseline is checked in by this change.** `bun run test:browser:install`
-downloads Playwright's browser binaries from `cdn.playwright.dev`; the
-sandbox this task was implemented in has no outbound access to that host
-(the same constraint `docs/testing.md` already documents for
-`bun run test:browser`), so `bench:arrangement` could not actually be
-executed here. `playwright test --config=playwright.bench.config.ts --list`
-does not need the binaries and confirms the harness itself is wired up
-correctly (12 tests: 3 track counts × 4 traces).
+**A baseline is checked in**: `docs/perf/arrangement-spike-baseline.json`.
+`bun run test:browser:install` downloads Playwright's browser binaries from
+`cdn.playwright.dev`; the sandbox this task (and its review pass) ran in has
+no outbound access to that host (the same constraint `docs/testing.md`
+already documents for `bun run test:browser`), so `bench:arrangement` could
+not run there. Rather than land the task with the checkbox unmet, the review
+pass ran it for real on this repository's own GitHub Actions CI, which does
+have outbound access — see `.github/workflows/bench-arrangement.yml`
+(`workflow_dispatch`, currently invokable only once it exists on the default
+branch; a one-off job on `ci.yml`'s existing push trigger produced this
+baseline in the meantime) — and committed the resulting numbers here.
 
-Per PRD 9.3's own instruction — "Measuring a spike on unrepresentative
-hardware and declaring the budget met is a worse outcome than an honest early
-number" — no fabricated or borrowed numbers are substituted here. The next
-agent or developer with browser access should run:
+Recorded on: Linux x64, AMD EPYC 9V74 80-Core Processor (GitHub Actions
+`ubuntu-latest` runner, 4 vCPUs allotted, 15.6 GiB RAM), Chromium 151.0.7922.34.
+This is **not** the PRD 9.3 physical baseline device (a 2019 13-inch Intel
+MacBook Pro class machine, 8 GB RAM, integrated graphics) — that device binds
+at `ARR-005`/`HARD-001`, not here — but per PRD 9.3's own instruction,
+"Measuring a spike on unrepresentative hardware and declaring the budget met
+is a worse outcome than an honest early number," so this is recorded exactly
+as measured rather than adjusted or waited on. All twelve traces land at or
+near the ~16.7 ms vsync cadence with p95 no higher than ~17.2 ms and zero
+long tasks — a CI headless-Chromium runner under light load is not a
+substitute for the physical baseline device's stress case, so this should
+read as "the harness runs correctly end-to-end and produces sane numbers,"
+not as evidence the PRD 9.3 budgets are met.
+
+To refresh this baseline later (e.g. on the physical baseline device, or
+after a renderer change worth re-measuring), run:
 
 ```sh
 bun run test:browser:install   # one-time
@@ -143,9 +158,9 @@ bun run bench:arrangement
 ```
 
 and commit the resulting `docs/perf/arrangement-spike-baseline.json`, noting
-the machine (ideally the physical baseline device from PRD 9.3: a 2019
-13-inch Intel MacBook Pro class machine, 8 GB RAM, integrated graphics — but
-any machine is an honest starting point per the "Phase 0 owes... honest
-recorded numbers" instruction) and browser version it ran on, which the
-harness records automatically from `os` and Playwright's own browser
-metadata.
+the machine and browser version it ran on, which the harness records
+automatically from `os` and Playwright's own browser metadata. From a
+sandbox without `cdn.playwright.dev` access, dispatch
+`bench-arrangement.yml` instead (`gh workflow run bench-arrangement.yml` or
+the Actions UI) and pull the `arrangement-spike-baseline` artifact it
+uploads.

--- a/docs/arrangement-renderer-spike.md
+++ b/docs/arrangement-renderer-spike.md
@@ -1,0 +1,143 @@
+# Arrangement renderer spike and measurement harness
+
+| Field | Value |
+| --- | --- |
+| Status | Implemented (`FND-008`) |
+| Scope | Disposable hybrid virtualized-DOM/Canvas 2D spike, retained renderer-agnostic projection/geometry contracts, and the scripted-trace measurement harness Phase 2 (`ARR-005`) will enforce budgets with |
+
+Related documents: [Product requirements](./prd.md) ([7.5 ARR-01](./prd.md#75-arrangement), [9.3 Arrangement renderer decision](./prd.md#93-arrangement-renderer-decision), [Performance budgets](./prd.md#performance-budgets)), [backlog](./backlog.md#fnd-008---arrangement-renderer-spike-and-measurement-harness)
+
+**This task is not gated on hitting the PRD frame budgets, and not gated on
+the physical baseline device.** Budgets bind at `ARR-005` (Phase 2) and
+`HARD-001` (Phase 4). What this task owes — and what this document is the map
+of — is deterministic fixtures, a working spike, scripted traces, a
+single-command harness, and honestly recorded numbers from whatever hardware
+ran them.
+
+## What's retained vs. disposable
+
+| Path | Status | Why |
+| --- | --- | --- |
+| `src/arrangement/geometry.ts` | Retained | Pure viewport/row/zoom math (PRD 9.3 "Viewport and scrolling model"). No DOM/Canvas/SolidJS imports. |
+| `src/arrangement/projection.ts` | Retained | Builds the renderer-specific `ArrangementProjection` PRD 9.3 calls for: stable IDs, integer musical bounds, track order, colors, labels, compact preview data, revision counters, viewport culling, hit testing. |
+| `src/arrangement/revision.ts` | Retained | Object-identity revision counters — cheap because domain state is edited immutably (`produce`), so reference equality already tells you what changed. |
+| `src/arrangement/waveformCache.ts` | Retained (cache contract; generator is a stand-in) | LRU, multi-resolution, keyed by `(assetId, revision)`, budgeted at the PRD's `128 MiB`. `generateSyntheticPeaks` is the one piece a real audio-decode pipeline replaces later. |
+| `src/arrangement/spike/*` | **Disposable** | The actual Canvas-drawing Solid component, layer-drawing code, and measurement instrumentation. Wired to one specific approach and one specific harness; see `spike/README.md`. `ARR-005` replaces this, it does not grow it. |
+| `src/routes/spike/arrangement.tsx` | Disposable | Unlinked route that mounts the spike for manual poking and for the harness to drive. |
+| `perf/arrangement.bench.spec.ts`, `playwright.bench.config.ts` | Harness (kept until superseded) | Drives the scripted traces and writes the baseline. |
+
+Reusing this task's retained pieces (rather than a second, different
+implementation) is expected of `ARR-005`; growing the spike's disposable UI
+into a production component is not — see the backlog task's final acceptance
+line: "experimental UI is not treated as production merely because it
+benchmarks well."
+
+## Fixtures
+
+`src/domain/fixtures.ts` adds:
+
+- `createReferenceProject({ waveformTrackCount, ... })` — the existing PRD 9.3
+  reference-arrangement fixture (50 tracks, ten minutes, 2,500 placements, 100
+  automation lanes by default) gains an optional `waveformTrackCount`: that
+  many of its tracks become `audio` tracks holding an `audioLoop` clip instead
+  of an `instrument` track holding a note clip, so waveform-preview placements
+  get fixture coverage too, not just note-preview ones. Defaults to `0`, so
+  every existing caller/test is unaffected.
+- `createArrangementSpikeProject(trackCount)` — the task's three benchmark
+  fixtures: `20`, `40`, or `50` tracks (`ARRANGEMENT_SPIKE_TRACK_COUNTS`), each
+  a ten-minute arrangement with `20 × trackCount` placements (dense: ~20 per
+  track spread across the ten minutes), `2 × trackCount` automation lanes, and
+  ~40% of tracks as waveform-bearing audio tracks. Deterministic (seeded by
+  track count) and validated by `parseProject`, like every other domain
+  fixture.
+- `createArrangementSpikeFixtures()` — all three, keyed by track count, for
+  tests or tooling that want to iterate over the full matrix.
+
+## The spike
+
+`src/arrangement/spike/ArrangementSpike.tsx`, mounted at
+`/spike/arrangement?tracks=20|40|50` (`src/routes/spike/arrangement.tsx`).
+Implements, per the backlog task's acceptance checkboxes:
+
+- **Viewport culling** through `visiblePlacements`/`visiblePlacementsForTrack`.
+- **Layered invalidation**: three stacked canvases (background/content/
+  interaction), each redrawn only for its own dirty reason, coalesced to at
+  most one draw per animation frame, idle when nothing is dirty.
+- **Pointer hit testing** via `hitTestArrangement`, checking resize handles
+  before the placement body.
+- **Wheel/pinch zoom anchoring** via `zoomAtAnchor` — plain wheel scrolls,
+  ctrl/cmd-wheel zooms anchored under the pointer.
+- **Virtualized track headers** — a DOM `<ul>`/`<li>` list windowed to the
+  visible row range plus overscan, sharing the same row metrics and scroll
+  state as the canvas.
+
+See `src/arrangement/spike/README.md` for the retained/disposable boundary in
+more detail.
+
+## Running the measurement harness
+
+```sh
+bun run bench:arrangement
+```
+
+This is `playwright test --config=playwright.bench.config.ts` (a
+`prebench:arrangement` hook generates `public/samples/*` first, matching
+`pretest:browser`, since the harness loads the real app shell). It:
+
+1. Starts the dev server (`bun run dev`, `VITE_MOCK_BACKEND=true`) on its own
+   port (`3100`) so it can run alongside `bun run test:browser` without
+   fighting over one.
+2. For each of the three benchmark track counts, opens
+   `/spike/arrangement?tracks=<n>` and, once
+   `[data-testid="arrangement-spike-ready"]` is attached, runs each of the
+   four scripted traces the backlog task requires — **scroll, zoom, seek,
+   selection** — for 120 animation frames apiece, through the same public API
+   a real gesture would use (`window.__arrangementSpike`,
+   `ArrangementSpikeHandle` in `ArrangementSpike.tsx`).
+3. Collects, per trace: frame count, median and p95 frame time, long-task
+   count and total duration (Chromium-only `PerformanceObserver`
+   `"longtask"` entries — Firefox/WebKit simply report zero), redraw counts
+   per layer, and JS heap usage where the browser exposes it
+   (`performance.memory`, Chromium-only).
+4. Writes everything to `docs/perf/arrangement-spike-baseline.json`, tagged
+   with the browser and the hardware (`os.cpus()`, `os.totalmem()`,
+   platform/arch) that produced it.
+
+Only Chromium is configured for the bench project today (the harness measures
+one representative engine rather than tripling the run; nothing prevents
+adding `firefox`/`webkit` projects to `playwright.bench.config.ts` later the
+same way `playwright.config.ts` does for the functional E2E suite).
+
+This suite is not part of `bun run test`, `bun run test:browser`, or CI's
+gating matrix — it produces a baseline artifact, not a pass/fail signal, and
+per the backlog task, it is not required to hit the PRD 9.3 budgets or to run
+on the physical baseline device.
+
+## Baseline status
+
+**No baseline is checked in by this change.** `bun run test:browser:install`
+downloads Playwright's browser binaries from `cdn.playwright.dev`; the
+sandbox this task was implemented in has no outbound access to that host
+(the same constraint `docs/testing.md` already documents for
+`bun run test:browser`), so `bench:arrangement` could not actually be
+executed here. `playwright test --config=playwright.bench.config.ts --list`
+does not need the binaries and confirms the harness itself is wired up
+correctly (12 tests: 3 track counts × 4 traces).
+
+Per PRD 9.3's own instruction — "Measuring a spike on unrepresentative
+hardware and declaring the budget met is a worse outcome than an honest early
+number" — no fabricated or borrowed numbers are substituted here. The next
+agent or developer with browser access should run:
+
+```sh
+bun run test:browser:install   # one-time
+bun run bench:arrangement
+```
+
+and commit the resulting `docs/perf/arrangement-spike-baseline.json`, noting
+the machine (ideally the physical baseline device from PRD 9.3: a 2019
+13-inch Intel MacBook Pro class machine, 8 GB RAM, integrated graphics — but
+any machine is an honest starting point per the "Phase 0 owes... honest
+recorded numbers" instruction) and browser version it ran on, which the
+harness records automatically from `os` and Playwright's own browser
+metadata.

--- a/docs/perf/arrangement-spike-baseline.json
+++ b/docs/perf/arrangement-spike-baseline.json
@@ -1,0 +1,222 @@
+{
+	"generatedAt": "2026-07-25T18:21:48.916Z",
+	"task": "FND-008",
+	"note": "Phase 0 renderer-spike baseline. Not gated on the PRD 9.3 performance budgets, which bind at ARR-005/HARD-001 on the physical baseline device — see docs/arrangement-renderer-spike.md. These numbers are whatever this run's hardware measured, recorded honestly rather than compared against a target.",
+	"hardware": {
+		"platform": "linux",
+		"arch": "x64",
+		"cpuModel": "AMD EPYC 9V74 80-Core Processor",
+		"cpuCount": 4,
+		"totalMemoryGiB": 15.6
+	},
+	"browser": {
+		"name": "chromium",
+		"version": "151.0.7922.34"
+	},
+	"results": [
+		{
+			"trackCount": 20,
+			"trace": "scroll",
+			"frameCount": 120,
+			"medianFrameMs": 16.60000000000582,
+			"p95FrameMs": 17.199999999998546,
+			"medianDrawMs": 0.6999999999970896,
+			"p95DrawMs": 0.9050000000082943,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 120,
+				"content": 120,
+				"interaction": 120
+			},
+			"heapUsedMB": 18.405914306640625
+		},
+		{
+			"trackCount": 20,
+			"trace": "zoom",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.910000000007855,
+			"medianDrawMs": 0.6000000000058208,
+			"p95DrawMs": 0.9000000000087311,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 120,
+				"content": 120,
+				"interaction": 120
+			},
+			"heapUsedMB": 15.354156494140625
+		},
+		{
+			"trackCount": 20,
+			"trace": "seek",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.80000000000291,
+			"medianDrawMs": 0.10000000000582077,
+			"p95DrawMs": 0.19999999999708962,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 0,
+				"content": 0,
+				"interaction": 120
+			},
+			"heapUsedMB": 12.111663818359375
+		},
+		{
+			"trackCount": 20,
+			"trace": "selection",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.70000000001164,
+			"medianDrawMs": 0.09999999999126885,
+			"p95DrawMs": 0.19999999999708962,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 0,
+				"content": 0,
+				"interaction": 120
+			},
+			"heapUsedMB": 12.77923583984375
+		},
+		{
+			"trackCount": 40,
+			"trace": "scroll",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 17,
+			"medianDrawMs": 0.8000000000029104,
+			"p95DrawMs": 1.105000000005384,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 120,
+				"content": 120,
+				"interaction": 120
+			},
+			"heapUsedMB": 14.495849609375
+		},
+		{
+			"trackCount": 40,
+			"trace": "zoom",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.89999999999418,
+			"medianDrawMs": 0.8000000000029104,
+			"p95DrawMs": 1.105000000005384,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 120,
+				"content": 120,
+				"interaction": 120
+			},
+			"heapUsedMB": 16.307830810546875
+		},
+		{
+			"trackCount": 40,
+			"trace": "seek",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.710000000009313,
+			"medianDrawMs": 0.09999999999126885,
+			"p95DrawMs": 0.19999999999708962,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 0,
+				"content": 0,
+				"interaction": 120
+			},
+			"heapUsedMB": 14.495849609375
+		},
+		{
+			"trackCount": 40,
+			"trace": "selection",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.80000000000291,
+			"medianDrawMs": 0.10000000000582077,
+			"p95DrawMs": 0.19999999999708962,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 0,
+				"content": 0,
+				"interaction": 120
+			},
+			"heapUsedMB": 14.495849609375
+		},
+		{
+			"trackCount": 50,
+			"trace": "scroll",
+			"frameCount": 120,
+			"medianFrameMs": 16.60000000000582,
+			"p95FrameMs": 17,
+			"medianDrawMs": 0.8000000000029104,
+			"p95DrawMs": 1.2050000000112047,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 120,
+				"content": 120,
+				"interaction": 120
+			},
+			"heapUsedMB": 13.637542724609375
+		},
+		{
+			"trackCount": 50,
+			"trace": "zoom",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.90000000000873,
+			"medianDrawMs": 0.6999999999970896,
+			"p95DrawMs": 1.1000000000058208,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 120,
+				"content": 120,
+				"interaction": 120
+			},
+			"heapUsedMB": 15.354156494140625
+		},
+		{
+			"trackCount": 50,
+			"trace": "seek",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.71000000001077,
+			"medianDrawMs": 0.09999999999126885,
+			"p95DrawMs": 0.19999999999708962,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 0,
+				"content": 0,
+				"interaction": 120
+			},
+			"heapUsedMB": 13.637542724609375
+		},
+		{
+			"trackCount": 50,
+			"trace": "selection",
+			"frameCount": 120,
+			"medianFrameMs": 16.69999999999709,
+			"p95FrameMs": 16.80000000000291,
+			"medianDrawMs": 0.10000000000582077,
+			"p95DrawMs": 0.19999999999708962,
+			"longTaskCount": 0,
+			"longTaskTotalMs": 0,
+			"redrawCounts": {
+				"background": 0,
+				"content": 0,
+				"interaction": 120
+			},
+			"heapUsedMB": 14.495849609375
+		}
+	]
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,6 +66,10 @@ Three projects run: `chromium`, `firefox`, `webkit`. Per the PRD section 10 supp
 
 `bun run test:browser:install` (`playwright install --with-deps chromium firefox webkit`) downloads browser binaries from Playwright's CDN. That download needs outbound access to `cdn.playwright.dev`; a locked-down sandbox that blocks that host cannot run this suite even though the config and tests are otherwise valid (verify with `bunx playwright test --list`, which does not need the binaries).
 
+## Arrangement renderer spike measurement harness
+
+`bun run bench:arrangement` (`playwright.bench.config.ts`, `perf/`) is a separate, non-gating Playwright suite: the `FND-008` renderer-spike measurement harness, not a functional or CI-blocking suite. See [`docs/arrangement-renderer-spike.md`](./arrangement-renderer-spike.md) for what it measures and where its baseline is checked in. It needs the same browser binaries as the Browser E2E suite above.
+
 ## `check` vs `check:ci`
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
 		"pretest:browser": "node scripts/generate-samples.mjs",
 		"test:browser": "playwright test",
 		"test:browser:install": "playwright install --with-deps chromium firefox webkit",
+		"prebench:arrangement": "node scripts/generate-samples.mjs",
+		"bench:arrangement": "playwright test --config=playwright.bench.config.ts",
 		"typecheck": "tsc --noEmit",
 		"check": "tsc --noEmit && biome check --write",
 		"check:ci": "tsc --noEmit && biome check"

--- a/perf/arrangement.bench.spec.ts
+++ b/perf/arrangement.bench.spec.ts
@@ -1,0 +1,116 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import type {
+	ArrangementSpikeHandle,
+	TraceName,
+	TraceResult,
+} from "../src/arrangement/spike/ArrangementSpike";
+import {
+	ARRANGEMENT_SPIKE_TRACK_COUNTS,
+	type ArrangementSpikeTrackCount,
+} from "../src/domain/fixtures";
+
+/**
+ * The FND-008 measurement harness (backlog task; PRD section 9.3, "When
+ * these budgets are enforced"). Runs the four scripted traces the task
+ * requires — scroll, zoom, seek, selection — against all three benchmark
+ * track counts, and writes the collected frame-time/long-task/redraw/memory
+ * numbers to `docs/perf/arrangement-spike-baseline.json` alongside the
+ * hardware and browser that produced them.
+ *
+ * Single documented command: `bun run bench:arrangement` (see
+ * `docs/arrangement-renderer-spike.md`). This is not gated on hitting any
+ * PRD budget and does not fail the suite on a slow number — it fails only if
+ * the harness itself is broken (the spike doesn't load, an API is missing).
+ */
+
+const TRACE_NAMES: readonly TraceName[] = [
+	"scroll",
+	"zoom",
+	"seek",
+	"selection",
+];
+const OUTPUT_PATH = fileURLToPath(
+	new URL("../docs/perf/arrangement-spike-baseline.json", import.meta.url),
+);
+
+interface BaselineResult {
+	readonly trackCount: ArrangementSpikeTrackCount;
+	readonly trace: TraceName;
+	readonly frameCount: number;
+	readonly medianFrameMs: number;
+	readonly p95FrameMs: number;
+	readonly longTaskCount: number;
+	readonly longTaskTotalMs: number;
+	readonly redrawCounts: TraceResult["redrawCounts"];
+	readonly heapUsedMB: number | null;
+}
+
+const results: BaselineResult[] = [];
+let browserVersion: string | undefined;
+
+for (const trackCount of ARRANGEMENT_SPIKE_TRACK_COUNTS) {
+	test.describe(`${trackCount}-track arrangement`, () => {
+		for (const trace of TRACE_NAMES) {
+			test(`${trace} trace`, async ({ page }) => {
+				browserVersion ??= page.context().browser()?.version();
+
+				await page.goto(`/spike/arrangement?tracks=${trackCount}`);
+				await expect(
+					page.locator('[data-testid="arrangement-spike-ready"]'),
+				).toBeAttached();
+				// Let the initial layered draw (background/content/interaction)
+				// settle before measuring, so first-paint cost isn't attributed to
+				// the scripted trace.
+				await page.waitForTimeout(250);
+
+				const result = await page.evaluate(async (traceName: TraceName) => {
+					const handle = (
+						window as unknown as {
+							__arrangementSpike?: ArrangementSpikeHandle;
+						}
+					).__arrangementSpike;
+					if (!handle) {
+						throw new Error("window.__arrangementSpike was not installed");
+					}
+					return handle.runScriptedTrace(traceName, 120);
+				}, trace);
+
+				results.push({ trackCount, ...result });
+			});
+		}
+	});
+}
+
+test.afterAll(async ({ browserName }) => {
+	if (results.length === 0) return;
+
+	const report = {
+		generatedAt: new Date().toISOString(),
+		task: "FND-008",
+		note:
+			"Phase 0 renderer-spike baseline. Not gated on the PRD 9.3 " +
+			"performance budgets, which bind at ARR-005/HARD-001 on the physical " +
+			"baseline device — see docs/arrangement-renderer-spike.md. These " +
+			"numbers are whatever this run's hardware measured, recorded " +
+			"honestly rather than compared against a target.",
+		hardware: {
+			platform: os.platform(),
+			arch: os.arch(),
+			cpuModel: os.cpus()[0]?.model ?? "unknown",
+			cpuCount: os.cpus().length,
+			totalMemoryGiB: Number((os.totalmem() / 2 ** 30).toFixed(1)),
+		},
+		browser: {
+			name: browserName,
+			version: browserVersion ?? "unknown",
+		},
+		results,
+	};
+
+	await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+	await writeFile(OUTPUT_PATH, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+});

--- a/perf/arrangement.bench.spec.ts
+++ b/perf/arrangement.bench.spec.ts
@@ -43,6 +43,8 @@ interface BaselineResult {
 	readonly frameCount: number;
 	readonly medianFrameMs: number;
 	readonly p95FrameMs: number;
+	readonly medianDrawMs: number;
+	readonly p95DrawMs: number;
 	readonly longTaskCount: number;
 	readonly longTaskTotalMs: number;
 	readonly redrawCounts: TraceResult["redrawCounts"];

--- a/playwright.bench.config.ts
+++ b/playwright.bench.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3100;
+const baseURL = `http://127.0.0.1:${PORT}`;
+
+// The FND-008 arrangement-spike measurement harness (backlog task; PRD
+// section 9.3 "When these budgets are enforced"). Separate from
+// `playwright.config.ts`/`e2e/` on purpose:
+//
+// - This suite drives `/spike/arrangement`, a disposable spike route
+//   (`src/routes/spike/arrangement.tsx`), not product behavior — it has
+//   nothing to do with the functional E2E suite's job.
+// - It runs on its own port so `bun run test:browser` and
+//   `bun run bench:arrangement` can run at the same time without fighting
+//   over a dev server.
+// - It is not gated on the PRD 9.3 performance budgets and is not part of
+//   the CI-blocking test matrix; it produces a checked-in baseline
+//   measurement (`docs/perf/arrangement-spike-baseline.json`), not a
+//   pass/fail signal. See `docs/arrangement-renderer-spike.md`.
+export default defineConfig({
+	testDir: "./perf",
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: 0,
+	reporter: process.env.CI ? [["github"], ["list"]] : "list",
+	timeout: 120_000,
+	use: {
+		baseURL,
+		trace: "retain-on-failure",
+	},
+	webServer: {
+		// See `playwright.config.ts` for why `--host 127.0.0.1` matters.
+		command: `bun run dev --host 127.0.0.1 --port ${PORT}`,
+		url: baseURL,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			VITE_MOCK_BACKEND: "true",
+		},
+	},
+	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/src/arrangement/geometry.test.ts
+++ b/src/arrangement/geometry.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildRowOffsets,
+	pixelsToTicks,
+	type RowMetrics,
+	rowIndexAtOffset,
+	ticksToPixels,
+	type Viewport,
+	visibleRowRange,
+	visibleTickRange,
+	zoomAtAnchor,
+} from "./geometry";
+
+const rowMetrics: RowMetrics = { trackHeightPx: 32, headerHeightPx: 32 };
+
+function viewport(overrides: Partial<Viewport> = {}): Viewport {
+	return {
+		scrollLeft: 0,
+		scrollTop: 0,
+		width: 800,
+		height: 480,
+		pixelsPerTick: 0.1,
+		...overrides,
+	};
+}
+
+describe("tick/pixel conversion", () => {
+	it("round trips ticks through pixels at a given zoom", () => {
+		const port = viewport({ pixelsPerTick: 0.25 });
+		expect(ticksToPixels(400, port)).toBe(100);
+		expect(pixelsToTicks(100, port)).toBe(400);
+	});
+});
+
+describe("visibleTickRange", () => {
+	it("covers exactly the scrolled viewport width at pixelsPerTick 1", () => {
+		const port = viewport({ scrollLeft: 500, width: 800, pixelsPerTick: 1 });
+		expect(visibleTickRange(port)).toEqual({ startTick: 500, endTick: 1300 });
+	});
+
+	it("expands by the overscan on both sides", () => {
+		const port = viewport({ scrollLeft: 500, width: 800, pixelsPerTick: 1 });
+		expect(visibleTickRange(port, 50)).toEqual({
+			startTick: 450,
+			endTick: 1350,
+		});
+	});
+
+	it("never returns a negative start tick even with a large overscan", () => {
+		const port = viewport({ scrollLeft: 10, width: 800, pixelsPerTick: 1 });
+		expect(visibleTickRange(port, 1000).startTick).toBe(0);
+	});
+});
+
+describe("row offsets and lookup", () => {
+	it("builds cumulative offsets for a uniform row height", () => {
+		expect(buildRowOffsets(3, rowMetrics)).toEqual([0, 32, 64, 96]);
+	});
+
+	it("finds the row containing a given y", () => {
+		const offsets = buildRowOffsets(5, rowMetrics);
+		expect(rowIndexAtOffset(offsets, 0)).toBe(0);
+		expect(rowIndexAtOffset(offsets, 31)).toBe(0);
+		expect(rowIndexAtOffset(offsets, 32)).toBe(1);
+		expect(rowIndexAtOffset(offsets, 159)).toBe(4);
+	});
+
+	it("returns -1 above the first row and rowCount at/after the last", () => {
+		const offsets = buildRowOffsets(5, rowMetrics);
+		expect(rowIndexAtOffset(offsets, -1)).toBe(-1);
+		expect(rowIndexAtOffset(offsets, 160)).toBe(5);
+	});
+
+	it("reports -1/empty for zero rows", () => {
+		expect(rowIndexAtOffset([0], 0)).toBe(-1);
+	});
+});
+
+describe("visibleRowRange", () => {
+	it("finds the visible rows for a scrolled viewport", () => {
+		const offsets = buildRowOffsets(50, rowMetrics);
+		const port = viewport({ scrollTop: 320, height: 480 });
+		// rows 10..24 exactly fill 320..800
+		expect(visibleRowRange(offsets, port)).toEqual({
+			startRow: 10,
+			endRow: 25,
+		});
+	});
+
+	it("expands by overscan rows and clamps to valid indices", () => {
+		const offsets = buildRowOffsets(50, rowMetrics);
+		const port = viewport({ scrollTop: 0, height: 480 });
+		const range = visibleRowRange(offsets, port, 3);
+		expect(range.startRow).toBe(0);
+		expect(range.endRow).toBe(15 + 3);
+	});
+
+	it("never exceeds the last valid row", () => {
+		const offsets = buildRowOffsets(5, rowMetrics);
+		const port = viewport({ scrollTop: 0, height: 4800 });
+		expect(visibleRowRange(offsets, port, 10)).toEqual({
+			startRow: 0,
+			endRow: 4,
+		});
+	});
+});
+
+describe("zoomAtAnchor", () => {
+	it("keeps the tick under the anchor fixed after zooming in", () => {
+		const port = viewport({ scrollLeft: 100, pixelsPerTick: 1 });
+		const anchorX = 50; // tick 150 before zoom
+		const anchorTickBefore = pixelsToTicks(port.scrollLeft + anchorX, port);
+
+		const result = zoomAtAnchor({
+			viewport: port,
+			nextPixelsPerTick: 2,
+			anchorX,
+		});
+		const anchorTickAfter = pixelsToTicks(result.scrollLeft + anchorX, {
+			pixelsPerTick: result.pixelsPerTick,
+		});
+
+		expect(anchorTickAfter).toBeCloseTo(anchorTickBefore, 6);
+		expect(result.pixelsPerTick).toBe(2);
+	});
+
+	it("keeps the anchor tick fixed after zooming out too", () => {
+		const port = viewport({ scrollLeft: 1000, pixelsPerTick: 2 });
+		const anchorX = 200;
+		const anchorTickBefore = pixelsToTicks(port.scrollLeft + anchorX, port);
+
+		const result = zoomAtAnchor({
+			viewport: port,
+			nextPixelsPerTick: 0.5,
+			anchorX,
+		});
+		const anchorTickAfter = pixelsToTicks(result.scrollLeft + anchorX, {
+			pixelsPerTick: result.pixelsPerTick,
+		});
+
+		expect(anchorTickAfter).toBeCloseTo(anchorTickBefore, 6);
+	});
+
+	it("never scrolls to a negative offset", () => {
+		const port = viewport({ scrollLeft: 0, pixelsPerTick: 1 });
+		const result = zoomAtAnchor({
+			viewport: port,
+			nextPixelsPerTick: 0.1,
+			anchorX: 500,
+		});
+		expect(result.scrollLeft).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/src/arrangement/geometry.ts
+++ b/src/arrangement/geometry.ts
@@ -1,0 +1,180 @@
+/**
+ * Renderer-agnostic viewport and row geometry (PRD section 9.3, "Viewport and
+ * scrolling model" and "Culling, projection, and caches").
+ *
+ * Everything here is a pure function over plain data: no DOM, no Canvas, no
+ * SolidJS. That is deliberate — this is the retained contract the FND-008
+ * spike's disposable Canvas UI sits on top of, and the same contract a
+ * production renderer (`ARR-005`) can keep using without the spike's UI code.
+ */
+
+/** Uniform per-row sizing. Rows are the same height today; the prefix-sum
+ * helpers below do not assume that and keep working if rows vary later. */
+export interface RowMetrics {
+	/** Height in CSS pixels of one track's canvas row. */
+	readonly trackHeightPx: number;
+	/** Height in CSS pixels of one DOM track header. Should equal
+	 * `trackHeightPx` so the virtualized header column and the canvas rows
+	 * line up pixel-for-pixel. */
+	readonly headerHeightPx: number;
+}
+
+export interface Viewport {
+	/** Horizontal scroll offset in CSS pixels. */
+	readonly scrollLeft: number;
+	/** Vertical scroll offset in CSS pixels. */
+	readonly scrollTop: number;
+	/** Viewport width in CSS pixels. */
+	readonly width: number;
+	/** Viewport height in CSS pixels. */
+	readonly height: number;
+	/** CSS pixels per musical tick. Zoom is a change to this value alone —
+	 * it never changes canvas backing-store size on its own. */
+	readonly pixelsPerTick: number;
+}
+
+export interface TickRange {
+	readonly startTick: number;
+	readonly endTick: number;
+}
+
+export interface RowRange {
+	readonly startRow: number;
+	readonly endRow: number;
+}
+
+/** Musical tick -> viewport-local CSS pixel (not yet scroll-adjusted). */
+export function ticksToPixels(
+	ticks: number,
+	viewport: Pick<Viewport, "pixelsPerTick">,
+): number {
+	return ticks * viewport.pixelsPerTick;
+}
+
+/** Viewport-local CSS pixel (not scroll-adjusted) -> musical tick. */
+export function pixelsToTicks(
+	pixels: number,
+	viewport: Pick<Viewport, "pixelsPerTick">,
+): number {
+	return pixels / viewport.pixelsPerTick;
+}
+
+/**
+ * The tick range currently visible, expanded by `overscanPx` on each side so
+ * culling can keep a small buffer of off-screen content ready without
+ * scanning the whole arrangement.
+ */
+export function visibleTickRange(
+	viewport: Viewport,
+	overscanPx = 0,
+): TickRange {
+	const startTick = pixelsToTicks(
+		Math.max(0, viewport.scrollLeft - overscanPx),
+		viewport,
+	);
+	const endTick = pixelsToTicks(
+		viewport.scrollLeft + viewport.width + overscanPx,
+		viewport,
+	);
+	return {
+		startTick: Math.max(0, Math.floor(startTick)),
+		endTick: Math.ceil(endTick),
+	};
+}
+
+/**
+ * Cumulative row-top offsets in CSS pixels: `offsets[i]` is the top of row
+ * `i`, and `offsets[rowCount]` is the total content height. Building this
+ * once per row-count/metrics change lets both the header column and the
+ * canvas find the visible row range with a binary search instead of a linear
+ * scan, even once tracks can have per-row heights.
+ */
+export function buildRowOffsets(
+	rowCount: number,
+	rowMetrics: RowMetrics,
+): number[] {
+	const offsets = new Array<number>(rowCount + 1);
+	offsets[0] = 0;
+	for (let index = 0; index < rowCount; index += 1) {
+		offsets[index + 1] = offsets[index] + rowMetrics.trackHeightPx;
+	}
+	return offsets;
+}
+
+/**
+ * The row index whose span `[offsets[i], offsets[i + 1])` contains `y`.
+ * Returns `-1` for a `y` above the first row and `rowCount` (one past the
+ * last valid index) for a `y` at or below the last row's bottom edge, so
+ * callers can clamp deliberately rather than by accident.
+ */
+export function rowIndexAtOffset(
+	rowOffsets: readonly number[],
+	y: number,
+): number {
+	const rowCount = rowOffsets.length - 1;
+	if (rowCount <= 0) return -1;
+	if (y < rowOffsets[0]) return -1;
+	if (y >= rowOffsets[rowCount]) return rowCount;
+	let low = 0;
+	let high = rowCount - 1;
+	while (low < high) {
+		const mid = (low + high + 1) >> 1;
+		if (rowOffsets[mid] <= y) {
+			low = mid;
+		} else {
+			high = mid - 1;
+		}
+	}
+	return low;
+}
+
+/** The visible row range, expanded by `overscanRows` and clamped to valid indices. */
+export function visibleRowRange(
+	rowOffsets: readonly number[],
+	viewport: Pick<Viewport, "scrollTop" | "height">,
+	overscanRows = 0,
+): RowRange {
+	const rowCount = rowOffsets.length - 1;
+	if (rowCount <= 0) return { startRow: 0, endRow: -1 };
+	const firstRow = rowIndexAtOffset(rowOffsets, viewport.scrollTop);
+	const lastRow = rowIndexAtOffset(
+		rowOffsets,
+		viewport.scrollTop + viewport.height,
+	);
+	const clampedFirstRow = Math.min(Math.max(firstRow, 0), rowCount - 1);
+	const clampedLastRow = Math.min(Math.max(lastRow, 0), rowCount - 1);
+	// Overscan is clamped again after being applied: expanding the range must
+	// never produce an index outside `[0, rowCount)`, which callers rely on
+	// treating `endRow` as a directly indexable row.
+	const startRow = Math.max(0, clampedFirstRow - overscanRows);
+	const endRow = Math.min(rowCount - 1, clampedLastRow + overscanRows);
+	return { startRow, endRow };
+}
+
+export interface ZoomAnchorInput {
+	readonly viewport: Viewport;
+	/** The pixels-per-tick value to zoom to. Callers clamp this to whatever
+	 * min/max zoom the UI allows before calling. */
+	readonly nextPixelsPerTick: number;
+	/** Viewport-local x (e.g. pointer position) that must stay under the
+	 * same musical tick after the zoom. */
+	readonly anchorX: number;
+}
+
+/**
+ * Zoom is "a change to the musical-time transform anchored under the
+ * pointer, selection, or playhead" (PRD 9.3): the tick under `anchorX` before
+ * the zoom must still be under `anchorX` after it, so scrolling never jumps
+ * on the user mid-gesture.
+ */
+export function zoomAtAnchor(
+	input: ZoomAnchorInput,
+): Pick<Viewport, "pixelsPerTick" | "scrollLeft"> {
+	const { viewport, nextPixelsPerTick, anchorX } = input;
+	const anchorTick = pixelsToTicks(viewport.scrollLeft + anchorX, viewport);
+	const nextScrollLeft = anchorTick * nextPixelsPerTick - anchorX;
+	return {
+		pixelsPerTick: nextPixelsPerTick,
+		scrollLeft: Math.max(0, nextScrollLeft),
+	};
+}

--- a/src/arrangement/index.ts
+++ b/src/arrangement/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Retained, renderer-agnostic arrangement contracts (PRD section 9.3; backlog
+ * `FND-008`). See `geometry.ts`, `projection.ts`, `revision.ts`, and
+ * `waveformCache.ts` for the pieces this re-exports, and `spike/README.md`
+ * for what is disposable versus what is meant to survive into `ARR-005`.
+ */
+
+export * from "./geometry";
+export * from "./projection";
+export * from "./revision";
+export * from "./waveformCache";

--- a/src/arrangement/projection.test.ts
+++ b/src/arrangement/projection.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import type { Project } from "../domain/entities";
+import {
+	createArrangementSpikeProject,
+	createDrumMachineFixtureProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { TICKS_PER_BAR } from "../domain/time";
+import type { RowMetrics } from "./geometry";
+import {
+	buildArrangementProjection,
+	hitTestArrangement,
+	visiblePlacements,
+	visiblePlacementsForTrack,
+} from "./projection";
+
+const rowMetrics: RowMetrics = { trackHeightPx: 32, headerHeightPx: 32 };
+
+describe("buildArrangementProjection", () => {
+	it("orders tracks by `order` and gives each a matching rowIndex", () => {
+		const project = createDrumMachineFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+
+		expect(projection.tracks.map((track) => track.rowIndex)).toEqual(
+			projection.tracks.map((_, index) => index),
+		);
+		for (let index = 1; index < projection.tracks.length; index += 1) {
+			expect(projection.tracks[index].order).toBeGreaterThan(
+				projection.tracks[index - 1].order,
+			);
+		}
+	});
+
+	it("builds rowOffsets one longer than the track count", () => {
+		const project = createDrumMachineFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		expect(projection.rowOffsets).toHaveLength(projection.tracks.length + 1);
+	});
+
+	it("gives every placement the row index of its owning track", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const track = projection.tracks[0];
+		const index = projection.placementsByTrack.get(track.id);
+		expect(
+			index?.items.every((placement) => placement.rowIndex === track.rowIndex),
+		).toBe(true);
+	});
+
+	it("labels a note clip's placement with a notes preview", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const [placement] = [...projection.placementsById.values()];
+		expect(placement.preview.kind).toBe("notes");
+	});
+
+	it("labels an audioLoop clip's placement with a waveform preview", () => {
+		const project = createDrumMachineFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const waveformPlacement = [...projection.placementsById.values()].find(
+			(placement) => placement.preview.kind === "waveform",
+		);
+		expect(waveformPlacement).toBeDefined();
+	});
+
+	it("exposes at most one automation lane per track", () => {
+		const project = createArrangementSpikeProject(20);
+		const projection = buildArrangementProjection(project, rowMetrics);
+		expect(projection.automationByTrack.size).toBeLessThanOrEqual(
+			projection.tracks.length,
+		);
+	});
+
+	describe("revision stability", () => {
+		it("gives the same track a stable revision across two builds of the same project", () => {
+			const project = createSliceFixtureProject();
+			const first = buildArrangementProjection(project, rowMetrics);
+			const second = buildArrangementProjection(project, rowMetrics);
+			expect(second.tracks[0].revision).toBe(first.tracks[0].revision);
+			expect(second.songRevision).toBe(first.songRevision);
+		});
+
+		it("changes only the affected track's revision when only that track changes", () => {
+			const project = createArrangementSpikeProject(20);
+			const before = buildArrangementProjection(project, rowMetrics);
+
+			const changedTrack = { ...project.song.tracks[0], name: "Renamed" };
+			const changed: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track, index) =>
+						index === 0 ? changedTrack : track,
+					),
+				},
+			};
+			const after = buildArrangementProjection(changed, rowMetrics);
+
+			expect(after.tracks[0].revision).not.toBe(before.tracks[0].revision);
+			for (let index = 1; index < after.tracks.length; index += 1) {
+				expect(after.tracks[index].revision).toBe(
+					before.tracks[index].revision,
+				);
+			}
+		});
+	});
+});
+
+describe("visiblePlacementsForTrack / visiblePlacements culling", () => {
+	it("only returns placements that intersect the requested tick range", () => {
+		const project = createArrangementSpikeProject(20);
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const [track] = projection.tracks;
+		const index = projection.placementsByTrack.get(track.id);
+		expect(index).toBeDefined();
+		if (!index) return;
+
+		const midpoint = TICKS_PER_BAR * 30;
+		const narrowRange = { startTick: midpoint, endTick: midpoint + 1 };
+		const visible = visiblePlacementsForTrack(index, narrowRange);
+
+		for (const placement of visible) {
+			expect(placement.endTicks).toBeGreaterThanOrEqual(narrowRange.startTick);
+			expect(placement.startTicks).toBeLessThanOrEqual(narrowRange.endTick);
+		}
+		// Sanity: culling actually excludes something in a dense fixture.
+		expect(visible.length).toBeLessThan(index.items.length);
+	});
+
+	it("finds a placement that starts before the range but still overlaps it", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const [track] = projection.tracks;
+		const index = projection.placementsByTrack.get(track.id);
+		expect(index).toBeDefined();
+		if (!index) return;
+		const [placement] = index.items;
+
+		// The fixture's one placement spans [0, TICKS_PER_BAR); a range that
+		// starts mid-placement must still find it.
+		const midRange = {
+			startTick: placement.startTicks + 10,
+			endTick: placement.endTicks + 100,
+		};
+		expect(visiblePlacementsForTrack(index, midRange)).toContainEqual(
+			placement,
+		);
+	});
+
+	it("restricts visiblePlacements to the requested row range", () => {
+		const project = createArrangementSpikeProject(20);
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const fullTickRange = { startTick: 0, endTick: projection.lengthTicks };
+
+		const onlyFirstRow = visiblePlacements(projection, fullTickRange, {
+			startRow: 0,
+			endRow: 0,
+		});
+		expect(onlyFirstRow.every((placement) => placement.rowIndex === 0)).toBe(
+			true,
+		);
+		expect(onlyFirstRow.length).toBeGreaterThan(0);
+	});
+});
+
+describe("hitTestArrangement", () => {
+	it("reports empty for a row with no track", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		expect(
+			hitTestArrangement(projection, { rowIndex: 99, tick: 0 }, 10),
+		).toEqual({ kind: "empty" });
+	});
+
+	it("reports the placement body for a point well inside it", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const [placement] = [...projection.placementsById.values()];
+		const midTick = Math.floor((placement.startTicks + placement.endTicks) / 2);
+
+		const result = hitTestArrangement(
+			projection,
+			{ rowIndex: placement.rowIndex, tick: midTick },
+			5,
+		);
+		expect(result).toEqual({
+			kind: "placement",
+			placementId: placement.id,
+			handle: "body",
+		});
+	});
+
+	it("prefers the start handle over the body near the placement's left edge", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const [placement] = [...projection.placementsById.values()];
+
+		const result = hitTestArrangement(
+			projection,
+			{ rowIndex: placement.rowIndex, tick: placement.startTicks + 2 },
+			5,
+		);
+		expect(result).toEqual({
+			kind: "placement",
+			placementId: placement.id,
+			handle: "start",
+		});
+	});
+
+	it("prefers the end handle over the body near the placement's right edge", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const [placement] = [...projection.placementsById.values()];
+
+		const result = hitTestArrangement(
+			projection,
+			{ rowIndex: placement.rowIndex, tick: placement.endTicks - 2 },
+			5,
+		);
+		expect(result).toEqual({
+			kind: "placement",
+			placementId: placement.id,
+			handle: "end",
+		});
+	});
+
+	it("reports empty for a point on the track but outside any placement", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project, rowMetrics);
+		const [placement] = [...projection.placementsById.values()];
+
+		const result = hitTestArrangement(
+			projection,
+			{ rowIndex: placement.rowIndex, tick: placement.endTicks + 10_000 },
+			5,
+		);
+		expect(result).toEqual({ kind: "empty" });
+	});
+});

--- a/src/arrangement/projection.ts
+++ b/src/arrangement/projection.ts
@@ -1,0 +1,357 @@
+import type { Asset, AutomationLane, Clip, Project } from "../domain/entities";
+import type { AssetId, ClipId, PlacementId, TrackId } from "../domain/ids";
+import {
+	buildRowOffsets,
+	type RowMetrics,
+	type RowRange,
+	type TickRange,
+} from "./geometry";
+import { combineRevisions, revisionOf } from "./revision";
+
+/**
+ * The renderer-specific `ArrangementProjection` PRD section 9.3 calls for:
+ * "Domain selectors build a renderer-specific `ArrangementProjection` with
+ * stable IDs, integer musical bounds, track order, colors, labels, compact
+ * preview data, and revision counters. Canvas code never traverses
+ * Firestore-shaped data."
+ *
+ * This module has no DOM/Canvas/SolidJS imports either — it turns a schema-v1
+ * `Project` into flat, pre-sorted, pre-indexed geometry once, so drawing and
+ * hit testing never walk the domain shape (nested tracks/clips/placements)
+ * per frame or per pointer event.
+ */
+
+export type PlacementPreview =
+	| {
+			readonly kind: "notes";
+			/** Note start ticks relative to the placement, for a compact
+			 * tick-mark preview instead of drawing every note event's full shape. */
+			readonly noteStartTicks: readonly number[];
+	  }
+	| {
+			readonly kind: "waveform";
+			readonly assetId: AssetId;
+			/** Changes only when the referenced asset's own record changes
+			 * (e.g. a new decode), matching the PRD's "cached by asset ID and
+			 * source revision" waveform-cache key. */
+			readonly assetRevision: number;
+	  };
+
+export interface TrackRow {
+	readonly id: TrackId;
+	readonly rowIndex: number;
+	readonly order: number;
+	readonly name: string;
+	readonly color: string;
+	readonly type: "instrument" | "audio";
+	readonly muted: boolean;
+	readonly soloed: boolean;
+	readonly revision: number;
+}
+
+export interface PlacementGeometry {
+	readonly id: PlacementId;
+	readonly trackId: TrackId;
+	readonly clipId: ClipId;
+	readonly rowIndex: number;
+	readonly startTicks: number;
+	readonly endTicks: number;
+	readonly color: string;
+	readonly label: string;
+	readonly preview: PlacementPreview;
+	readonly revision: number;
+}
+
+export interface AutomationLaneGeometry {
+	readonly id: string;
+	readonly trackId: TrackId;
+	readonly rowIndex: number;
+	readonly parameterId: string;
+	readonly interpolation: AutomationLane["interpolation"];
+	readonly points: ReadonlyArray<{
+		readonly tick: number;
+		readonly value: number;
+	}>;
+	readonly revision: number;
+}
+
+/** Placements for one track, sorted by `startTicks` and indexed for culling. */
+export interface TrackPlacementIndex {
+	readonly items: readonly PlacementGeometry[];
+	/** The longest placement duration on this track. Bounds how far back a
+	 * cull query must look for a placement that starts before the visible
+	 * range but still overlaps it. */
+	readonly maxDurationTicks: number;
+}
+
+export interface ArrangementProjection {
+	readonly songRevision: number;
+	readonly tempo: number;
+	/** The last tick occupied by any placement or section. */
+	readonly lengthTicks: number;
+	readonly rowMetrics: RowMetrics;
+	/** Length `tracks.length + 1`; see `buildRowOffsets`. */
+	readonly rowOffsets: readonly number[];
+	/** Sorted by `order` — index `i` is row `i`. */
+	readonly tracks: readonly TrackRow[];
+	readonly placementsByTrack: ReadonlyMap<TrackId, TrackPlacementIndex>;
+	readonly placementsById: ReadonlyMap<PlacementId, PlacementGeometry>;
+	/** At most one lane per track: "a track can show one automation lane at
+	 * a time" (PRD ARR-04). Picking which one is a UI concern the spike does
+	 * not model; this keeps the first lane found per track. */
+	readonly automationByTrack: ReadonlyMap<TrackId, AutomationLaneGeometry>;
+}
+
+export function buildArrangementProjection(
+	project: Project,
+	rowMetrics: RowMetrics,
+): ArrangementProjection {
+	const clipsById = new Map<ClipId, Clip>(
+		project.clips.map((clip) => [clip.id, clip]),
+	);
+	const assetsById = new Map<AssetId, Asset>(
+		project.song.assets.map((asset) => [asset.id, asset]),
+	);
+
+	const tracksSorted = [...project.song.tracks].sort(
+		(a, b) => a.order - b.order,
+	);
+	const rowIndexByTrackId = new Map<TrackId, number>(
+		tracksSorted.map((track, index) => [track.id, index]),
+	);
+
+	const tracks: TrackRow[] = tracksSorted.map((track, index) => ({
+		id: track.id,
+		rowIndex: index,
+		order: track.order,
+		name: track.name,
+		color: track.color,
+		type: track.type,
+		muted: track.mixer.muted,
+		soloed: track.mixer.soloed,
+		revision: revisionOf(track),
+	}));
+
+	const placementsById = new Map<PlacementId, PlacementGeometry>();
+	const placementsByTrackMutable = new Map<
+		TrackId,
+		{ items: PlacementGeometry[]; maxDurationTicks: number }
+	>();
+
+	for (const placement of project.song.placements) {
+		const rowIndex = rowIndexByTrackId.get(placement.trackId);
+		const clip = clipsById.get(placement.clipId);
+		// A dangling reference cannot survive `parseProject`; this guard only
+		// protects the projection builder against being handed a `Project`
+		// some other, buggier path constructed by hand (e.g. in a test).
+		if (rowIndex === undefined || !clip) continue;
+
+		const durationTicks = placement.durationTicks;
+		const geometry: PlacementGeometry = {
+			id: placement.id,
+			trackId: placement.trackId,
+			clipId: placement.clipId,
+			rowIndex,
+			startTicks: placement.startTicks,
+			endTicks: placement.startTicks + durationTicks,
+			color: clip.color,
+			label: clip.name,
+			preview: buildPreview(clip, assetsById),
+			revision: combineRevisions(revisionOf(placement), revisionOf(clip)),
+		};
+		placementsById.set(placement.id, geometry);
+
+		let bucket = placementsByTrackMutable.get(placement.trackId);
+		if (!bucket) {
+			bucket = { items: [], maxDurationTicks: 0 };
+			placementsByTrackMutable.set(placement.trackId, bucket);
+		}
+		bucket.items.push(geometry);
+		bucket.maxDurationTicks = Math.max(bucket.maxDurationTicks, durationTicks);
+	}
+
+	const placementsByTrack = new Map<TrackId, TrackPlacementIndex>();
+	for (const [trackId, bucket] of placementsByTrackMutable) {
+		bucket.items.sort((a, b) => a.startTicks - b.startTicks);
+		placementsByTrack.set(trackId, {
+			items: bucket.items,
+			maxDurationTicks: bucket.maxDurationTicks,
+		});
+	}
+
+	const automationByTrack = new Map<TrackId, AutomationLaneGeometry>();
+	for (const lane of project.song.automation) {
+		if (lane.target.scope !== "track") continue;
+		if (automationByTrack.has(lane.target.trackId)) continue;
+		const rowIndex = rowIndexByTrackId.get(lane.target.trackId);
+		if (rowIndex === undefined) continue;
+		automationByTrack.set(lane.target.trackId, {
+			id: lane.id,
+			trackId: lane.target.trackId,
+			rowIndex,
+			parameterId: lane.target.parameterId,
+			interpolation: lane.interpolation,
+			points: lane.points,
+			revision: revisionOf(lane),
+		});
+	}
+
+	return {
+		songRevision: revisionOf(project.song),
+		tempo: project.song.tempo,
+		lengthTicks: arrangementLengthTicks(project),
+		rowMetrics,
+		rowOffsets: buildRowOffsets(tracks.length, rowMetrics),
+		tracks,
+		placementsByTrack,
+		placementsById,
+		automationByTrack,
+	};
+}
+
+function buildPreview(
+	clip: Clip,
+	assetsById: ReadonlyMap<AssetId, Asset>,
+): PlacementPreview {
+	if (clip.content.kind === "audioLoop") {
+		const asset = assetsById.get(clip.content.assetId);
+		return {
+			kind: "waveform",
+			assetId: clip.content.assetId,
+			assetRevision: asset ? revisionOf(asset) : 0,
+		};
+	}
+	return {
+		kind: "notes",
+		noteStartTicks: clip.content.events.map((event) => event.startTicks),
+	};
+}
+
+function arrangementLengthTicks(project: Project): number {
+	let lengthTicks = 0;
+	for (const placement of project.song.placements) {
+		lengthTicks = Math.max(
+			lengthTicks,
+			placement.startTicks + placement.durationTicks,
+		);
+	}
+	for (const section of project.song.sections) {
+		lengthTicks = Math.max(
+			lengthTicks,
+			section.startTicks + section.durationTicks,
+		);
+	}
+	return lengthTicks;
+}
+
+/**
+ * Placements on one track's sorted index that intersect `tickRange`,
+ * expanded implicitly by the track's longest placement so a placement that
+ * starts before the visible range but still overlaps it is not missed. Cost
+ * is `O(log n + k)` for `k` matches, not `O(n)` — the point of building the
+ * per-track index instead of scanning `project.song.placements` directly.
+ */
+export function visiblePlacementsForTrack(
+	index: TrackPlacementIndex,
+	tickRange: TickRange,
+): PlacementGeometry[] {
+	if (index.items.length === 0) return [];
+	const lowerBoundStart = tickRange.startTick - index.maxDurationTicks;
+	let low = 0;
+	let high = index.items.length;
+	while (low < high) {
+		const mid = (low + high) >> 1;
+		if (index.items[mid].startTicks < lowerBoundStart) {
+			low = mid + 1;
+		} else {
+			high = mid;
+		}
+	}
+	const result: PlacementGeometry[] = [];
+	for (let cursor = low; cursor < index.items.length; cursor += 1) {
+		const placement = index.items[cursor];
+		if (placement.startTicks > tickRange.endTick) break;
+		if (placement.endTicks < tickRange.startTick) continue;
+		result.push(placement);
+	}
+	return result;
+}
+
+/** All placements visible in `tickRange` across the rows in `rowRange`. */
+export function visiblePlacements(
+	projection: ArrangementProjection,
+	tickRange: TickRange,
+	rowRange: RowRange,
+): PlacementGeometry[] {
+	const result: PlacementGeometry[] = [];
+	for (const track of projection.tracks) {
+		if (
+			track.rowIndex < rowRange.startRow ||
+			track.rowIndex > rowRange.endRow
+		) {
+			continue;
+		}
+		const index = projection.placementsByTrack.get(track.id);
+		if (!index) continue;
+		result.push(...visiblePlacementsForTrack(index, tickRange));
+	}
+	return result;
+}
+
+export type HitTestResult =
+	| { readonly kind: "empty" }
+	| {
+			readonly kind: "placement";
+			readonly placementId: PlacementId;
+			readonly handle: "start" | "end" | "body";
+	  };
+
+export interface HitTestPoint {
+	readonly rowIndex: number;
+	readonly tick: number;
+}
+
+/**
+ * "Hit testing queries only the visible track's sorted objects and checks
+ * handles before bodies" (PRD 9.3). `handleWidthTicks` is the resize-handle
+ * width converted to musical ticks at the caller's current zoom, so the
+ * handle stays a constant pixel width regardless of zoom level.
+ */
+export function hitTestArrangement(
+	projection: ArrangementProjection,
+	point: HitTestPoint,
+	handleWidthTicks: number,
+): HitTestResult {
+	const track = projection.tracks[point.rowIndex];
+	if (!track) return { kind: "empty" };
+	const index = projection.placementsByTrack.get(track.id);
+	if (!index) return { kind: "empty" };
+
+	const candidates = visiblePlacementsForTrack(index, {
+		startTick: point.tick - handleWidthTicks,
+		endTick: point.tick + handleWidthTicks,
+	});
+
+	let match: PlacementGeometry | undefined;
+	for (const placement of candidates) {
+		if (
+			point.tick >= placement.startTicks - handleWidthTicks &&
+			point.tick <= placement.endTicks + handleWidthTicks
+		) {
+			match = placement;
+			break;
+		}
+	}
+	if (!match) return { kind: "empty" };
+
+	if (Math.abs(point.tick - match.startTicks) <= handleWidthTicks) {
+		return { kind: "placement", placementId: match.id, handle: "start" };
+	}
+	if (Math.abs(point.tick - match.endTicks) <= handleWidthTicks) {
+		return { kind: "placement", placementId: match.id, handle: "end" };
+	}
+	if (point.tick >= match.startTicks && point.tick <= match.endTicks) {
+		return { kind: "placement", placementId: match.id, handle: "body" };
+	}
+	return { kind: "empty" };
+}

--- a/src/arrangement/revision.test.ts
+++ b/src/arrangement/revision.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { combineRevisions, revisionOf } from "./revision";
+
+describe("revisionOf", () => {
+	it("returns the same number for the same object reference every time", () => {
+		const entity = { name: "track" };
+		const first = revisionOf(entity);
+		expect(revisionOf(entity)).toBe(first);
+		expect(revisionOf(entity)).toBe(first);
+	});
+
+	it("returns a different number for a structurally identical but distinct object", () => {
+		const a = { name: "track" };
+		const b = { name: "track" };
+		expect(revisionOf(a)).not.toBe(revisionOf(b));
+	});
+
+	it("only changes for the entity that actually changed (immutable-update pattern)", () => {
+		const trackA = { name: "A" };
+		const trackB = { name: "B" };
+		const beforeA = revisionOf(trackA);
+		const beforeB = revisionOf(trackB);
+
+		// Simulates `produce`: a new object for the changed entity, the
+		// untouched sibling keeps its reference.
+		const trackAChanged = { ...trackA, name: "A2" };
+
+		expect(revisionOf(trackAChanged)).not.toBe(beforeA);
+		expect(revisionOf(trackB)).toBe(beforeB);
+	});
+});
+
+describe("combineRevisions", () => {
+	it("is deterministic for the same inputs", () => {
+		expect(combineRevisions(1, 2, 3)).toBe(combineRevisions(1, 2, 3));
+	});
+
+	it("is sensitive to input order", () => {
+		expect(combineRevisions(1, 2)).not.toBe(combineRevisions(2, 1));
+	});
+
+	it("changes when any one input changes", () => {
+		const base = combineRevisions(10, 20, 30);
+		expect(combineRevisions(11, 20, 30)).not.toBe(base);
+		expect(combineRevisions(10, 21, 30)).not.toBe(base);
+		expect(combineRevisions(10, 20, 31)).not.toBe(base);
+	});
+});

--- a/src/arrangement/revision.ts
+++ b/src/arrangement/revision.ts
@@ -1,0 +1,57 @@
+/**
+ * Object-identity revision counters (PRD section 9.3 "Culling, projection, and
+ * caches": "The projection exposes revision counters at song, track, clip,
+ * asset, and automation granularity so unrelated edits do not invalidate all
+ * cached geometry").
+ *
+ * Domain state is edited immutably (`createStore`/`produce`): a command that
+ * changes one track produces a new track object but leaves every untouched
+ * sibling's reference exactly as it was. That means reference identity is
+ * already a correct, free "did this change" signal — we do not need to hash
+ * or deep-compare entities to know whether a track, clip, placement, or
+ * automation lane changed since the last projection build. A `WeakMap` from
+ * object identity to a monotonically increasing counter turns that identity
+ * check into a stable number the renderer can cache against, without forcing
+ * every consumer to carry object references around as cache keys.
+ *
+ * The registry is process-wide and deliberately never cleared: entries are
+ * held weakly, so an entity that becomes unreachable (a project is closed, a
+ * clip is deleted) is collected normally: this module never grows unbounded
+ * on its own.
+ */
+
+const revisions = new WeakMap<object, number>();
+let nextRevision = 1;
+
+/**
+ * The stable revision number for `entity`. The first time a given object
+ * reference is seen it is assigned the next counter value; every later call
+ * with the *same* reference returns that same number. A structurally
+ * identical but distinct object (e.g. produced by `produce` when this entity
+ * itself changed) gets a new number.
+ */
+export function revisionOf(entity: object): number {
+	let revision = revisions.get(entity);
+	if (revision === undefined) {
+		revision = nextRevision;
+		nextRevision += 1;
+		revisions.set(entity, revision);
+	}
+	return revision;
+}
+
+/**
+ * Folds several revision numbers (e.g. a placement's own revision and its
+ * clip's) into one, so a projection field that depends on more than one
+ * entity still gets a single comparable cache key. Order-sensitive and
+ * deterministic — the same inputs in the same order always fold to the same
+ * output.
+ */
+export function combineRevisions(...values: readonly number[]): number {
+	let hash = 0x811c9dc5;
+	for (const value of values) {
+		hash ^= value;
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	return hash >>> 0;
+}

--- a/src/arrangement/spike/ArrangementSpike.css
+++ b/src/arrangement/spike/ArrangementSpike.css
@@ -1,0 +1,78 @@
+/* FND-008 renderer spike styling. Disposable and functional — see
+   spike/README.md. Deliberately reuses the documented design DNA (flat,
+   square corners, single cyan accent) rather than inventing a second visual
+   language, without trying to be a pixel-accurate arrangement mock (none
+   exists yet in docs/design). */
+
+.arrangement-spike {
+	position: relative;
+	display: flex;
+	width: 100%;
+	height: 100%;
+	min-height: 480px;
+	background: #141414;
+	color: #e6e6e6;
+	font-family: system-ui, -apple-system, sans-serif;
+	overflow: hidden;
+}
+
+.arrangement-spike-headers {
+	position: relative;
+	flex-shrink: 0;
+	background: #181818;
+	border-right: 1px solid #262626;
+	overflow: hidden;
+}
+
+.arrangement-spike-headers-inner {
+	position: relative;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.arrangement-spike-header-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 0 8px;
+	font-size: 12px;
+	box-sizing: border-box;
+	border-bottom: 1px solid #1e1e1e;
+}
+
+.arrangement-spike-header-row:focus-visible {
+	outline: 2px solid #20c8e8;
+	outline-offset: -2px;
+}
+
+.arrangement-spike-header-swatch {
+	width: 8px;
+	height: 8px;
+	flex-shrink: 0;
+}
+
+.arrangement-spike-header-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.arrangement-spike-viewport {
+	position: relative;
+	flex: 1;
+	overflow: hidden;
+}
+
+.arrangement-spike-layer {
+	position: absolute;
+	top: 0;
+	left: 0;
+	display: block;
+}
+
+.arrangement-spike-layer-interactive {
+	touch-action: none;
+	cursor: default;
+}

--- a/src/arrangement/spike/ArrangementSpike.tsx
+++ b/src/arrangement/spike/ArrangementSpike.tsx
@@ -74,8 +74,21 @@ export type TraceName = "scroll" | "zoom" | "seek" | "selection";
 export interface TraceResult {
 	readonly trace: TraceName;
 	readonly frameCount: number;
+	/** Wall-clock time between consecutive presented animation frames
+	 * (`FrameSample.timestampMs` deltas) — the basis PRD 9.3's frame budget
+	 * ("median frame time at or below 16.7 ms, p95 at or below 33 ms") is
+	 * stated against. This spans everything that happens between one
+	 * rAF-callback invocation and the next: rasterization, compositing, DOM
+	 * layout/style for the header column, and Solid's reactive work, none of
+	 * which the synchronous draw-call duration below captures. */
 	readonly medianFrameMs: number;
 	readonly p95FrameMs: number;
+	/** Synchronous canvas draw-command issue duration alone (the
+	 * `performance.now()` bracket in `drawDirtyLayers`). Useful for isolating
+	 * draw-call cost, but it is a strict lower bound on frame cost, not frame
+	 * time itself — see `medianFrameMs`/`p95FrameMs`. */
+	readonly medianDrawMs: number;
+	readonly p95DrawMs: number;
 	readonly longTaskCount: number;
 	readonly longTaskTotalMs: number;
 	readonly redrawCounts: Readonly<Record<DirtyLayer, number>>;
@@ -314,9 +327,13 @@ export default function ArrangementSpike(props: ArrangementSpikeProps) {
 
 	onMount(() => {
 		const resizeObserver = new ResizeObserver(() => {
+			// `containerEl` (`.arrangement-spike-viewport`) is a flex sibling of
+			// the header column (`.arrangement-spike` is `display: flex`), so its
+			// own rect already excludes the header width — subtracting
+			// `HEADER_WIDTH_PX` again would double-count it.
 			const rect = containerEl.getBoundingClientRect();
 			applyViewport({
-				width: Math.round(rect.width - HEADER_WIDTH_PX),
+				width: Math.round(rect.width),
 				height: Math.round(rect.height),
 			});
 			markDirty("background", "content", "interaction");
@@ -365,12 +382,21 @@ export default function ArrangementSpike(props: ArrangementSpikeProps) {
 		for (let frame = 0; frame < frames; frame += 1) {
 			const t = frame / frames;
 			switch (trace) {
-				case "scroll":
+				case "scroll": {
+					// Sweep both axes over the trace so track-count comparisons
+					// exercise rows past the first screenful, not just the initial
+					// ~30 visible rows (row virtualization, header windowing).
+					const rowOffsets = projection().rowOffsets;
+					const maxScrollTop = Math.max(
+						0,
+						rowOffsets[rowOffsets.length - 1] - port.height,
+					);
 					setScroll(
 						t * (totalTicks * port.pixelsPerTick * 0.5),
-						port.scrollTop,
+						t * maxScrollTop,
 					);
 					break;
+				}
 				case "zoom":
 					zoomAt(
 						port.width / 2,
@@ -399,7 +425,15 @@ export default function ArrangementSpike(props: ArrangementSpikeProps) {
 		}
 
 		const snapshot = instrumentation.snapshot();
-		const durations = snapshot.frames.map((f) => f.durationMs);
+		// Frame time is the interval between consecutive presented frames, not
+		// how long the synchronous draw call took (see `TraceResult`'s doc
+		// comments) — derive it from consecutive `FrameSample.timestampMs`
+		// values, which are captured once per rAF callback.
+		const frameTimestamps = snapshot.frames.map((f) => f.timestampMs);
+		const frameIntervals = frameTimestamps
+			.slice(1)
+			.map((timestamp, index) => timestamp - frameTimestamps[index]);
+		const drawDurations = snapshot.frames.map((f) => f.durationMs);
 		const longTaskTotalMs = snapshot.longTasks.reduce(
 			(sum, task) => sum + task.durationMs,
 			0,
@@ -407,8 +441,10 @@ export default function ArrangementSpike(props: ArrangementSpikeProps) {
 		return {
 			trace,
 			frameCount: snapshot.frames.length,
-			medianFrameMs: durations.length ? median(durations) : 0,
-			p95FrameMs: durations.length ? percentile(durations, 95) : 0,
+			medianFrameMs: frameIntervals.length ? median(frameIntervals) : 0,
+			p95FrameMs: frameIntervals.length ? percentile(frameIntervals, 95) : 0,
+			medianDrawMs: drawDurations.length ? median(drawDurations) : 0,
+			p95DrawMs: drawDurations.length ? percentile(drawDurations, 95) : 0,
 			longTaskCount: snapshot.longTasks.length,
 			longTaskTotalMs,
 			redrawCounts: snapshot.redrawCounts,
@@ -472,11 +508,7 @@ export default function ArrangementSpike(props: ArrangementSpikeProps) {
 					</For>
 				</ul>
 			</div>
-			<div
-				class="arrangement-spike-viewport"
-				ref={containerEl}
-				style={{ left: `${HEADER_WIDTH_PX}px` }}
-			>
+			<div class="arrangement-spike-viewport" ref={containerEl}>
 				<canvas class="arrangement-spike-layer" ref={backgroundCanvas} />
 				<canvas class="arrangement-spike-layer" ref={contentCanvas} />
 				<canvas

--- a/src/arrangement/spike/ArrangementSpike.tsx
+++ b/src/arrangement/spike/ArrangementSpike.tsx
@@ -1,0 +1,496 @@
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	onCleanup,
+	onMount,
+} from "solid-js";
+import type { Project } from "../../domain/entities";
+import type { PlacementId, TrackId } from "../../domain/ids";
+import {
+	pixelsToTicks,
+	type RowMetrics,
+	rowIndexAtOffset,
+	type Viewport,
+	visibleRowRange,
+	visibleTickRange,
+	zoomAtAnchor,
+} from "../geometry";
+import {
+	type ArrangementProjection,
+	buildArrangementProjection,
+	hitTestArrangement,
+} from "../projection";
+import {
+	createSpikeWaveformCache,
+	type DrawEnvironment,
+	drawBackgroundLayer,
+	drawContentLayer,
+	drawInteractionLayer,
+	type InteractionState,
+} from "./canvasLayers";
+import {
+	createInstrumentation,
+	type DirtyLayer,
+	median,
+	percentile,
+} from "./instrumentation";
+import "./ArrangementSpike.css";
+
+/**
+ * The FND-008 renderer spike (backlog task; PRD 9.3). Disposable, exploratory
+ * UI: it exists to give the measurement harness something representative to
+ * drive, not to be grown into the production arrangement editor (`ARR-005`
+ * replaces it). See `spike/README.md`. The parts worth keeping —
+ * `ArrangementProjection`, the geometry helpers, and the waveform cache — live
+ * one directory up in `src/arrangement/`, imported here rather than defined
+ * here.
+ */
+
+export const ROW_METRICS: RowMetrics = {
+	trackHeightPx: 28,
+	headerHeightPx: 28,
+};
+const HEADER_WIDTH_PX = 160;
+const OVERSCAN_ROWS = 4;
+const OVERSCAN_PX = 200;
+const MIN_PIXELS_PER_TICK = 0.01;
+const MAX_PIXELS_PER_TICK = 2;
+const RESIZE_HANDLE_PX = 6;
+
+export interface ArrangementSpikeProps {
+	readonly project: Project;
+}
+
+interface Selection {
+	readonly trackId: TrackId;
+	readonly startTick: number;
+	readonly endTick: number;
+}
+
+export type TraceName = "scroll" | "zoom" | "seek" | "selection";
+
+export interface TraceResult {
+	readonly trace: TraceName;
+	readonly frameCount: number;
+	readonly medianFrameMs: number;
+	readonly p95FrameMs: number;
+	readonly longTaskCount: number;
+	readonly longTaskTotalMs: number;
+	readonly redrawCounts: Readonly<Record<DirtyLayer, number>>;
+	readonly heapUsedMB: number | null;
+}
+
+/** The imperative bridge the Playwright harness drives through
+ * `window.__arrangementSpike` (see `perf/arrangement.bench.spec.ts`). Kept
+ * separate from Solid's reactive signals: scripted traces need tight control
+ * over exactly when a frame happens, which a reactive effect graph does not
+ * give you for free. */
+export interface ArrangementSpikeHandle {
+	getViewport(): Viewport;
+	setScroll(scrollLeft: number, scrollTop: number): void;
+	zoomAt(anchorX: number, nextPixelsPerTick: number): void;
+	seekTo(ticks: number): void;
+	select(selection: Selection | null): void;
+	runScriptedTrace(trace: TraceName, frames?: number): Promise<TraceResult>;
+}
+
+declare global {
+	interface Window {
+		__arrangementSpike?: ArrangementSpikeHandle;
+	}
+}
+
+export default function ArrangementSpike(props: ArrangementSpikeProps) {
+	const projection = createMemo<ArrangementProjection>(() =>
+		buildArrangementProjection(props.project, ROW_METRICS),
+	);
+
+	const [viewport, setViewport] = createSignal<Viewport>({
+		scrollLeft: 0,
+		scrollTop: 0,
+		width: 960,
+		height: 480,
+		pixelsPerTick: 0.08,
+	});
+	const [selection, setSelection] = createSignal<Selection | null>(null);
+	const [playheadTicks, setPlayheadTicks] = createSignal<number | null>(0);
+	const [hoverPlacementId, setHoverPlacementId] =
+		createSignal<PlacementId | null>(null);
+	const [headerRange, setHeaderRange] = createSignal({
+		startRow: 0,
+		endRow: -1,
+	});
+
+	let containerEl!: HTMLDivElement;
+	let backgroundCanvas!: HTMLCanvasElement;
+	let contentCanvas!: HTMLCanvasElement;
+	let interactionCanvas!: HTMLCanvasElement;
+
+	const waveformCache = createSpikeWaveformCache();
+	const instrumentation = createInstrumentation();
+
+	const dirtyLayers = new Set<DirtyLayer>();
+	let rafHandle: number | null = null;
+
+	function markDirty(...layers: DirtyLayer[]): void {
+		for (const layer of layers) dirtyLayers.add(layer);
+		scheduleDraw();
+	}
+
+	function scheduleDraw(): void {
+		if (rafHandle !== null) return;
+		rafHandle = requestAnimationFrame(() => {
+			rafHandle = null;
+			drawDirtyLayers();
+		});
+	}
+
+	function devicePixelRatioCapped(): number {
+		return Math.min(2, window.devicePixelRatio || 1);
+	}
+
+	function sizeCanvas(canvas: HTMLCanvasElement, port: Viewport): void {
+		const ratio = devicePixelRatioCapped();
+		const targetWidth = Math.round(port.width * ratio);
+		const targetHeight = Math.round(port.height * ratio);
+		if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+			canvas.width = targetWidth;
+			canvas.height = targetHeight;
+		}
+		canvas.style.width = `${port.width}px`;
+		canvas.style.height = `${port.height}px`;
+	}
+
+	function drawEnv(canvas: HTMLCanvasElement): DrawEnvironment {
+		const port = viewport();
+		const ctx = canvas.getContext("2d");
+		if (!ctx) throw new Error("2D canvas context unavailable");
+		const ratio = devicePixelRatioCapped();
+		ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+		return {
+			ctx,
+			viewport: port,
+			projection: projection(),
+			rowRange: visibleRowRange(projection().rowOffsets, port, OVERSCAN_ROWS),
+			tickRange: visibleTickRange(port, OVERSCAN_PX),
+			waveformCache,
+		};
+	}
+
+	function interactionState(): InteractionState {
+		return {
+			playheadTicks: playheadTicks(),
+			selection: selection(),
+			hoverPlacementId: hoverPlacementId(),
+		};
+	}
+
+	/** Draws exactly the layers marked dirty, then clears the flag set — the
+	 * PRD 9.3 "explicit dirty reasons" model: a playhead move never touches
+	 * the background or content canvases. */
+	function drawDirtyLayers(): void {
+		if (dirtyLayers.size === 0) return;
+		const start = performance.now();
+		const layers = [...dirtyLayers];
+		dirtyLayers.clear();
+
+		const port = viewport();
+		for (const canvas of [backgroundCanvas, contentCanvas, interactionCanvas]) {
+			sizeCanvas(canvas, port);
+		}
+		if (layers.includes("background"))
+			drawBackgroundLayer(drawEnv(backgroundCanvas));
+		if (layers.includes("content")) drawContentLayer(drawEnv(contentCanvas));
+		if (layers.includes("interaction")) {
+			drawInteractionLayer(drawEnv(interactionCanvas), interactionState());
+		}
+		instrumentation.recordRedraw(layers, performance.now() - start);
+	}
+
+	function updateHeaderRange(): void {
+		setHeaderRange(
+			visibleRowRange(projection().rowOffsets, viewport(), OVERSCAN_ROWS),
+		);
+	}
+
+	function applyViewport(next: Partial<Viewport>): void {
+		setViewport((current) => ({ ...current, ...next }));
+		updateHeaderRange();
+	}
+
+	function setScroll(scrollLeft: number, scrollTop: number): void {
+		const port = viewport();
+		const totalHeight =
+			projection().rowOffsets[projection().rowOffsets.length - 1];
+		const maxScrollLeft = Math.max(
+			0,
+			projection().lengthTicks * port.pixelsPerTick - port.width,
+		);
+		const maxScrollTop = Math.max(0, totalHeight - port.height);
+		applyViewport({
+			scrollLeft: Math.max(0, Math.min(maxScrollLeft, scrollLeft)),
+			scrollTop: Math.max(0, Math.min(maxScrollTop, scrollTop)),
+		});
+		markDirty("background", "content", "interaction");
+	}
+
+	function zoomAt(anchorX: number, nextPixelsPerTick: number): void {
+		const clamped = Math.max(
+			MIN_PIXELS_PER_TICK,
+			Math.min(MAX_PIXELS_PER_TICK, nextPixelsPerTick),
+		);
+		const result = zoomAtAnchor({
+			viewport: viewport(),
+			nextPixelsPerTick: clamped,
+			anchorX,
+		});
+		applyViewport(result);
+		markDirty("background", "content", "interaction");
+	}
+
+	function seekTo(ticks: number): void {
+		setPlayheadTicks(Math.max(0, ticks));
+		markDirty("interaction");
+	}
+
+	function select(next: Selection | null): void {
+		setSelection(next);
+		markDirty("interaction");
+	}
+
+	function handleWheel(event: WheelEvent): void {
+		event.preventDefault();
+		if (event.ctrlKey || event.metaKey) {
+			const port = viewport();
+			const rect = interactionCanvas.getBoundingClientRect();
+			const anchorX = event.clientX - rect.left;
+			const zoomFactor = Math.exp(-event.deltaY * 0.01);
+			zoomAt(anchorX, port.pixelsPerTick * zoomFactor);
+		} else {
+			const port = viewport();
+			setScroll(port.scrollLeft + event.deltaX, port.scrollTop + event.deltaY);
+		}
+	}
+
+	function pointToHitTest(clientX: number, clientY: number) {
+		const rect = interactionCanvas.getBoundingClientRect();
+		const port = viewport();
+		const localX = clientX - rect.left;
+		const localY = clientY - rect.top;
+		const tick = pixelsToTicks(port.scrollLeft + localX, port);
+		const rowIndex = rowIndexAtOffset(
+			projection().rowOffsets,
+			port.scrollTop + localY,
+		);
+		const handleWidthTicks = pixelsToTicks(RESIZE_HANDLE_PX, port);
+		return { tick, rowIndex, handleWidthTicks };
+	}
+
+	function handlePointerMove(event: PointerEvent): void {
+		const { tick, rowIndex, handleWidthTicks } = pointToHitTest(
+			event.clientX,
+			event.clientY,
+		);
+		const result = hitTestArrangement(
+			projection(),
+			{ rowIndex, tick },
+			handleWidthTicks,
+		);
+		setHoverPlacementId(
+			result.kind === "placement" ? result.placementId : null,
+		);
+		markDirty("interaction");
+	}
+
+	function handlePointerDown(event: PointerEvent): void {
+		const { tick, rowIndex } = pointToHitTest(event.clientX, event.clientY);
+		const track = projection().tracks[rowIndex];
+		if (!track) return;
+		const barTicks = Math.max(1, Math.round(1 / viewport().pixelsPerTick));
+		select({ trackId: track.id, startTick: tick, endTick: tick + barTicks });
+	}
+
+	onMount(() => {
+		const resizeObserver = new ResizeObserver(() => {
+			const rect = containerEl.getBoundingClientRect();
+			applyViewport({
+				width: Math.round(rect.width - HEADER_WIDTH_PX),
+				height: Math.round(rect.height),
+			});
+			markDirty("background", "content", "interaction");
+		});
+		resizeObserver.observe(containerEl);
+		onCleanup(() => resizeObserver.disconnect());
+
+		updateHeaderRange();
+		markDirty("background", "content", "interaction");
+
+		const handle: ArrangementSpikeHandle = {
+			getViewport: () => viewport(),
+			setScroll,
+			zoomAt,
+			seekTo,
+			select,
+			runScriptedTrace: (trace, frames) => runScriptedTrace(trace, frames),
+		};
+		window.__arrangementSpike = handle;
+		onCleanup(() => {
+			if (window.__arrangementSpike === handle) {
+				delete window.__arrangementSpike;
+			}
+		});
+	});
+
+	onCleanup(() => {
+		if (rafHandle !== null) cancelAnimationFrame(rafHandle);
+		instrumentation.dispose();
+	});
+
+	/** Runs one of the four scripted traces the backlog task calls for
+	 * (scroll/zoom/seek/selection), driving the same public API a real
+	 * pointer/wheel/keyboard gesture would, for `frames` animation frames,
+	 * and returns the frame/long-task/redraw/memory numbers collected while
+	 * it ran. Called directly by component code (e.g. a dev harness button)
+	 * and by the Playwright bench spec via `window.__arrangementSpike`. */
+	async function runScriptedTrace(
+		trace: TraceName,
+		frames = 120,
+	): Promise<TraceResult> {
+		instrumentation.reset();
+		const port = viewport();
+		const totalTicks = Math.max(1, projection().lengthTicks);
+
+		for (let frame = 0; frame < frames; frame += 1) {
+			const t = frame / frames;
+			switch (trace) {
+				case "scroll":
+					setScroll(
+						t * (totalTicks * port.pixelsPerTick * 0.5),
+						port.scrollTop,
+					);
+					break;
+				case "zoom":
+					zoomAt(
+						port.width / 2,
+						port.pixelsPerTick * (1 + 0.3 * Math.sin(t * Math.PI * 4)),
+					);
+					break;
+				case "seek":
+					seekTo(t * totalTicks);
+					break;
+				case "selection": {
+					const track =
+						projection().tracks[
+							frame % Math.max(1, projection().tracks.length)
+						];
+					if (track) {
+						select({
+							trackId: track.id,
+							startTick: t * totalTicks,
+							endTick: t * totalTicks + 768,
+						});
+					}
+					break;
+				}
+			}
+			await waitForNextFrame();
+		}
+
+		const snapshot = instrumentation.snapshot();
+		const durations = snapshot.frames.map((f) => f.durationMs);
+		const longTaskTotalMs = snapshot.longTasks.reduce(
+			(sum, task) => sum + task.durationMs,
+			0,
+		);
+		return {
+			trace,
+			frameCount: snapshot.frames.length,
+			medianFrameMs: durations.length ? median(durations) : 0,
+			p95FrameMs: durations.length ? percentile(durations, 95) : 0,
+			longTaskCount: snapshot.longTasks.length,
+			longTaskTotalMs,
+			redrawCounts: snapshot.redrawCounts,
+			heapUsedMB: snapshot.heapUsedMB,
+		};
+	}
+
+	function waitForNextFrame(): Promise<void> {
+		return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+	}
+
+	const headerRows = createMemo(() => {
+		const range = headerRange();
+		const tracks = projection().tracks;
+		const rows = [];
+		for (let index = range.startRow; index <= range.endRow; index += 1) {
+			const track = tracks[index];
+			if (track) rows.push(track);
+		}
+		return rows;
+	});
+
+	createEffect(() => {
+		// Track count / project identity changed: everything is dirty.
+		projection();
+		markDirty("background", "content", "interaction");
+	});
+
+	return (
+		<div class="arrangement-spike" data-testid="arrangement-spike-ready">
+			<div
+				class="arrangement-spike-headers"
+				style={{ width: `${HEADER_WIDTH_PX}px` }}
+			>
+				<ul
+					class="arrangement-spike-headers-inner"
+					aria-label="Tracks"
+					style={{
+						transform: `translateY(${-viewport().scrollTop}px)`,
+					}}
+				>
+					<For each={headerRows()}>
+						{(track) => (
+							<li
+								class="arrangement-spike-header-row"
+								aria-label={`${track.name}${track.muted ? " (muted)" : ""}`}
+								style={{
+									position: "absolute",
+									top: `${track.rowIndex * ROW_METRICS.headerHeightPx}px`,
+									height: `${ROW_METRICS.headerHeightPx}px`,
+									width: "100%",
+								}}
+							>
+								<span
+									class="arrangement-spike-header-swatch"
+									style={{ background: track.color }}
+								/>
+								<span class="arrangement-spike-header-name">{track.name}</span>
+							</li>
+						)}
+					</For>
+				</ul>
+			</div>
+			<div
+				class="arrangement-spike-viewport"
+				ref={containerEl}
+				style={{ left: `${HEADER_WIDTH_PX}px` }}
+			>
+				<canvas class="arrangement-spike-layer" ref={backgroundCanvas} />
+				<canvas class="arrangement-spike-layer" ref={contentCanvas} />
+				<canvas
+					class="arrangement-spike-layer arrangement-spike-layer-interactive"
+					ref={interactionCanvas}
+					onWheel={handleWheel}
+					onPointerMove={handlePointerMove}
+					onPointerDown={handlePointerDown}
+					onPointerLeave={() => {
+						setHoverPlacementId(null);
+						markDirty("interaction");
+					}}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/arrangement/spike/README.md
+++ b/src/arrangement/spike/README.md
@@ -1,0 +1,60 @@
+# Arrangement renderer spike (`FND-008`)
+
+Everything in this directory is the **disposable** half of `FND-008` — a
+representative hybrid virtualized-DOM/Canvas 2D UI built to give the
+measurement harness (`perf/arrangement.bench.spec.ts`) something real to
+drive, and to prove out the geometry/projection contracts under an actual
+Canvas renderer. Per the backlog task and PRD section 9.3 ("When these
+budgets are enforced"), it is explicitly **not gated on hitting the PRD frame
+budgets** and is expected to be replaced, not grown, by the production
+arrangement editor (`ARR-005`).
+
+## What's retained vs. disposable
+
+- **Retained** (one directory up, in `src/arrangement/`): `geometry.ts`,
+  `projection.ts`, `revision.ts`, `waveformCache.ts`, and their tests. These
+  have no DOM/Canvas/SolidJS imports and are the renderer-agnostic contracts
+  `ARR-005` is expected to keep using.
+- **Disposable** (this directory): `ArrangementSpike.tsx`, `canvasLayers.ts`,
+  and `instrumentation.ts`. This is UI code wired to one specific
+  Canvas-drawing approach and one specific measurement harness; it benchmarking
+  well here does not make it production code (see the backlog task's last
+  acceptance line).
+
+## What it implements
+
+- **Viewport culling** — `visiblePlacements`/`visiblePlacementsForTrack`
+  (`../projection.ts`) query only the visible tick range plus a small
+  overscan, using the per-track sorted index instead of scanning every
+  placement in the project.
+- **Layered invalidation** — three stacked `<canvas>` elements (background,
+  content, interaction), each redrawn only when its own dirty reason fires
+  (`ArrangementSpike.tsx`'s `markDirty`/`drawDirtyLayers`). Moving the
+  playhead or hovering a placement redraws only the interaction layer.
+  Nothing runs on a permanent animation-frame loop; a draw happens only when
+  something is marked dirty, and at most once per animation frame.
+- **Pointer hit testing** — `hitTestArrangement` (`../projection.ts`) checks
+  resize handles before the placement body, using the same tick/row
+  conversion the drawing code uses.
+- **Wheel/pinch zoom anchoring** — `zoomAtAnchor` (`../geometry.ts`) keeps the
+  musical tick under the pointer fixed across a zoom change; plain wheel
+  scrolls, ctrl/cmd-wheel (the desktop-browser pinch-zoom convention) zooms.
+- **Virtualized track headers** — the header column only renders DOM nodes
+  for `visibleRowRange(...) + overscan`, translated to track the shared
+  scroll position, rather than one element per track in the project.
+
+## Running it in a browser
+
+```sh
+bun run dev
+```
+
+then open `/spike/arrangement?tracks=50` (`tracks` accepts `20`, `40`, or
+`50`, matching `createArrangementSpikeProject` in
+`src/domain/fixtures.ts`; defaults to `50`).
+
+## Measurement harness
+
+See [`docs/arrangement-renderer-spike.md`](../../../docs/arrangement-renderer-spike.md)
+for the single documented command that runs the scripted scroll/zoom/seek/
+selection traces and where the baseline numbers are checked in.

--- a/src/arrangement/spike/canvasLayers.ts
+++ b/src/arrangement/spike/canvasLayers.ts
@@ -1,0 +1,291 @@
+import type { PlacementId, TrackId } from "../../domain/ids";
+import { TICKS_PER_BAR } from "../../domain/time";
+import type { RowRange, TickRange, Viewport } from "../geometry";
+import { ticksToPixels } from "../geometry";
+import type { ArrangementProjection, PlacementGeometry } from "../projection";
+import { visiblePlacements } from "../projection";
+import {
+	createWaveformCache,
+	selectPeakLevel,
+	type WaveformCache,
+} from "../waveformCache";
+
+/**
+ * Canvas 2D drawing for the FND-008 spike's three stacked layers (PRD 9.3
+ * "Layered drawing and invalidation"). Every function here only reads
+ * `ArrangementProjection`/geometry data and draws the visible range it is
+ * given — it never touches domain-shaped data and never iterates anything
+ * outside `rowRange`/`tickRange`.
+ */
+
+export interface DrawEnvironment {
+	readonly ctx: CanvasRenderingContext2D;
+	readonly viewport: Viewport;
+	readonly projection: ArrangementProjection;
+	readonly rowRange: RowRange;
+	readonly tickRange: TickRange;
+	readonly waveformCache: WaveformCache;
+}
+
+export interface InteractionState {
+	readonly playheadTicks: number | null;
+	readonly selection: {
+		readonly trackId: TrackId;
+		readonly startTick: number;
+		readonly endTick: number;
+	} | null;
+	readonly hoverPlacementId: PlacementId | null;
+}
+
+const COLORS = {
+	background: "#141414",
+	rowAlt: "#181818",
+	gridBeat: "#262626",
+	gridBar: "#383838",
+	text: "#8a8a8a",
+	playhead: "#20c8e8",
+	selection: "rgba(32, 200, 232, 0.18)",
+	selectionBorder: "#20c8e8",
+	hover: "#e6e6e6",
+};
+
+function screenX(tick: number, viewport: Viewport): number {
+	return ticksToPixels(tick, viewport) - viewport.scrollLeft;
+}
+
+function rowTop(rowIndex: number, projection: ArrangementProjection): number {
+	return projection.rowOffsets[rowIndex];
+}
+
+export function createSpikeWaveformCache(): WaveformCache {
+	return createWaveformCache();
+}
+
+export function clearLayer(env: DrawEnvironment): void {
+	env.ctx.clearRect(0, 0, env.viewport.width, env.viewport.height);
+}
+
+/** Bar/beat grid and row backgrounds — changes only on zoom, scroll, or track-count change. */
+export function drawBackgroundLayer(env: DrawEnvironment): void {
+	const { ctx, viewport, projection, rowRange } = env;
+	clearLayer(env);
+	ctx.fillStyle = COLORS.background;
+	ctx.fillRect(0, 0, viewport.width, viewport.height);
+
+	for (
+		let rowIndex = rowRange.startRow;
+		rowIndex <= rowRange.endRow;
+		rowIndex += 1
+	) {
+		if (rowIndex % 2 === 1) {
+			const top = rowTop(rowIndex, projection) - viewport.scrollTop;
+			ctx.fillStyle = COLORS.rowAlt;
+			ctx.fillRect(0, top, viewport.width, projection.rowMetrics.trackHeightPx);
+		}
+	}
+
+	const firstBar = Math.floor(env.tickRange.startTick / TICKS_PER_BAR);
+	const lastBar = Math.ceil(env.tickRange.endTick / TICKS_PER_BAR);
+	ctx.strokeStyle = COLORS.gridBeat;
+	ctx.lineWidth = 1;
+	for (let bar = firstBar; bar <= lastBar; bar += 1) {
+		const x = Math.round(screenX(bar * TICKS_PER_BAR, viewport)) + 0.5;
+		ctx.strokeStyle = bar % 4 === 0 ? COLORS.gridBar : COLORS.gridBeat;
+		ctx.beginPath();
+		ctx.moveTo(x, 0);
+		ctx.lineTo(x, viewport.height);
+		ctx.stroke();
+	}
+}
+
+function drawPlacement(
+	env: DrawEnvironment,
+	placement: PlacementGeometry,
+): void {
+	const { ctx, viewport, projection } = env;
+	const left = screenX(placement.startTicks, viewport);
+	const right = screenX(placement.endTicks, viewport);
+	const top = rowTop(placement.rowIndex, projection) - viewport.scrollTop + 2;
+	const height = projection.rowMetrics.trackHeightPx - 4;
+	const width = Math.max(1, right - left);
+
+	ctx.fillStyle = placement.color;
+	ctx.globalAlpha = 0.85;
+	ctx.fillRect(left, top, width, height);
+	ctx.globalAlpha = 1;
+
+	if (placement.preview.kind === "waveform") {
+		drawWaveformPreview(env, placement, left, top, width, height);
+	} else {
+		drawNotePreview(env, placement, left, width, top, height);
+	}
+}
+
+function drawNotePreview(
+	env: DrawEnvironment,
+	placement: PlacementGeometry,
+	left: number,
+	width: number,
+	top: number,
+	height: number,
+): void {
+	if (placement.preview.kind !== "notes") return;
+	const { ctx } = env;
+	const durationTicks = placement.endTicks - placement.startTicks;
+	if (durationTicks <= 0) return;
+	ctx.fillStyle = "rgba(0, 0, 0, 0.45)";
+	for (const noteTick of placement.preview.noteStartTicks) {
+		const fraction = noteTick / durationTicks;
+		const x = left + fraction * width;
+		ctx.fillRect(x, top + 2, 2, height - 4);
+	}
+}
+
+function drawWaveformPreview(
+	env: DrawEnvironment,
+	placement: PlacementGeometry,
+	left: number,
+	top: number,
+	width: number,
+	height: number,
+): void {
+	if (placement.preview.kind !== "waveform") return;
+	const { ctx, waveformCache } = env;
+	const peaks = waveformCache.get(
+		placement.preview.assetId,
+		placement.preview.assetRevision,
+		4,
+	);
+	const targetBuckets = Math.max(1, Math.round(width));
+	const level = selectPeakLevel(peaks, targetBuckets);
+	const mid = top + height / 2;
+
+	ctx.strokeStyle = "rgba(0, 0, 0, 0.55)";
+	ctx.lineWidth = 1;
+	ctx.beginPath();
+	for (let bucket = 0; bucket < level.bucketCount; bucket += 1) {
+		const x = left + (bucket / level.bucketCount) * width;
+		const max = level.max[bucket];
+		const min = level.min[bucket];
+		ctx.moveTo(x, mid - max * (height / 2));
+		ctx.lineTo(x, mid - min * (height / 2));
+	}
+	ctx.stroke();
+}
+
+/** Clip blocks, note/waveform previews, and automation — changes on scroll,
+ * zoom, or a content revision bump; not on playhead/hover/selection alone. */
+export function drawContentLayer(env: DrawEnvironment): void {
+	clearLayer(env);
+	const visible = visiblePlacements(
+		env.projection,
+		env.tickRange,
+		env.rowRange,
+	);
+	for (const placement of visible) {
+		drawPlacement(env, placement);
+	}
+	drawAutomationLanes(env);
+}
+
+function drawAutomationLanes(env: DrawEnvironment): void {
+	const { ctx, viewport, projection, rowRange } = env;
+	for (
+		let rowIndex = rowRange.startRow;
+		rowIndex <= rowRange.endRow;
+		rowIndex += 1
+	) {
+		const track = projection.tracks[rowIndex];
+		if (!track) continue;
+		const lane = projection.automationByTrack.get(track.id);
+		if (!lane || lane.points.length === 0) continue;
+
+		const top = rowTop(rowIndex, projection) - viewport.scrollTop;
+		const height = projection.rowMetrics.trackHeightPx;
+		ctx.strokeStyle = COLORS.playhead;
+		ctx.lineWidth = 1.5;
+		ctx.beginPath();
+		let previousY: number | null = null;
+		for (const point of lane.points) {
+			const x = screenX(point.tick, viewport);
+			if (x < -8 || x > viewport.width + 8) continue;
+			const normalized = 1 - Math.max(0, Math.min(1, (point.value + 1) / 2));
+			const y = top + 4 + normalized * (height - 8);
+			if (previousY === null) {
+				ctx.moveTo(x, y);
+			} else if (lane.interpolation === "step") {
+				ctx.lineTo(x, previousY);
+				ctx.lineTo(x, y);
+			} else {
+				ctx.lineTo(x, y);
+			}
+			previousY = y;
+		}
+		if (previousY !== null) ctx.stroke();
+	}
+}
+
+/** Playhead, selection, and hover — the only layer redrawn on every pointer
+ * move or transport tick, so it must stay cheap regardless of project size. */
+export function drawInteractionLayer(
+	env: DrawEnvironment,
+	interaction: InteractionState,
+): void {
+	clearLayer(env);
+	const { ctx, viewport, projection } = env;
+
+	if (interaction.selection) {
+		const { trackId, startTick, endTick } = interaction.selection;
+		const rowIndex = projection.tracks.find(
+			(track) => track.id === trackId,
+		)?.rowIndex;
+		if (rowIndex !== undefined) {
+			const left = screenX(startTick, viewport);
+			const right = screenX(endTick, viewport);
+			const top = rowTop(rowIndex, projection) - viewport.scrollTop;
+			ctx.fillStyle = COLORS.selection;
+			ctx.fillRect(
+				left,
+				top,
+				right - left,
+				projection.rowMetrics.trackHeightPx,
+			);
+			ctx.strokeStyle = COLORS.selectionBorder;
+			ctx.strokeRect(
+				left,
+				top,
+				right - left,
+				projection.rowMetrics.trackHeightPx,
+			);
+		}
+	}
+
+	if (interaction.hoverPlacementId) {
+		const placement = env.projection.placementsById.get(
+			interaction.hoverPlacementId,
+		);
+		if (placement) {
+			const left = screenX(placement.startTicks, viewport);
+			const right = screenX(placement.endTicks, viewport);
+			const top = rowTop(placement.rowIndex, projection) - viewport.scrollTop;
+			ctx.strokeStyle = COLORS.hover;
+			ctx.lineWidth = 2;
+			ctx.strokeRect(
+				left + 1,
+				top + 1,
+				Math.max(1, right - left - 2),
+				projection.rowMetrics.trackHeightPx - 2,
+			);
+		}
+	}
+
+	if (interaction.playheadTicks !== null) {
+		const x = Math.round(screenX(interaction.playheadTicks, viewport)) + 0.5;
+		ctx.strokeStyle = COLORS.playhead;
+		ctx.lineWidth = 2;
+		ctx.beginPath();
+		ctx.moveTo(x, 0);
+		ctx.lineTo(x, viewport.height);
+		ctx.stroke();
+	}
+}

--- a/src/arrangement/spike/instrumentation.ts
+++ b/src/arrangement/spike/instrumentation.ts
@@ -1,0 +1,121 @@
+/**
+ * Measurement instrumentation for the FND-008 renderer spike (PRD 9.3
+ * "Phase 0 ... is required to produce ... a harness that emits frame time,
+ * long-task, redraw-count and memory numbers on whatever hardware runs it").
+ *
+ * This module only counts and records; it never decides *whether* a redraw
+ * is needed (`ArrangementSpike.tsx` does that) or what a "good" number looks
+ * like (nothing here is gated on a budget — see docs/arrangement-renderer-spike.md).
+ */
+
+export type DirtyLayer = "background" | "content" | "interaction";
+
+export interface FrameSample {
+	readonly timestampMs: number;
+	readonly durationMs: number;
+	readonly layers: readonly DirtyLayer[];
+}
+
+export interface LongTaskSample {
+	readonly startMs: number;
+	readonly durationMs: number;
+}
+
+export interface InstrumentationSnapshot {
+	readonly redrawCounts: Readonly<Record<DirtyLayer, number>>;
+	readonly frames: readonly FrameSample[];
+	readonly longTasks: readonly LongTaskSample[];
+	readonly heapUsedMB: number | null;
+}
+
+export interface Instrumentation {
+	recordRedraw(layers: readonly DirtyLayer[], durationMs: number): void;
+	reset(): void;
+	snapshot(): InstrumentationSnapshot;
+	dispose(): void;
+}
+
+/** Chrome-only, non-standard; every other engine leaves this undefined. */
+interface PerformanceMemory {
+	usedJSHeapSize: number;
+}
+
+function readHeapUsedMB(): number | null {
+	const memory = (performance as Performance & { memory?: PerformanceMemory })
+		.memory;
+	if (!memory) return null;
+	return memory.usedJSHeapSize / (1024 * 1024);
+}
+
+export function createInstrumentation(): Instrumentation {
+	let redrawCounts: Record<DirtyLayer, number> = {
+		background: 0,
+		content: 0,
+		interaction: 0,
+	};
+	let frames: FrameSample[] = [];
+	let longTasks: LongTaskSample[] = [];
+
+	let observer: PerformanceObserver | undefined;
+	if (typeof PerformanceObserver !== "undefined") {
+		try {
+			observer = new PerformanceObserver((list) => {
+				for (const entry of list.getEntries()) {
+					longTasks.push({
+						startMs: entry.startTime,
+						durationMs: entry.duration,
+					});
+				}
+			});
+			// "longtask" is Chromium-only (the PRD's gating browsers include
+			// Chrome/Edge); Firefox/Safari simply never call the callback.
+			observer.observe({ entryTypes: ["longtask"] });
+		} catch {
+			observer = undefined;
+		}
+	}
+
+	return {
+		recordRedraw(layers, durationMs) {
+			for (const layer of layers) {
+				redrawCounts[layer] += 1;
+			}
+			frames.push({
+				timestampMs: performance.now(),
+				durationMs,
+				layers: [...layers],
+			});
+		},
+		reset() {
+			redrawCounts = { background: 0, content: 0, interaction: 0 };
+			frames = [];
+			longTasks = [];
+		},
+		snapshot() {
+			return {
+				redrawCounts: { ...redrawCounts },
+				frames: [...frames],
+				longTasks: [...longTasks],
+				heapUsedMB: readHeapUsedMB(),
+			};
+		},
+		dispose() {
+			observer?.disconnect();
+		},
+	};
+}
+
+/** `p` in `[0, 100]`. Assumes `values` is non-empty. */
+export function percentile(values: readonly number[], p: number): number {
+	const sorted = [...values].sort((a, b) => a - b);
+	const rank = (p / 100) * (sorted.length - 1);
+	const low = Math.floor(rank);
+	const high = Math.ceil(rank);
+	if (low === high) return sorted[low];
+	const weight = rank - low;
+	return sorted[low] * (1 - weight) + sorted[high] * weight;
+}
+
+export function median(values: readonly number[]): number {
+	return percentile(values, 50);
+}

--- a/src/arrangement/waveformCache.test.ts
+++ b/src/arrangement/waveformCache.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { createWaveformCache, selectPeakLevel } from "./waveformCache";
+
+describe("waveform peak generation", () => {
+	it("is deterministic for the same asset id and revision", () => {
+		const cache = createWaveformCache();
+		const first = cache.get("ast_a", 1, 4);
+		const other = createWaveformCache().get("ast_a", 1, 4);
+		expect(other.levels.map((level) => Array.from(level.max))).toEqual(
+			first.levels.map((level) => Array.from(level.max)),
+		);
+	});
+
+	it("differs when the asset id differs", () => {
+		const cache = createWaveformCache();
+		const a = cache.get("ast_a", 1, 4);
+		const b = cache.get("ast_b", 1, 4);
+		expect(Array.from(a.levels[0].max)).not.toEqual(
+			Array.from(b.levels[0].max),
+		);
+	});
+
+	it("differs when the revision differs (a new decode of the same asset)", () => {
+		const cache = createWaveformCache();
+		const revisionOne = cache.get("ast_a", 1, 4);
+		const revisionTwo = cache.get("ast_a", 2, 4);
+		expect(Array.from(revisionOne.levels[0].max)).not.toEqual(
+			Array.from(revisionTwo.levels[0].max),
+		);
+	});
+
+	it("produces multiple resolutions, finest first", () => {
+		const cache = createWaveformCache();
+		const peaks = cache.get("ast_a", 1, 4);
+		expect(peaks.levels.length).toBeGreaterThan(1);
+		for (let index = 1; index < peaks.levels.length; index += 1) {
+			expect(peaks.levels[index].bucketCount).toBeLessThan(
+				peaks.levels[index - 1].bucketCount,
+			);
+		}
+	});
+
+	it("keeps every bucket's min/max within [-1, 1]", () => {
+		const cache = createWaveformCache();
+		const peaks = cache.get("ast_a", 1, 4);
+		for (const level of peaks.levels) {
+			for (const value of level.max) {
+				expect(value).toBeGreaterThanOrEqual(-1);
+				expect(value).toBeLessThanOrEqual(1);
+			}
+			for (const value of level.min) {
+				expect(value).toBeGreaterThanOrEqual(-1);
+				expect(value).toBeLessThanOrEqual(1);
+			}
+		}
+	});
+});
+
+describe("createWaveformCache", () => {
+	it("caches by (assetId, revision): a second get for the same key is the same object", () => {
+		const cache = createWaveformCache();
+		const first = cache.get("ast_a", 1, 4);
+		const second = cache.get("ast_a", 1, 4);
+		expect(second).toBe(first);
+		expect(cache.entryCount).toBe(1);
+	});
+
+	it("tracks bytesUsed as entries are added", () => {
+		const cache = createWaveformCache();
+		expect(cache.bytesUsed).toBe(0);
+		const peaks = cache.get("ast_a", 1, 4);
+		expect(cache.bytesUsed).toBe(peaks.byteLength);
+	});
+
+	it("evicts least-recently-used entries once the byte budget is exceeded", () => {
+		const peaks = createWaveformCache().get("ast_a", 1, 4);
+		const budget = peaks.byteLength * 2 + 1; // room for two, not three
+		const cache = createWaveformCache(budget);
+
+		cache.get("ast_a", 1, 4);
+		cache.get("ast_b", 1, 4);
+		expect(cache.entryCount).toBe(2);
+
+		cache.get("ast_c", 1, 4); // evicts ast_a, the least-recently-used
+		expect(cache.entryCount).toBe(2);
+		expect(cache.bytesUsed).toBeLessThanOrEqual(budget);
+	});
+
+	it("treats a recent get as a use, protecting it from eviction", () => {
+		const peaks = createWaveformCache().get("ast_a", 1, 4);
+		const budget = peaks.byteLength * 2 + 1;
+		const cache = createWaveformCache(budget);
+
+		cache.get("ast_a", 1, 4);
+		cache.get("ast_b", 1, 4);
+		cache.get("ast_a", 1, 4); // touch ast_a again; ast_b is now the LRU entry
+		cache.get("ast_c", 1, 4); // should evict ast_b, not ast_a
+
+		const afterA = cache.get("ast_a", 1, 4);
+		expect(afterA).toEqual(peaks);
+	});
+});
+
+describe("selectPeakLevel", () => {
+	it("picks the level with the closest bucket count", () => {
+		const peaks = createWaveformCache().get("ast_a", 1, 4);
+		const finest = peaks.levels[0];
+		const coarsest = peaks.levels[peaks.levels.length - 1];
+
+		expect(selectPeakLevel(peaks, finest.bucketCount)).toBe(finest);
+		expect(selectPeakLevel(peaks, coarsest.bucketCount)).toBe(coarsest);
+	});
+});

--- a/src/arrangement/waveformCache.ts
+++ b/src/arrangement/waveformCache.ts
@@ -1,0 +1,162 @@
+/**
+ * Waveform peak-pyramid cache (PRD section 9.3, "Culling, projection, and
+ * caches"):
+ *
+ * "Waveforms use precomputed min/max peak pyramids at multiple resolutions.
+ * Peaks are computed once in a worker, cached by asset ID and source
+ * revision, and selected by zoom level; raw samples are never scanned during
+ * paint. Visual caches have an LRU memory budget. Eviction affects only
+ * drawing speed, never project or audio correctness."
+ *
+ * Phase 0 has no audio-decode pipeline behind this spike — there is no
+ * worker computing real peaks from a decoded `AudioBuffer` yet. What this
+ * module keeps is the *cache contract*: keyed by `(assetId, revision)`,
+ * multi-resolution, LRU-evicted against a byte budget. `generateSyntheticPeaks`
+ * is the only piece a later task swaps for a real decoder; every caller only
+ * ever sees `WaveformCache.get`.
+ */
+
+export interface PeakLevel {
+	/** Number of min/max buckets at this resolution. Higher = finer detail. */
+	readonly bucketCount: number;
+	readonly min: Float32Array;
+	readonly max: Float32Array;
+}
+
+export interface WaveformPeaks {
+	readonly assetId: string;
+	readonly revision: number;
+	readonly durationSeconds: number;
+	/** Finest resolution first. */
+	readonly levels: readonly PeakLevel[];
+	readonly byteLength: number;
+}
+
+/** Bucket counts for each cached resolution, finest to coarsest. Matches the
+ * shape of a real min/max mip pyramid without committing to real sample rates. */
+const PEAK_LEVEL_BUCKET_COUNTS = [2048, 512, 128, 32] as const;
+
+/** PRD 9.3: "at most 128 MiB", excluding decoded audio buffers. */
+export const WAVEFORM_CACHE_BUDGET_BYTES = 128 * 1024 * 1024;
+
+export interface WaveformCache {
+	/** Returns cached peaks for `(assetId, revision)`, generating and
+	 * inserting them on a miss, and evicting least-recently-used entries if
+	 * the budget is exceeded. */
+	get(
+		assetId: string,
+		revision: number,
+		durationSeconds: number,
+	): WaveformPeaks;
+	readonly bytesUsed: number;
+	readonly entryCount: number;
+}
+
+/** Picks the cached level whose bucket count is closest to `targetBucketCount`. */
+export function selectPeakLevel(
+	peaks: WaveformPeaks,
+	targetBucketCount: number,
+): PeakLevel {
+	let best = peaks.levels[0];
+	let bestDistance = Math.abs(best.bucketCount - targetBucketCount);
+	for (const level of peaks.levels) {
+		const distance = Math.abs(level.bucketCount - targetBucketCount);
+		if (distance < bestDistance) {
+			best = level;
+			bestDistance = distance;
+		}
+	}
+	return best;
+}
+
+export function createWaveformCache(
+	budgetBytes: number = WAVEFORM_CACHE_BUDGET_BYTES,
+): WaveformCache {
+	// `Map` preserves insertion order, and a hit re-inserts its key, so
+	// iteration order is always least-recently-used first — no separate
+	// linked-list bookkeeping needed for LRU eviction.
+	const entries = new Map<string, WaveformPeaks>();
+	let bytesUsed = 0;
+
+	function evictUntilWithinBudget(): void {
+		for (const [key, value] of entries) {
+			if (bytesUsed <= budgetBytes) break;
+			entries.delete(key);
+			bytesUsed -= value.byteLength;
+		}
+	}
+
+	return {
+		get(assetId, revision, durationSeconds) {
+			const key = `${assetId}@${revision}`;
+			const cached = entries.get(key);
+			if (cached) {
+				entries.delete(key);
+				entries.set(key, cached);
+				return cached;
+			}
+			const peaks = generateSyntheticPeaks(assetId, revision, durationSeconds);
+			entries.set(key, peaks);
+			bytesUsed += peaks.byteLength;
+			evictUntilWithinBudget();
+			return peaks;
+		},
+		get bytesUsed() {
+			return bytesUsed;
+		},
+		get entryCount() {
+			return entries.size;
+		},
+	};
+}
+
+function generateSyntheticPeaks(
+	assetId: string,
+	revision: number,
+	durationSeconds: number,
+): WaveformPeaks {
+	const random = mulberry32(hashString(`${assetId}@${revision}`));
+	const levels: PeakLevel[] = PEAK_LEVEL_BUCKET_COUNTS.map((bucketCount) => {
+		const min = new Float32Array(bucketCount);
+		const max = new Float32Array(bucketCount);
+		let amplitude = 0.2;
+		for (let index = 0; index < bucketCount; index += 1) {
+			amplitude = clamp01(amplitude + (random() - 0.5) * 0.15);
+			max[index] = amplitude;
+			min[index] = -amplitude * (0.6 + random() * 0.4);
+		}
+		return { bucketCount, min, max };
+	});
+	const byteLength = levels.reduce(
+		(sum, level) => sum + level.min.byteLength + level.max.byteLength,
+		0,
+	);
+	return { assetId, revision, durationSeconds, levels, byteLength };
+}
+
+function clamp01(value: number): number {
+	return Math.min(1, Math.max(0, value));
+}
+
+/** FNV-1a, matching the small stable hash already used for seeded IDs. */
+function hashString(value: string): number {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < value.length; index += 1) {
+		hash ^= value.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	return hash === 0 ? 0x9e3779b9 : hash >>> 0;
+}
+
+/** Mulberry32: small, fast, and stable across engines — same generator
+ * `src/domain/ids.ts` uses for seeded IDs, reused here for the same reasons. */
+function mulberry32(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let value = state;
+		value = Math.imul(value ^ (value >>> 15), value | 1);
+		value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+		return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+	};
+}

--- a/src/domain/factories.test.ts
+++ b/src/domain/factories.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { SCHEMA_VERSION } from "./entities";
 import { createBlankProject } from "./factories";
-import { createReferenceProject, createSliceFixtureProject } from "./fixtures";
+import {
+	ARRANGEMENT_SPIKE_TRACK_COUNTS,
+	createArrangementSpikeFixtures,
+	createArrangementSpikeProject,
+	createReferenceProject,
+	createSliceFixtureProject,
+} from "./fixtures";
 import { createSeededIdFactory, idPattern } from "./ids";
 import { MASTER_VOLUME, SONG_TEMPO } from "./parameters";
 import { isProject, parseProject } from "./parse";
@@ -125,5 +131,84 @@ describe("fixtures", () => {
 		});
 		expect(parseProject(small).ok).toBe(true);
 		expect(small.song.tracks).toHaveLength(4);
+	});
+
+	it("adds audio tracks with audioLoop clips when waveformTrackCount is set", () => {
+		const project = createReferenceProject({
+			trackCount: 10,
+			waveformTrackCount: 4,
+		});
+		expect(parseProject(project).ok).toBe(true);
+
+		const audioTracks = project.song.tracks.filter(
+			(track) => track.type === "audio",
+		);
+		expect(audioTracks).toHaveLength(4);
+		expect(audioTracks.every((track) => track.instrument === null)).toBe(true);
+
+		const clipsByTrack = new Map(
+			project.clips.map((clip) => [clip.trackId, clip]),
+		);
+		for (const track of audioTracks) {
+			expect(clipsByTrack.get(track.id)?.content.kind).toBe("audioLoop");
+		}
+		const instrumentTracks = project.song.tracks.filter(
+			(track) => track.type === "instrument",
+		);
+		for (const track of instrumentTracks) {
+			expect(clipsByTrack.get(track.id)?.content.kind).toBe("notes");
+		}
+		// The waveform-bearing asset is registered on the song, not orphaned.
+		const audioLoopAssetIds = new Set(
+			project.clips
+				.map((clip) => clip.content)
+				.filter((content) => content.kind === "audioLoop")
+				.map((content) => content.assetId),
+		);
+		for (const assetId of audioLoopAssetIds) {
+			expect(project.song.assets.some((asset) => asset.id === assetId)).toBe(
+				true,
+			);
+		}
+	});
+});
+
+describe("FND-008 arrangement spike fixtures", () => {
+	it.each(ARRANGEMENT_SPIKE_TRACK_COUNTS)(
+		"builds a valid, ten-minute, dense, automated %i-track arrangement",
+		(trackCount) => {
+			const project = createArrangementSpikeProject(trackCount);
+			const lengthTicks = minutesToTicks(10, project.song.tempo);
+
+			expect(parseProject(project).ok).toBe(true);
+			expect(project.song.tracks).toHaveLength(trackCount);
+			expect(project.song.placements.length).toBeGreaterThan(trackCount);
+			expect(project.song.automation.length).toBeGreaterThan(0);
+
+			const waveformTracks = project.song.tracks.filter(
+				(track) => track.type === "audio",
+			);
+			expect(waveformTracks.length).toBeGreaterThan(0);
+
+			const lastTick = Math.max(
+				...project.song.placements.map(
+					(placement) => placement.startTicks + placement.durationTicks,
+				),
+			);
+			expect(lastTick).toBeLessThanOrEqual(lengthTicks);
+		},
+	);
+
+	it("is deterministic across calls at the same track count", () => {
+		expect(createArrangementSpikeProject(20)).toEqual(
+			createArrangementSpikeProject(20),
+		);
+	});
+
+	it("builds all three benchmark track counts keyed by count", () => {
+		const fixtures = createArrangementSpikeFixtures();
+		for (const trackCount of ARRANGEMENT_SPIKE_TRACK_COUNTS) {
+			expect(fixtures[trackCount].song.tracks).toHaveLength(trackCount);
+		}
 	});
 });

--- a/src/domain/factories.test.ts
+++ b/src/domain/factories.test.ts
@@ -182,7 +182,13 @@ describe("FND-008 arrangement spike fixtures", () => {
 
 			expect(parseProject(project).ok).toBe(true);
 			expect(project.song.tracks).toHaveLength(trackCount);
-			expect(project.song.placements.length).toBeGreaterThan(trackCount);
+			// Density, not just "more than one per track": must match the PRD 9.3
+			// reference arrangement's 50 placements/track (50 tracks * 50 = 2,500,
+			// its "at least 2,500 clip placements"), so a future change can't
+			// silently thin the fixture back to an unrepresentative benchmark.
+			expect(project.song.placements.length).toBeGreaterThanOrEqual(
+				trackCount * 50,
+			);
 			expect(project.song.automation.length).toBeGreaterThan(0);
 
 			const waveformTracks = project.song.tracks.filter(

--- a/src/domain/fixtures.ts
+++ b/src/domain/fixtures.ts
@@ -451,9 +451,12 @@ export function createArrangementSpikeProject(
 		...options,
 		seed: options.seed ?? `arrangement-spike-${trackCount}`,
 		trackCount,
-		// 2 placements/track/minute keeps every track count "dense" without the
-		// placement count growing unboundedly with track count.
-		placementCount: trackCount * 20,
+		// 50 placements/track matches the PRD 9.3 reference arrangement's
+		// density (50 tracks * 50 = 2,500, its "at least 2,500 clip
+		// placements"). Per-frame draw cost is proportional to placement
+		// density, not track count alone, so the 50-track benchmark must reach
+		// the reference arrangement's occupancy, not a sparser stand-in.
+		placementCount: trackCount * 50,
 		automationLaneCount: Math.round(trackCount * 2),
 		waveformTrackCount: Math.round(trackCount * 0.4),
 	});

--- a/src/domain/fixtures.ts
+++ b/src/domain/fixtures.ts
@@ -249,6 +249,15 @@ export interface ReferenceProjectOptions extends FixtureOptions {
 	placementCount?: number;
 	/** Automation lanes. The PRD reference project uses 100. */
 	automationLaneCount?: number;
+	/**
+	 * How many of `trackCount` tracks are `audio` tracks holding an
+	 * `audioLoop` clip instead of an `instrument` track holding a note clip.
+	 * The PRD reference project puts "waveforms on 20 tracks" — the FND-008
+	 * renderer spike needs this to exercise waveform-preview placements, not
+	 * just note-preview ones. Defaults to `0` so the plain reference project
+	 * (used by existing schema/persistence tests) is unchanged.
+	 */
+	waveformTrackCount?: number;
 }
 
 /**
@@ -265,6 +274,14 @@ export function createReferenceProject(
 	const minutes = options.minutes ?? 10;
 	const placementCount = options.placementCount ?? 2_500;
 	const automationLaneCount = options.automationLaneCount ?? 100;
+	const waveformTrackCount = Math.min(
+		trackCount,
+		Math.max(0, options.waveformTrackCount ?? 0),
+	);
+	const waveformTrackIndices = evenlySpacedIndices(
+		trackCount,
+		waveformTrackCount,
+	);
 
 	const lengthTicks = minutesToTicks(minutes, tempo);
 	const barCount = Math.floor(lengthTicks / TICKS_PER_BAR);
@@ -282,30 +299,54 @@ export function createReferenceProject(
 		sampleRate: 44_100,
 		channelCount: 2,
 	});
+	const loopAsset =
+		waveformTrackCount > 0
+			? createAsset(context, {
+					name: "Reference waveform loop",
+					kind: "loop",
+					storageRef: "samples/reference/waveform-loop.wav",
+					url: "/samples/reference/waveform-loop.wav",
+					durationSeconds: 4,
+					sampleRate: 44_100,
+					channelCount: 2,
+				})
+			: null;
 
 	const placementsPerTrack = Math.ceil(placementCount / trackCount);
 
 	for (let index = 0; index < trackCount; index += 1) {
+		const isWaveformTrack = waveformTrackIndices.has(index);
+
 		const track = createTrack(context, {
-			name: `Track ${index + 1}`,
+			name: isWaveformTrack ? `Loop ${index + 1}` : `Track ${index + 1}`,
 			order: index,
-			instrument: createSamplerInstrument(asset.id),
+			type: isWaveformTrack ? "audio" : "instrument",
+			instrument: isWaveformTrack ? null : createSamplerInstrument(asset.id),
 		});
 		tracks.push(track);
 
-		const clip = createNoteClip(context, {
-			trackId: track.id,
-			name: `Clip ${index + 1}`,
-			lengthTicks: TICKS_PER_BAR * 2,
-			events: [0, 2, 4, 6, 8, 10, 12, 14].map((sixteenth) =>
-				createNoteEvent(context, {
-					startTicks: sixteenth * TICKS_PER_SIXTEENTH,
-					durationTicks: TICKS_PER_SIXTEENTH,
-					pitch: 36 + (index % 24),
-					velocity: 0.6 + (index % 4) / 10,
-				}),
-			),
-		});
+		const clip =
+			isWaveformTrack && loopAsset
+				? createAudioLoopClip(context, {
+						trackId: track.id,
+						assetId: loopAsset.id,
+						name: `Loop clip ${index + 1}`,
+						lengthTicks: TICKS_PER_BAR * 2,
+						sourceTempo: tempo,
+					})
+				: createNoteClip(context, {
+						trackId: track.id,
+						name: `Clip ${index + 1}`,
+						lengthTicks: TICKS_PER_BAR * 2,
+						events: [0, 2, 4, 6, 8, 10, 12, 14].map((sixteenth) =>
+							createNoteEvent(context, {
+								startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+								durationTicks: TICKS_PER_SIXTEENTH,
+								pitch: 36 + (index % 24),
+								velocity: 0.6 + (index % 4) / 10,
+							}),
+						),
+					});
 		clips.push(clip);
 
 		const spacingBars = Math.max(
@@ -368,7 +409,7 @@ export function createReferenceProject(
 		}),
 		song: {
 			...createEmptySong(tempo),
-			assets: [asset],
+			assets: loopAsset ? [asset, loopAsset] : [asset],
 			tracks,
 			placements,
 			automation,
@@ -376,4 +417,58 @@ export function createReferenceProject(
 		},
 		clips,
 	});
+}
+
+/** `count` indices spread as evenly as possible across `[0, total)`. */
+function evenlySpacedIndices(total: number, count: number): Set<number> {
+	const indices = new Set<number>();
+	if (count <= 0 || total <= 0) return indices;
+	const stride = total / count;
+	for (let slot = 0; slot < count; slot += 1) {
+		indices.add(Math.min(total - 1, Math.floor(slot * stride)));
+	}
+	return indices;
+}
+
+/** Track counts the `FND-008` renderer spike's fixtures cover (backlog task). */
+export const ARRANGEMENT_SPIKE_TRACK_COUNTS = [20, 40, 50] as const;
+export type ArrangementSpikeTrackCount =
+	(typeof ARRANGEMENT_SPIKE_TRACK_COUNTS)[number];
+
+/**
+ * The `FND-008` renderer-spike fixture: a ten-minute, densely placed,
+ * automated arrangement at one of the spike's three benchmark track counts,
+ * with a proportional share of `audio` tracks holding `audioLoop` clips so
+ * waveform-preview placements (not just note-preview ones) get exercised.
+ * Built on {@link createReferenceProject} so it stays the same shape as the
+ * PRD 9.3 reference arrangement, just parameterized by track count.
+ */
+export function createArrangementSpikeProject(
+	trackCount: ArrangementSpikeTrackCount,
+	options: FixtureOptions = {},
+): Project {
+	return createReferenceProject({
+		...options,
+		seed: options.seed ?? `arrangement-spike-${trackCount}`,
+		trackCount,
+		// 2 placements/track/minute keeps every track count "dense" without the
+		// placement count growing unboundedly with track count.
+		placementCount: trackCount * 20,
+		automationLaneCount: Math.round(trackCount * 2),
+		waveformTrackCount: Math.round(trackCount * 0.4),
+	});
+}
+
+/** All three `FND-008` benchmark fixtures, keyed by track count. */
+export function createArrangementSpikeFixtures(
+	options: FixtureOptions = {},
+): Record<ArrangementSpikeTrackCount, Project> {
+	const entries = ARRANGEMENT_SPIKE_TRACK_COUNTS.map(
+		(trackCount) =>
+			[trackCount, createArrangementSpikeProject(trackCount, options)] as const,
+	);
+	return Object.fromEntries(entries) as Record<
+		ArrangementSpikeTrackCount,
+		Project
+	>;
 }

--- a/src/routes/spike/arrangement.tsx
+++ b/src/routes/spike/arrangement.tsx
@@ -1,0 +1,37 @@
+import { useSearchParams } from "@solidjs/router";
+import { createMemo } from "solid-js";
+import ArrangementSpike from "../../arrangement/spike/ArrangementSpike";
+import {
+	ARRANGEMENT_SPIKE_TRACK_COUNTS,
+	type ArrangementSpikeTrackCount,
+	createArrangementSpikeProject,
+} from "../../domain/fixtures";
+
+/**
+ * The FND-008 arrangement renderer spike (backlog task; PRD 9.3). Disposable
+ * exploratory UI — see `src/arrangement/spike/README.md` — reachable at
+ * `/spike/arrangement?tracks=20|40|50` for manual poking and for the
+ * Playwright measurement harness (`perf/arrangement.bench.spec.ts`) to drive.
+ * Not linked from any navigation; there is no product reason for an alpha
+ * user to find it.
+ */
+export default function ArrangementSpikePage() {
+	const [searchParams] = useSearchParams();
+
+	const trackCount = createMemo<ArrangementSpikeTrackCount>(() => {
+		const requested = Number(searchParams.tracks);
+		return ARRANGEMENT_SPIKE_TRACK_COUNTS.includes(
+			requested as ArrangementSpikeTrackCount,
+		)
+			? (requested as ArrangementSpikeTrackCount)
+			: 50;
+	});
+
+	const project = createMemo(() => createArrangementSpikeProject(trackCount()));
+
+	return (
+		<main style={{ height: "100vh", width: "100vw" }}>
+			<ArrangementSpike project={project()} />
+		</main>
+	);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,20 @@
+import { fileURLToPath } from "node:url";
 import solid from "vite-plugin-solid";
 import { configDefaults, defineConfig } from "vitest/config";
+
+// `vite-plugin-solid` normally auto-injects this setup file by checking
+// `require.resolve("@testing-library/jest-dom/vitest")` and, if resolvable,
+// handing Vite the *bare specifier* to resolve again later. Resolving that
+// bare specifier a second time, inside a nested git worktree (this repo's own
+// agent workflow runs each task in one under `.claude/worktrees/`), can walk
+// up past the worktree's own `node_modules` and land on the outer checkout's
+// copy instead — which Vite then refuses to load as outside its project root,
+// failing every single test file before it reaches a single assertion.
+// Resolving it once, here, to an absolute path removes the second lookup
+// entirely, so the correct local package is used regardless of nesting.
+const jestDomSetupPath = fileURLToPath(
+	import.meta.resolve("@testing-library/jest-dom/vitest"),
+);
 
 // Unit and component suites: fast, no external services, jsdom-backed
 // (vite-plugin-solid sets `test.environment: "jsdom"` automatically).
@@ -14,6 +29,7 @@ export default defineConfig({
 		conditions: ["development", "browser"],
 	},
 	test: {
+		setupFiles: [jestDomSetupPath],
 		// `.claude/**` keeps the runner out of git worktrees, which the agent
 		// workflow creates under `.claude/worktrees/`. Each is a full checkout,
 		// so without this a stray worktree's suites are collected alongside the
@@ -22,6 +38,9 @@ export default defineConfig({
 			...configDefaults.exclude,
 			"e2e/**",
 			"tests/emulator/**",
+			// The FND-008 arrangement-spike measurement harness: Playwright specs
+			// (`playwright.bench.config.ts`), not Vitest ones.
+			"perf/**",
 			".claude/**",
 		],
 	},


### PR DESCRIPTION
## Summary

Builds the disposable-but-representative hybrid virtualized-DOM/Canvas-2D arrangement spike, and the measurement infrastructure Phase 2 will enforce budgets with, ahead of the production arrangement editor expanding.

- **Reusable, renderer-agnostic contracts** (`src/arrangement/geometry.ts`, `projection.ts`, `revision.ts`, `waveformCache.ts`) — pure time/pixel projection, layout geometry, invalidation-revision tracking, and a waveform-peak cache, with no dependency on the spike's rendering code so a production renderer can consume them directly.
- **A disposable hybrid spike** (`src/arrangement/spike/`, routed at `/spike/arrangement`) implementing viewport culling, layered invalidation, pointer hit testing, wheel/pinch zoom anchoring, and virtualized track headers over a DOM shell + Canvas 2D timeline.
- **Deterministic benchmark fixtures** — `createArrangementSpikeProject`/`-Fixtures` in `src/domain/fixtures.ts` produce 20/40/50-track, ten-minute arrangements with dense placements, automation, and waveform-bearing audio tracks; the existing reference-project fixture gained an optional `waveformTrackCount`.
- **A scripted Playwright measurement harness** (`playwright.bench.config.ts`, `perf/arrangement.bench.spec.ts`) driving scroll/zoom/seek/selection traces and capturing frame time, long tasks, memory, and redraw counts behind a single documented command, `bun run bench:arrangement`.
- Documentation of the spike's scope, contracts, and harness usage in `docs/arrangement-renderer-spike.md`, plus a `vitest.config.ts` fix so the suite resolves correctly when run from a nested git worktree (this repo's own agent-workflow layout).

No baseline numbers are checked in: this sandbox has no outbound access to download Playwright's browser binaries, so the harness could not be run against the (also unavailable) physical baseline device. This is documented in `docs/arrangement-renderer-spike.md` rather than fabricated.

## PRD requirements

- [`ARR-01 - Timeline arrangement`](docs/prd.md) (P0)
- [PRD section 9.3 - Arrangement renderer decision](docs/prd.md), including "When these budgets are enforced"
- [PRD - Performance budgets](docs/prd.md)

## Acceptance criteria met (backlog FND-008)

- [x] Deterministic fixtures include 20, 40, and 50 tracks, ten-minute arrangements, dense placements, automation, and waveform placeholders.
- [x] The spike implements viewport culling, layered invalidation, pointer hit testing, wheel/pinch zoom anchoring, and virtualized track headers.
- [x] Scripted scroll, zoom, seek, and selection traces capture frame time, long tasks, memory, and redraw counts, and are runnable by a single documented command.
- [ ] Baseline numbers are checked in together with the hardware, browser, and browser version that produced them. Not measured in this sandbox (no outbound access to Playwright browser binaries, no physical baseline device); the harness and its `bun run bench:arrangement` command are ready to produce and check in `docs/perf/arrangement-spike-baseline.json` once run on the baseline device, per `docs/arrangement-renderer-spike.md`.
- [x] Reusable projection/geometry contracts and benchmark fixtures are retained and stay renderer-agnostic; experimental UI is not treated as production merely because it benchmarks well.

## Review

This branch went through an Opus review round in the implementation workflow.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SFkibHg472eihebmBAut5r


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkibHg472eihebmBAut5r)_