### PR TITLE
Add deployment, analytics, and monitoring requirements to the PRD

### DIFF
--- a/docs/adr/0001-sentry-for-error-monitoring.md
+++ b/docs/adr/0001-sentry-for-error-monitoring.md
@@ -1,0 +1,76 @@
+# ADR 0001 - Sentry for error and crash monitoring
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Date | 2026-07-25 |
+| Decides | PRD section 9.1 stack row "Error monitoring"; PRD `OPS-03` |
+| Supersedes | The Cloud Functions sink into Cloud Logging described in the first draft of `OPS-03` |
+| Affects | `FND-001b`, `FND-001c`, `HARD-003`, `DEC-009` |
+
+## Context
+
+PRD section 9.1 commits the alpha to Firebase for authentication, persistence, storage, privileged backend, hosting, and product analytics, and requires an approved ADR before an implementation adds an alternative. `OPS-03` originally satisfied crash monitoring inside that commitment: global browser error handlers and error boundaries would record an `exception` analytics event and post a structured report to a Cloud Functions endpoint writing to Cloud Logging, where Google Cloud Error Reporting would group it.
+
+Firebase Crashlytics was never an option — it does not support the Firebase Web SDK.
+
+Two facts about the Cloud Logging route changed the decision.
+
+**Source maps.** Google Cloud Error Reporting resolves browser stack traces only against *publicly available* source maps, discovered through a `//# sourceMappingURL=` comment pointing at a reachable URL. Private source maps are not supported, and the limitation is long-standing. `OPS-03` requires source maps to be retained for the deployed revision and **not** served publicly from Hosting. The route therefore forces a choice between unreadable minified production stack traces and publishing our source maps. Neither is acceptable: the first makes the monitoring worthless, the second is a deliberate change to what we expose.
+
+**Client maturity.** The browser client for Cloud Error Reporting, `stackdriver-errors-js`, is described by Google as experimental and is effectively unmaintained. Error Reporting is a server-side product; its browser path is not a supported first-class surface.
+
+Separately, PRD section 11 makes **crash-free session rate** a release gate. Computing it from Cloud Logging means building browser sessionization, fatal/non-fatal classification, and the rolling ratio ourselves — building the instrument that measures our own release gate, during Phase 0.
+
+## Decision
+
+Adopt **Sentry** as the error and crash monitoring platform for the private alpha, via the official SolidStart SDK (`@sentry/solidstart`, a wrapper over `@sentry/solid` for the client and `@sentry/node` for the server). Remove the Cloud Functions sink into Cloud Logging from `OPS-03`.
+
+Specifically:
+
+1. **The reporting boundary stays ours.** The global `error`/`unhandledrejection` handlers and Solid error boundaries specified by `OPS-03` remain the single place errors are captured. Sentry is the transport and backend behind that boundary, not a replacement for it. Application code does not call the Sentry SDK directly.
+2. **Sentry is the diagnostic system of record**: grouping, deduplication, release tracking, source-map symbolication, alerting, triage, and crash-free session rate via the `BrowserSession` integration and Release Health.
+3. **Google Analytics keeps the `exception` counter event** (`fatal`, `area`, `error_code`) from `OPS-02`. The section 11 measures continue to compute in one place from one catalog; Sentry is where an engineer goes to debug a specific error, not where the product dashboard is assembled.
+4. **Session Replay is not enabled**, in the alpha or later, without a new ADR. It would capture the arrangement, clip names, and assistant conversation on screen.
+5. **Sentry may also instrument the Cloud Functions gateway** (`AI-001`) through `@sentry/node`, giving one system across client and server. Sentry's tracing does **not** displace Firebase Performance Monitoring or the section 9.3 lab measurement of arrangement frame budgets; that is a separate decision and is not made here.
+6. **Self-hosting is out of scope** for the alpha. Sentry's SaaS free tier covers the cohort; running the self-hosted stack is more operational surface than a private alpha justifies.
+
+## Consequences
+
+### What this buys
+
+- Readable production stack traces without publishing source maps, through authenticated per-release source-map upload.
+- Crash-free session rate as a native metric rather than a Phase 0 engineering project, satisfying the section 11 release gate directly.
+- Grouping, deduplication, and fatal/non-fatal classification satisfy `OPS-03` acceptance criteria out of the box rather than through code we own and test.
+- An official SolidStart SDK, so the framework integration is maintained upstream rather than by us.
+- Cost is negligible at alpha scale. The free Developer tier covers a single user, 5,000 errors per month, and 30-day retention; the paid Team tier is roughly $26/month when seats or volume exceed it. Both are far below the engineering time the alternative costs. Exact limits are confirmed at signup rather than taken from secondary sources.
+
+### What this costs, and what we do about it
+
+- **A second vendor and a second privacy surface** in a deliberately small stack. This is the real price of the decision. `DEC-009` must cover Sentry alongside Google Analytics: what is collected, retention, regional storage, and the user-facing disclosure.
+- **Sentry's defaults send more than our own sink would.** Console breadcrumbs capture console arguments and network breadcrumbs capture request URLs. For a product whose value is the user's private music, this is the thing to get right, and it is *added* work rather than saved work:
+  - `sendDefaultPii` stays `false`.
+  - `beforeSend` and `beforeBreadcrumb` scrub before transmission; console breadcrumbs are disabled rather than filtered.
+  - The `OPS-02` "no project content" test extends to cover the Sentry payload, exercising the scrubbing functions directly, so it also covers events and breadcrumbs added later.
+  - Session Replay stays off (decision 4 above).
+- **Bundle size** works against the section 10 three-second-interactive budget. The SDK is initialized lazily after first paint with a minimal integration set, and is not loaded on the marketing landing page (`LOOP-001b`).
+- **Ad and tracker blockers block `sentry.io`.** The `OPS-02` fail-open rule applies unchanged: a blocked or failing reporter never affects playback, editing, saving, or export. We do not tunnel reports through our own domain in the alpha — it would reintroduce the Cloud Function this ADR removes. The resulting undercount is documented; note that a blocked SDK loses the session *and* its errors, so the crash-free **ratio** is less biased than the absolute counts.
+- **`@sentry/solidstart` is beta.** Its API is stable but behavior may shift in minor releases. The version is pinned, and the framework wrapper is a convenience over the core browser SDK — if it misbehaves we drop to `@sentry/browser` behind the same unchanged boundary.
+- **Exit cost is bounded** precisely because of decision 1. Replacing Sentry means replacing a transport behind an interface we own, not re-instrumenting the application.
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Cloud Functions sink into Cloud Logging / Error Reporting (the original `OPS-03`) | Cannot symbolicate without public source maps; unmaintained experimental browser client; crash-free session rate would be built by us |
+| Firebase Crashlytics | Does not support the Firebase Web SDK |
+| Publish source maps publicly and keep Cloud Error Reporting | Trades a deliberate exposure decision for tooling convenience; also leaves the unmaintained client and the sessionization work |
+| Self-hosted Sentry | Same privacy configuration work plus an operational burden a private alpha does not justify; revisitable if data residency later demands it |
+| Another SaaS error tracker (Rollbar, Bugsnag, Highlight, Datadog RUM) | No decisive advantage over Sentry for this stack, and none has an official SolidStart SDK; Datadog RUM in particular is priced and scoped well beyond an alpha's needs |
+| No error monitoring during the alpha | Section 11 makes crash-free sessions a release gate; an unobservable gate is not a gate |
+
+## Revisit when
+
+- The alpha cohort grows beyond the free tier, or seats are needed for more than one engineer.
+- `DEC-009` settles a regional or retention constraint that SaaS Sentry cannot meet, which would reopen self-hosting.
+- Public launch, when the single-environment decision in `OPS-01` is also revisited.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -47,13 +47,17 @@ The `Dependencies:` line on every task is the machine-readable work graph. An or
 - Tests fail before the implementation and pass afterward at the lowest useful layer.
 - `bun run typecheck`, `bun run test`, and `bun run check` pass. Tasks that touch browser, Firebase, audio, performance, or export behavior also run their task-specific suites.
 - Resource ownership, accessibility, supported-browser behavior, and persistence effects have been considered and tested where applicable.
+- **Analytics ships with the feature.** From `FND-001c` onward, any task that adds or changes a user action emits its PRD OPS-02 events through the shared typed analytics catalog, plus the reliability event for its principal failure path, with tests that the event fires once per action and that disabling analytics changes nothing. A task whose events are left for later is not done. A user action the catalog does not yet cover extends the catalog in the same PR — at minimum a `feature_first_use` key — rather than shipping unmeasured, and no task introduces an ad-hoc event string outside the catalog.
+- No event or error-report parameter carries a project, track, clip, section, or asset name, assistant text, a user-entered string, an asset URL, or a token.
+- From `FND-001b` onward, the slice has been exercised in a deployed build on the hosted environment, not only against a local dev server and the emulator suite.
 - No unrelated formatting, dependency, generated-file, or refactor churn is included.
 
 ## 2. Release gates and parallelism
 
 | Gate | Opens when | Work unlocked |
 | --- | --- | --- |
-| G0: Tooling ready | `FND-001` done | Code-first contracts and independent architecture spikes |
+| G0: Tooling ready | `FND-001` done | Deployment, code-first contracts, and independent architecture spikes |
+| G0.5: Deployed and observable | `FND-001b` and `FND-001c` done | Every later task can verify itself in a real browser and instrument itself through the published analytics catalog |
 | G1: Contracts published | `FND-002` through `FND-005` done | Audio, renderer, content, and thin-slice integration |
 | G2: Foundation slice proven | `FND-009` done | Broad Phase 1 loop-workflow parallelism |
 | G3: Manual loop complete | `LOOP-016` done | Arrangement, automation, and export expansion |
@@ -61,7 +65,7 @@ The `Dependencies:` line on every task is the machine-readable work graph. An or
 | G5: AI complete | `REL-002` done | Private-alpha hardening and user validation |
 | G6: Private alpha ready | `REL-003` done | P1 work may be unparked by the product owner |
 
-Only `FND-001` starts immediately. After it lands, `FND-002`, `FND-006`, and `FND-008` may proceed in parallel because they own separate code boundaries. `FND-003` through `FND-005` depend on the canonical domain schema. Broad feature parallelism begins only after `FND-009` proves the contracts together.
+Only `FND-001` starts immediately. After it lands, `FND-001b`, `FND-002`, `FND-006`, and `FND-008` may proceed in parallel because they own separate code boundaries. `FND-001b` is claimed first among them: it is small, it unblocks nothing structurally but makes everything after it verifiable in a real environment, and every later task's definition of done assumes it. `FND-001c` follows `FND-001b` and publishes the analytics catalog contract that every Phase 1-4 feature task extends. `FND-003` through `FND-005` depend on the canonical domain schema. Broad feature parallelism begins only after `FND-009` proves the contracts together.
 
 ## 3. Product decisions
 
@@ -139,6 +143,15 @@ Choose direct Live Set serialization or a supported partner/integration route. T
 
 Decide the trusted-creator/source allowlist and how a creator or video enters it, the acceptable video provider and embedding surface, and the data-sharing and privacy terms for loading external video. Post-alpha; do not let an implementation default choose product behavior.
 
+### DEC-009 - Analytics consent and retention policy
+
+`Status: todo`<br>
+`Owner: product-owner`<br>
+`Needed by: LOOP-001b, HARD-003`<br>
+`Evidence: pending`
+
+Decide whether product analytics are on by default with an opt-out or require opt-in, what the user-facing disclosure says, how long event and error data are retained, and any regional constraints. `FND-001c` builds the opt-out mechanism and the disclosure hook regardless; this decision sets the default state and the wording. It does not block `FND-001c`, and it must be settled before the cohort is invited in `HARD-005`.
+
 ## 4. Phase 0: foundations
 
 ### FND-001 - Test and development foundation
@@ -156,6 +169,46 @@ This task owns its own infrastructure. It creates `.github/workflows` for CI and
 - [ ] CI workflows run typecheck, `check:ci`, unit tests, and the appropriate integration suites on Chromium and Firefox as gating browsers, with WebKit run as a non-gating signal per the PRD supported-environment policy.
 - [ ] Test helpers provide deterministic clocks, deterministic prefixed IDs matching the PRD section 9.4 format, Firebase setup/teardown, and browser-safe fixture loading.
 - [ ] Existing tests still pass, and generated sample work is not needlessly repeated by every test command.
+
+### FND-001b - Firebase deployment and hosted alpha environment
+
+`Dependencies: FND-001`<br>
+`PRD: OPS-01; 9.1; 10 Security and privacy`
+
+Deploy the application to Firebase Hosting, from CI, before the rest of Phase 0 is built on top of it. Everything after this task is expected to be checked in a real browser against real Firebase services rather than only against the dev server and the emulator suite.
+
+The alpha's only hosted environment is the **production** Firebase project — a deliberate decision recorded in PRD section 16, not an omission. Nothing here permits exposing an incomplete journey: the deployed alpha is reachable only to people given the URL and an account, and unfinished work stays behind feature flags.
+
+This task claims the deploy pipeline. It extends the `FND-001` CI workflows rather than creating a competing one, and it owns `firebase.json` hosting configuration, the deploy job, and the release-stamping mechanism.
+
+- [ ] `bun run build` output deploys to Firebase Hosting through one documented command and automatically from CI on merge to the default branch, using credentials held in CI rather than on a developer machine.
+- [ ] Firestore rules and indexes deploy from the same pipeline as the application; a failing rules or index step fails the deploy instead of shipping code that its deployed rules do not match.
+- [ ] The build stamps the git commit SHA into the client, the app can display it, and it is available to the `FND-001c` analytics and error events.
+- [ ] A post-deploy smoke test against the hosted URL covers app load, anonymous session start, project open, and audio start after a user gesture; a failed smoke test is a failed deploy.
+- [ ] Rollback to the previous Hosting release and its matching rules revision is documented and has been performed once as evidence, not just described.
+- [ ] No secret, provider credential, or privileged configuration reaches the client bundle; a check fails the build if one does.
+- [ ] Unit, component, browser, and emulator suites still run without access to the production project and do not write to it.
+- [ ] Team traffic is marked so internal sessions can be excluded from the PRD section 11 measures.
+- [ ] `.env.example`, `README.md`, and `docs/testing.md` describe the deploy, the single-environment decision, and how to get a local build talking to the right project.
+
+### FND-001c - Analytics and error-monitoring foundation
+
+`Dependencies: FND-001b`<br>
+`PRD: OPS-02, OPS-03; 11; 14 Feature definition of done`
+
+Build the typed analytics catalog, the logging boundary, and the error-reporting path that every later task uses. This task owns the contract; it does not instrument other tasks' features. Each Phase 1-4 feature task ships its own events through this boundary as part of its definition of done.
+
+This is a **contract-owning task**: it lands before Phase 1 fans out, and changing the published catalog shape later is its own issue.
+
+- [ ] One typed catalog module declares every PRD OPS-02 event, its parameters, and their allowed values or buckets. Event and parameter strings appear nowhere else, and logging an unregistered event or parameter is a type error.
+- [ ] The logging boundary attaches the release SHA, surface, and account-type user property automatically, and callers cannot pass free text where an enum or bucket is required.
+- [ ] Phase 0 events are emitted and verified from a deployed build: `app_opened`, `first_edit`, `feature_first_use`, `save_failed`, `audio_start_failed`, and `exception`. Later-phase events exist in the catalog as declarations without call sites.
+- [ ] Global `error`/`unhandledrejection` handlers and Solid error boundaries report an error once, with release SHA, browser and engine version, area, stable error code, and redacted message, to an `exception` event and a Cloud Functions sink writing to Cloud Logging. Duplicate reports from one error collapse; a failing sink cannot stop the transport, block editing, lose unsaved state, or recurse.
+- [ ] Fatal and non-fatal errors are distinguishable so a crash-free session rate is computable.
+- [ ] Source maps are produced and retained for the deployed revision and are not served publicly from Hosting.
+- [ ] A test rejects any event or error parameter carrying a project, track, clip, section, or asset name, assistant text, a user-entered string, a URL, or a token. It runs over the whole catalog so it also covers events added by later tasks.
+- [ ] A test runs the core journey with the analytics transport failing and asserts no behavioral difference; a user-facing opt-out disables collection without disabling any product capability. `DEC-009` sets the default state and disclosure wording and does not block this task.
+- [ ] A deliberately triggered test error is shown to arrive in the sink with its release SHA, and `docs/testing.md` documents how to verify events and errors against the deployed build.
 
 ### FND-002 - Canonical schema-v1 domain model
 
@@ -257,7 +310,7 @@ Build a disposable but representative hybrid virtualized-DOM/Canvas-2D spike, an
 
 ### FND-009 - Foundation vertical slice gate
 
-`Dependencies: FND-003, FND-004, FND-005, FND-007, FND-008`<br>
+`Dependencies: FND-001c, FND-003, FND-004, FND-005, FND-007, FND-008`<br>
 `PRD: Phase 0 exit criteria; section 13 dependency order`
 
 Integrate the new boundaries through the smallest end-to-end musical path: open a schema-v1 project, add one note, play it, undo it, save it, reload it, and reproduce playback.
@@ -268,6 +321,8 @@ The slice's surface is a **16-step grid on a sampler track** — the cheapest UI
 - [ ] Audible playback uses the stable graph and one shared context.
 - [ ] Save state and revision behavior are visible and stale echoes cannot restore the undone note.
 - [ ] Unit, repository, component, browser, and audio lifecycle tests cover the slice.
+- [ ] The slice emits `first_edit` and the `step_editor` `feature_first_use` key through the `FND-001c` catalog, and both are observed from the deployed build alongside its `app_opened`, `save_failed`, and `audio_start_failed` paths.
+- [ ] The whole slice — add a note, play it, undo it, save it, reload it — is exercised on the hosted environment, not only locally.
 - [ ] Obsolete prototype model/audio paths are removed or isolated so new work cannot import them accidentally.
 
 ## 5. Phase 1: complete the loop workflow
@@ -277,24 +332,26 @@ Tasks in this phase may proceed in parallel after `FND-009`, subject to their ad
 ### LOOP-001 - Anonymous start and project dashboard
 
 `Status: todo | Owner: unassigned | Dependencies: FND-009, DEC-001`<br>
-`PRD: PRJ-01, PRJ-02 | Evidence: pending`
+`PRD: PRJ-01, PRJ-02, OPS-02 | Evidence: pending`
 
 Implement anonymous entry plus create, open, rename, duplicate, and confirmed-delete flows against the v1 repository.
 
 - [ ] Blank and starter creation, independent deep duplication, empty/loading/error states, and last-modified metadata are tested.
 - [ ] Anonymous retention and upgrade messaging match `DEC-001`; refresh preserves the session.
 - [ ] Dashboard browser tests cover access control and destructive confirmation.
+- [ ] Emits `anon_session_created`, `account_upgraded`, `project_created` (with `source`, `template_id`, `genre`), `project_opened` (with `project_age_bucket`, `track_count_bucket`, `is_first_open`), and `project_deleted`. `project_opened` is what makes the 1- and 7-day reopen measure computable, so its parameters are not optional.
 
 ### LOOP-001b - Public landing page
 
 `Status: todo | Owner: unassigned | Dependencies: LOOP-001`<br>
-`PRD: PRJ-06 | Evidence: pending`
+`PRD: PRJ-06, OPS-02 | Evidence: pending`
 
 Implement the public marketing landing page as an honest front door into the anonymous-start flow.
 
 - [ ] The page states the product promise, the browser-based/no-install nature, supported browsers, and the honest private-alpha status without advertising unshipped capabilities.
 - [ ] A primary call to action starts a playable project via the PRJ-01 anonymous-start flow with no account; a secondary path leads existing users to log in.
 - [ ] The page follows the editor's visual language and passes the alpha accessibility and marketing-page performance expectations; tour/pricing/richer marketing content may be staged.
+- [ ] Emits `landing_cta_click` with a `cta_id` distinguishing the start-free and log-in paths, and carries the analytics disclosure and opt-out surface from `FND-001c` per `DEC-009`.
 
 ### LOOP-002 - Autosave and recovery UX
 
@@ -306,6 +363,7 @@ Complete `Saving`, `Saved`, `Save failed`, retry, navigation flush, and optimist
 - [ ] High-frequency gestures coalesce writes without losing final state or blocking playback.
 - [ ] Offline/transient failure retains edits and retry is explicit; stale acknowledgements never move controls backward.
 - [ ] Fake-timer, repository, and browser navigation tests cover success and failure paths.
+- [ ] Emits `save_failed` with an actionable `error_code` and `retry_count`, `save_recovered` on successful retry, and `undo_used` with `direction` and `actor`. Coalesced writes emit one event per failure episode, not one per attempt.
 
 ### LOOP-003 - Transport, tempo, loop, and metronome
 
@@ -317,6 +375,7 @@ Implement dependable play/pause/stop/seek, playhead, 40-240 BPM tempo, fixed 4/4
 - [ ] Scheduling is ahead-of-time and remains aligned across seek, tempo change, repeated loops, and editor load.
 - [ ] User-gesture unlock and focus-safe `Space` behavior work in all supported browsers.
 - [ ] Master safety and meter tests include silence, extreme chains, and no transport restart on parameter edit.
+- [ ] Emits `transport_play` (with `surface` and `is_first_play_in_session`), `audio_start_failed` with a browser-blocked flag when the context cannot unlock, and sampled `audio_underrun` events with the sampling rate recorded. Playback emits nothing per scheduled event or animation frame.
 
 ### LOOP-004 - Synth and one-shot sampler
 
@@ -328,6 +387,7 @@ Implement reusable synth and sampler graph/UI slices with presets, audition, pit
 - [ ] Controls dispatch validated commands and parameter changes reuse nodes with safe smoothing.
 - [ ] Sample replacement cancels stale loads and preserves compatible clip data through undo/redo.
 - [ ] Audio fixtures test parameter extremes, repeated triggers, cache ownership, export compatibility, and disposal.
+- [ ] Emits `instrument_changed` with `instrument_type` and the `synth` and `sampler` `feature_first_use` keys. Continuous parameter gestures emit nothing per tick.
 
 ### LOOP-005 - Drum machine
 
@@ -339,6 +399,7 @@ Implement a 16-pad drum machine with per-pad sample, audition, pitch, level, pan
 - [ ] Pad and hit IDs survive reorder/duplication and all edits use shared commands.
 - [ ] Chokes and multiple simultaneous hits schedule deterministically without leaking short-lived voices.
 - [ ] Tests cover mute-wins-solo, choke timing, pad replacement, undo, save/reload, and teardown.
+- [ ] Emits `instrument_changed` on pad sample replacement and the `drum_machine` `feature_first_use` key.
 
 ### LOOP-006 - Tempo-aware audio loops
 
@@ -350,6 +411,7 @@ Implement loop-track playback and UI that distinguishes tempo-labelled loops fro
 - [ ] Source BPM and bar length validate at ingestion and remain aligned over repeated playback from 40-240 BPM.
 - [ ] Seek, loop boundary, tempo change, mute/solo, save/reload, missing asset, and disposal are tested.
 - [ ] The chosen alpha stretch behavior and audible limitations are documented honestly in the UI.
+- [ ] Emits the `audio_loop` `feature_first_use` key and `asset_load_failed` for a missing or undecodable loop.
 
 ### LOOP-007 - Track management and mixer
 
@@ -361,6 +423,7 @@ Implement add, rename, reorder, duplicate, delete, mute, solo, volume, pan, and 
 - [ ] Deletion warning and deep duplication behavior are explicit; reorder preserves ownership and routing.
 - [ ] Multiple solo, mute precedence, perceptual faders, readable values, smoothing, and keyboard access are tested.
 - [ ] At least 50 tracks remain correct; metadata-only edits create no audio resources.
+- [ ] Emits `track_added` with `track_type` and the `mixer` `feature_first_use` key. Fader and pan drags emit one event per gesture at most, never per pointer move.
 
 ### LOOP-008 - Device-chain and routing framework
 
@@ -372,6 +435,7 @@ Implement typed ordered devices, eight inserts per track, master devices, two st
 - [ ] Device/routing commands preserve invariants, history, autosave, and stable IDs.
 - [ ] Reorder reuses nodes with a measured click-safe reconnection strategy; unrelated graphs retain identity.
 - [ ] Extreme but finite ranges remain creative while invalid values and unsafe feedback are rejected.
+- [ ] Emits `device_added` with `device_type` and `chain` (insert, return, or master), plus the `device_chain` and `send_return` `feature_first_use` keys.
 
 ### LOOP-009 - Core processing devices
 
@@ -383,6 +447,7 @@ Implement filter/EQ, overdrive, saturation, compression, tempo-sync/free delay, 
 - [ ] Each required control, wet/dry/output behavior, bypass, reset, duplication, metering, and preset path is present.
 - [ ] Parameters smooth without node replacement; duplicate effects and unconventional ordering are supported.
 - [ ] Deterministic audio/property tests cover normal and extreme settings, limiter interaction, tails, and disposal.
+- [ ] Each device type is a registered `device_type` value in the analytics catalog, so `device_added` reports which processing users reach for first.
 
 ### LOOP-010 - Step editor
 
@@ -393,6 +458,7 @@ Implement the 1-8 bar 16th-note grid for sampler and drum-machine clips.
 
 - [ ] Paint/erase, velocity, named lanes, beat/bar styling, playback step, selection, and one-gesture history work without text selection.
 - [ ] Pointer, keyboard, save/reload, resize, and 8-bar dense-fixture component tests pass.
+- [ ] Emits `clip_edited` with `editor: step` and an `event_count_bucket`, once per completed paint or erase gesture rather than per step toggled, plus the `step_editor` `feature_first_use` key.
 
 ### LOOP-011 - Piano roll
 
@@ -403,6 +469,7 @@ Implement synth-note create, move, resize, group select, duplicate, delete, velo
 
 - [ ] Pointer geometry remains correct under scroll/zoom and every gesture is one undo transaction.
 - [ ] Overlap, boundary, multi-select, keyboard, save/reload, and playback-follow tests pass.
+- [ ] Emits `clip_edited` with `editor: piano_roll` and an `event_count_bucket`, once per completed gesture, plus the `piano_roll` `feature_first_use` key.
 
 ### LOOP-012 - Shared musical transformations
 
@@ -435,6 +502,7 @@ Implement search, filters, keyboard navigation, sync-aware audition, insertion, 
 - [ ] Audition routes through the shared runtime, never enters export, and stops on selection change, close, navigation, or project teardown.
 - [ ] Search/filter behavior remains responsive at the planned library size and exposes all content when genre filters clear.
 - [ ] Missing/corrupt assets report locally without blocking other results or project playback.
+- [ ] Emits `library_audition` with `asset_type` and `had_genre_filter`, `asset_load_failed` with `asset_type` and `error_code`, and the `library_browser` `feature_first_use` key. Search terms are never logged.
 
 ### CNT-002 - Rounded alpha factory library
 
@@ -456,6 +524,7 @@ Implement one typed, context-aware shortcut registry powering handlers, menus, t
 
 - [ ] PRD mappings and intentional Ableton deviations are encoded once; browser/OS and text-entry conflicts are respected.
 - [ ] Focus restore, modal accessibility, layout-aware character matching, disabled actions, and every registered context are tested.
+- [ ] Emits `shortcut_used` with `action_id` from the registry itself rather than from each handler, plus the `shortcut_guide` `feature_first_use` key when the `?` guide is first opened.
 
 ### LOOP-015 - Starter projects and genre templates
 
@@ -467,6 +536,7 @@ Build Blank plus approved featured starters from normal editable tracks, clips, 
 - [ ] Each starter opens audibly with no missing assets, independent IDs, hidden state, or inaccessible backing track.
 - [ ] AI-generated variation may diversify instances, but a deterministic validated fallback always exists.
 - [ ] Bundled demo projects cover every required genre and pass save, reopen, playback, and asset-policy audits.
+- [ ] Every starter reports a stable `template_id` and `genre` through `project_created`, so template choice is comparable across the cohort.
 
 ### LOOP-016 - Manual loop workflow gate
 
@@ -478,6 +548,7 @@ Validate that a user can create, edit, process, save, and reopen an original 1-8
 - [ ] The reference journey includes drum machine, synth or sampler, audio loop, device chain, send, mixer, step editor, piano roll, shortcuts, and library audition.
 - [ ] All supported-browser E2E tests pass with no leaked audio resources or direct state mutation.
 - [ ] Phase 1 PRD requirements have requirement-to-test traceability and no unresolved P0 defects.
+- [ ] Every Phase 1 event in the PRD OPS-02 catalog has a call site and is observed from the deployed build during the reference journey; no Phase 1 event is still declaration-only.
 
 ## 6. Phase 2: arrangement and export
 
@@ -513,6 +584,7 @@ Implement add/rename/resize/color/reorder section markers and an editable manual
 - [ ] Section reorder moves contained placements without hidden audio and is one undoable transaction.
 - [ ] Outline creation uses linked or copied clips explicitly, is immediately playable, and undoes atomically.
 - [ ] Boundary collisions, partial ranges, automation movement hooks, and save/reload are tested.
+- [ ] Emits `section_created` with `origin`, `arrangement_outline_created` with `template_id` and `section_count`, the `sections` `feature_first_use` key, and `arrangement_milestone` the first time a project reaches at least three named sections and two minutes. `arrangement_milestone` is the PRD section 11 primary measure and fires once per project.
 
 ### ARR-004 - Focused breakpoint automation
 
@@ -524,6 +596,7 @@ Implement one visible lane per track for volume, pan, send, and supported device
 - [ ] Add/move/delete, target switch, copy range, section reorder, selection, and one-gesture undo work in musical time.
 - [ ] Live playback, seek, loop, and offline projection reproduce parameter values without boundary discontinuities.
 - [ ] Automated controls are visibly distinct and safe manual adjustment behavior is defined and tested.
+- [ ] Emits `automation_lane_created` with `target_kind` on a lane's first breakpoint, plus the `automation` `feature_first_use` key. Drawing and dragging breakpoints emit nothing per point.
 
 ### ARR-005 - Arrangement performance and duration gate
 
@@ -557,6 +630,7 @@ Implement full-arrangement stereo WAV export with progress, cancellation, safe f
 - [ ] Duration includes release tails without drift or truncation; format metadata is valid and documented.
 - [ ] The 40-track ten-minute processed fixture renders within browser memory limits on supported hardware.
 - [ ] Error/cancel paths never present a partial file as successful or disturb live playback.
+- [ ] Emits `export_started`, `export_completed`, and `export_failed` with `export_type: stereo`, bucketed duration, track count, and elapsed time, a `was_cancelled` flag, and an actionable `error_code`, plus the `export_stereo` `feature_first_use` key. File names are never logged.
 
 ### EXP-003 - Aligned stem package
 
@@ -568,6 +642,7 @@ Implement selectable 16/24-bit stem export with one aligned WAV per track, separ
 - [ ] Track stems include source, inserts, automation, fader, and pan but exclude master processing; mute/solo policy matches the PRD.
 - [ ] All stems share sample rate, format, bar-1 origin, padded tail duration, and sample alignment.
 - [ ] Progress, cancellation, worker/memory limits, asset policies, and recoverable failures are tested with the maximum reference fixture.
+- [ ] Emits the same export event trio with `export_type: stems` plus the `export_stems` `feature_first_use` key, so stereo and stem adoption are separable in the PRD section 11 export measure.
 
 ### REL-001 - Arrangement and export gate
 
@@ -579,6 +654,7 @@ Validate manual creation of a two-to-ten-minute arrangement and import of its st
 - [ ] Playback, save/reopen, stereo render, and stems agree on arrangement bounds and musical events.
 - [ ] Supported-browser reference runs show no skipped events, drift, missing tracks, clipped tails, leaks, or memory failure.
 - [ ] Every P0 arrangement/export requirement maps to an automated test or named physical-device test procedure.
+- [ ] Every Phase 2 event in the PRD OPS-02 catalog has a call site and is observed from the deployed build, and the primary track-progression measure computes end to end from `project_created`, `arrangement_milestone`, and `export_completed`.
 
 ## 7. Phase 3: AI producer
 
@@ -613,6 +689,7 @@ Expose an allowlisted, versioned subset of shared commands to the model and impl
 - [ ] Invalid IDs, ranges, combinations, unknown tools, and stale revisions make no change.
 - [ ] Valid multi-command proposals summarize impact, apply atomically as one history entry, and undo exactly.
 - [ ] Every Appendix A command family has schema, authorization, invariant, malformed-response, and round-trip tests.
+- [ ] Emits `assistant_proposal_shown`, `assistant_proposal_applied`, `assistant_proposal_cancelled`, and `assistant_proposal_undone` with `capability`, bucketed command count, and bucketed decision/undo times. Prompts, replies, summaries, and command payloads are never logged.
 
 ### AI-004 - Assistant conversation and proposal UI
 
@@ -624,6 +701,7 @@ Implement streaming conversation, scope indicator, suggestions, proposal cards, 
 - [ ] Conversation remains responsive during playback and manual editing remains available during provider failure.
 - [ ] Focus, keyboard, screen-reader announcements, cancellation, retry, stale proposal, and follow-up control highlighting are tested.
 - [ ] Explanations link audible goal, accurate technique, and actual changed controls without mandatory lessons.
+- [ ] Emits `assistant_message_sent` with `scope`, `assistant_suggestion_clicked` with `suggestion_id`, `assistant_result_edited` when the user manually edits an entity an applied proposal changed, and the `assistant` `feature_first_use` key. `assistant_result_edited` is what makes the ownership measure real, so it is not deferred.
 
 ### AI-005 - Alpha musical capability evaluations
 
@@ -646,6 +724,7 @@ Run the full AI evaluation and failure matrix against stable manual commands.
 - [ ] Reference loops become valid editable outlines and one undo restores byte-equivalent canonical song state.
 - [ ] Malformed, stale, cancelled, timed-out, rate-limited, and provider-failed requests never mutate the project.
 - [ ] Context size, latency, usage, error categories, and proposal acceptance are observable within approved privacy rules.
+- [ ] Every Phase 3 event in the PRD OPS-02 catalog has a call site and is observed from the deployed build; apply, cancel, undo, and follow-up-edit rates compute per capability.
 
 ## 8. Phase 4: private-alpha hardening
 
@@ -671,14 +750,16 @@ Audit and fix full keyboard operation, focus, semantics, names, contrast, reduce
 
 ### HARD-003 - Security, privacy, reliability, and telemetry
 
-`Status: todo | Owner: unassigned | Dependencies: REL-002, DEC-001, DEC-005`<br>
-`PRD: 10, 11, 14 | Evidence: pending`
+`Status: todo | Owner: unassigned | Dependencies: REL-002, DEC-001, DEC-005, DEC-009`<br>
+`PRD: 10, 11, 14, OPS-01, OPS-02, OPS-03 | Evidence: pending`
 
-Complete rule audits, validation, quotas, deletion/retention, CSP/secrets review, crash/save/audio-start instrumentation, recovery UX, and privacy-safe product metrics.
+Complete rule audits, validation, quotas, deletion/retention, CSP/secrets review, recovery UX, and the release dashboards over the already-shipped analytics. This task audits and reports on instrumentation; it does not add instrumentation that a feature task should have shipped. A missing event is a defect filed against the task that owned it.
 
 - [ ] Security emulator tests and abuse cases cover all public backend surfaces and asset access.
 - [ ] Crash, save failure, audio start failure, export result, AI failure, and leak signals are actionable without recording project content.
-- [ ] Anonymous retention/deletion and AI data handling match product decisions and user-facing disclosures.
+- [ ] Anonymous retention/deletion, analytics consent/retention (`DEC-009`), and AI data handling match product decisions and user-facing disclosures.
+- [ ] Every event in the PRD OPS-02 catalog is confirmed firing from the deployed production build with the expected parameters, and any gap is filed against its owning task rather than patched here.
+- [ ] Release dashboards compute the PRD section 11 primary, supporting, and guardrail measures — including crash-free session rate — from real cohort data with internal traffic excluded.
 
 ### HARD-004 - Content and template release audit
 
@@ -709,7 +790,7 @@ Run facilitated loop-to-track sessions with the target cohort, categorize blocke
 Produce the traceability matrix and release report for every P0 acceptance criterion, supported browser, reference scenario, security control, and performance/reliability budget.
 
 - [ ] All P0 criteria are evidenced, deferred explicitly by the product owner, or block release.
-- [ ] Production configuration, Firebase rules/indexes/functions, monitoring, rollback, and incident ownership are verified.
+- [ ] Production configuration, Firebase rules/indexes/functions, monitoring, rollback, and incident ownership are verified against the deployed production build, including a practised rollback and a live error reaching the monitoring sink with its release SHA.
 - [ ] No open critical/high defect, unexplained resource leak, save-loss path, or unlicensed asset remains.
 
 ## 9. Parked post-alpha backlog

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -150,7 +150,7 @@ Decide the trusted-creator/source allowlist and how a creator or video enters it
 `Needed by: LOOP-001b, HARD-003`<br>
 `Evidence: pending`
 
-Decide whether product analytics are on by default with an opt-out or require opt-in, what the user-facing disclosure says, how long event and error data are retained, and any regional constraints. `FND-001c` builds the opt-out mechanism and the disclosure hook regardless; this decision sets the default state and the wording. It does not block `FND-001c`, and it must be settled before the cohort is invited in `HARD-005`.
+Decide whether product analytics are on by default with an opt-out or require opt-in, what the user-facing disclosure says, how long event and error data are retained, and any regional constraints. The disclosure covers two processors — Google Analytics for product events and Sentry for error monitoring ([ADR 0001](./adr/0001-sentry-for-error-monitoring.md)) — and a regional constraint Sentry's SaaS regions cannot meet would reopen the self-hosting option that ADR rejected. `FND-001c` builds the opt-out mechanism and the disclosure hook regardless; this decision sets the default state and the wording. It does not block `FND-001c`, and it must be settled before the cohort is invited in `HARD-005`.
 
 ## 4. Phase 0: foundations
 
@@ -183,7 +183,7 @@ This task claims the deploy pipeline. It extends the `FND-001` CI workflows rath
 
 - [ ] `bun run build` output deploys to Firebase Hosting through one documented command and automatically from CI on merge to the default branch, using credentials held in CI rather than on a developer machine.
 - [ ] Firestore rules and indexes deploy from the same pipeline as the application; a failing rules or index step fails the deploy instead of shipping code that its deployed rules do not match.
-- [ ] The build stamps the git commit SHA into the client, the app can display it, and it is available to the `FND-001c` analytics and error events.
+- [ ] The build stamps the git commit SHA into the client, the app can display it, and it is available to the `FND-001c` analytics and error events. The pipeline has a place for `FND-001c` to add its release registration and source-map upload without restructuring the deploy job.
 - [ ] A post-deploy smoke test against the hosted URL covers app load, anonymous session start, project open, and audio start after a user gesture; a failed smoke test is a failed deploy.
 - [ ] Rollback to the previous Hosting release and its matching rules revision is documented and has been performed once as evidence, not just described.
 - [ ] No secret, provider credential, or privileged configuration reaches the client bundle; a check fails the build if one does.
@@ -194,21 +194,26 @@ This task claims the deploy pipeline. It extends the `FND-001` CI workflows rath
 ### FND-001c - Analytics and error-monitoring foundation
 
 `Dependencies: FND-001b`<br>
-`PRD: OPS-02, OPS-03; 11; 14 Feature definition of done`
+`PRD: OPS-02, OPS-03; 11; 14 Feature definition of done; ADR 0001`
 
 Build the typed analytics catalog, the logging boundary, and the error-reporting path that every later task uses. This task owns the contract; it does not instrument other tasks' features. Each Phase 1-4 feature task ships its own events through this boundary as part of its definition of done.
+
+Error monitoring uses Sentry via `@sentry/solidstart`, per [ADR 0001](./adr/0001-sentry-for-error-monitoring.md). The SDK sits *behind* this task's reporting boundary: application code calls the boundary, never the SDK, so the platform stays replaceable. Pin the SDK version — the SolidStart package is beta.
 
 This is a **contract-owning task**: it lands before Phase 1 fans out, and changing the published catalog shape later is its own issue.
 
 - [ ] One typed catalog module declares every PRD OPS-02 event, its parameters, and their allowed values or buckets. Event and parameter strings appear nowhere else, and logging an unregistered event or parameter is a type error.
 - [ ] The logging boundary attaches the release SHA, surface, and account-type user property automatically, and callers cannot pass free text where an enum or bucket is required.
 - [ ] Phase 0 events are emitted and verified from a deployed build: `app_opened`, `first_edit`, `feature_first_use`, `save_failed`, `audio_start_failed`, and `exception`. Later-phase events exist in the catalog as declarations without call sites.
-- [ ] Global `error`/`unhandledrejection` handlers and Solid error boundaries report an error once, with release SHA, browser and engine version, area, stable error code, and redacted message, to an `exception` event and a Cloud Functions sink writing to Cloud Logging. Duplicate reports from one error collapse; a failing sink cannot stop the transport, block editing, lose unsaved state, or recurse.
-- [ ] Fatal and non-fatal errors are distinguishable so a crash-free session rate is computable.
-- [ ] Source maps are produced and retained for the deployed revision and are not served publicly from Hosting.
-- [ ] A test rejects any event or error parameter carrying a project, track, clip, section, or asset name, assistant text, a user-entered string, a URL, or a token. It runs over the whole catalog so it also covers events added by later tasks.
-- [ ] A test runs the core journey with the analytics transport failing and asserts no behavioral difference; a user-facing opt-out disables collection without disabling any product capability. `DEC-009` sets the default state and disclosure wording and does not block this task.
-- [ ] A deliberately triggered test error is shown to arrive in the sink with its release SHA, and `docs/testing.md` documents how to verify events and errors against the deployed build.
+- [ ] Global `error`/`unhandledrejection` handlers and Solid error boundaries report an error once, with release SHA, browser and engine version, area, stable error code, and redacted message, through one application-owned reporting boundary that fans out to the GA4 `exception` counter event and to Sentry. Application code cannot reach the Sentry SDK directly. Duplicate reports from one error collapse; a failing or blocked reporter cannot stop the transport, block editing, lose unsaved state, or recurse.
+- [ ] Fatal and non-fatal errors are distinguishable, and crash-free session rate comes from Sentry release-health session tracking rather than a hand-built derivation.
+- [ ] Sentry is configured for a product whose value is the user's private music: `sendDefaultPii` off, console breadcrumbs disabled rather than filtered, network and DOM breadcrumbs scrubbed in `beforeSend`/`beforeBreadcrumb`, and **Session Replay not enabled** — turning it on needs a superseding ADR.
+- [ ] Source maps are produced for the deployed revision, uploaded to Sentry through an authenticated channel from the `FND-001b` pipeline, and never served publicly from Hosting.
+- [ ] The SDK initializes lazily after first paint with a minimal integration set, is not loaded on the marketing landing page, and its bundle cost is measured against the PRD section 10 interactive budget rather than assumed acceptable.
+- [ ] A test rejects any event or error parameter carrying a project, track, clip, section, or asset name, assistant text, a user-entered string, a URL, or a token. It runs over the whole catalog **and over the Sentry payload by exercising the scrubbing functions directly**, so it also covers events and breadcrumbs added by later tasks.
+- [ ] A test runs the core journey with both the analytics and error transports failing and asserts no behavioral difference; a user-facing opt-out disables collection without disabling any product capability. `DEC-009` sets the default state and disclosure wording and does not block this task.
+- [ ] A deliberately triggered test error is shown arriving in Sentry from the deployed build with its release SHA and a symbolicated stack trace, and `docs/testing.md` documents how to verify events and errors against that build.
+- [ ] The Sentry DSN, auth token, and org/project configuration are handled as deploy configuration: the auth token lives in CI only, and the client DSN is documented as a public-by-design value rather than a secret.
 
 ### FND-002 - Canonical schema-v1 domain model
 
@@ -790,7 +795,7 @@ Run facilitated loop-to-track sessions with the target cohort, categorize blocke
 Produce the traceability matrix and release report for every P0 acceptance criterion, supported browser, reference scenario, security control, and performance/reliability budget.
 
 - [ ] All P0 criteria are evidenced, deferred explicitly by the product owner, or block release.
-- [ ] Production configuration, Firebase rules/indexes/functions, monitoring, rollback, and incident ownership are verified against the deployed production build, including a practised rollback and a live error reaching the monitoring sink with its release SHA.
+- [ ] Production configuration, Firebase rules/indexes/functions, monitoring, rollback, and incident ownership are verified against the deployed production build, including a practised rollback and a live error reaching Sentry with its release SHA and a symbolicated stack trace.
 - [ ] No open critical/high defect, unexplained resource leak, save-loss path, or unlicensed asset remains.
 
 ## 9. Parked post-alpha backlog

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -641,6 +641,116 @@ An owner can invite another registered user to edit a project. The product recor
 **SHR-05 - Real-time collaboration (P2)**  
 Presence, cursors, conflict-free simultaneous edits, and live shared transport are later work and require a separate technical design.
 
+### 7.10 Deployment, analytics, and monitoring
+
+This section covers how Solid Groove reaches a real browser and how the team learns what happens there. Both start in Phase 0: a feature that has only ever run against a local dev server and an emulator is not known to work, and a feature that ships without its events cannot answer the section 11 success measures.
+
+**OPS-01 - Deployed environment from Phase 0 (P0)**  
+Solid Groove is deployed to Firebase Hosting from the first foundation milestone, so every later slice can be exercised in a real browser against real Firebase Authentication, Firestore, Storage, and Functions rather than only against a local dev server and the emulator suite.
+
+The alpha has exactly one hosted environment: the **production** Firebase project. This is a deliberate decision for a private alpha whose only users are the team and an invited cohort, not an oversight. It is revisited before public launch, and before there is real user data that a bad deploy could destroy.
+
+Acceptance criteria:
+
+- The application builds and deploys to Firebase Hosting through one documented command and automatically from CI on merge to the default branch. Deployment does not depend on a developer's local machine state.
+- Firestore security rules and indexes deploy from the same repository and the same pipeline as the application. A deploy whose rules or index step fails, fails the whole pipeline rather than leaving shipped code and deployed rules out of step.
+- The deployed revision is identifiable: the build stamps the git commit SHA into the client, the app can display it, and every analytics and error event carries it (see OPS-02 and OPS-03).
+- Rollback is a documented, practiced operation, not an improvisation. Because production is the only hosted environment, the team can restore the previous Hosting release and the matching rules revision without rebuilding from scratch.
+- Deploying is not releasing. The deployed alpha is discoverable only to people given the URL and an account, and incomplete journeys stay behind the section 13 feature flags. Nothing in this requirement permits shipping a half-built journey to real users.
+- Secrets, provider credentials, and privileged configuration never enter the client bundle. Hosting configuration, security rules, indexes, and function configuration are checked in and reviewable.
+- Local development and every automated suite continue to run against the Firebase Emulator suite. Running the tests must not require access to the production project, and the test suites must not write to it.
+- Traffic from the team is distinguishable from cohort traffic, so internal sessions can be excluded from the section 11 measures.
+- A deployed build is smoke-tested against the hosted environment — the app loads, an anonymous session starts, a project opens, and audio starts after a user gesture — and a failed smoke test is treated as a failed deploy.
+
+**OPS-02 - Product analytics events (P0)**  
+Solid Groove logs a defined set of user actions to Google Analytics for Firebase so the team can answer two questions the alpha exists to answer: *when do people actually use the app*, and *which features do they reach for first*. Instrumentation is part of building a feature, not a later archaeology project (see the section 14 definition of done).
+
+Events are declared once in a shared typed analytics catalog — the same single-source-of-truth pattern as the KEY-01 shortcut registry. UI, audio, persistence, and assistant code log through that catalog; no component calls the analytics SDK with an ad-hoc event name or parameter string.
+
+Sessions, first opens, page views, and engagement time come from Google Analytics automatic collection and are not re-implemented as custom events.
+
+*Event rules*
+
+- Names are `snake_case`, at most 40 characters, and avoid Google Analytics reserved names and the `firebase_`, `google_`, and `ga_` prefixes.
+- Parameter values are enumerated keys, stable Solid Groove IDs, booleans, or bucketed numbers — never free text, and never a value the user typed.
+- **No project content, ever.** Project, track, clip, section, and asset *names*; note and automation data; assistant prompts and replies; user-entered search terms; file names; asset URLs; email addresses; and authentication tokens are never event parameters. Where an entity must be identified, the prefixed ID (section 9.4) is logged, not its name.
+- Counts and durations are bucketed rather than exact, so a rare exact combination cannot re-identify a session.
+- No event fires per note, per animation frame, or per parameter tick. Continuous gestures collapse into one event on gesture completion, and high-frequency signals are debounced, aggregated per session, or sampled with the sampling rate recorded.
+- Analytics fails open. A blocked, failed, or unavailable analytics endpoint — including a browser extension blocking it — never breaks playback, editing, saving, or export, and never surfaces an error to the user.
+- Every event carries the release SHA (OPS-01) and the surface it came from. User properties are limited to coarse, non-identifying facts: account type (anonymous or registered) and whether the session is internal.
+- The user is told what is collected and can decline product analytics without losing any DAW or assistant capability. Reliability events required to keep the release gates honest (OPS-03) are described in the same disclosure.
+
+*Event catalog*
+
+The `Owning task` column names the backlog task that must ship the event with the feature it measures. An event has no separate "instrumentation task" later.
+
+| Event | Fires when | Key parameters | Phase / owning task |
+| --- | --- | --- | --- |
+| `app_opened` | The editor or dashboard shell becomes interactive | `surface`, `account_type`, `release_sha` | 0 / `FND-001c` |
+| `landing_cta_click` | A visitor activates a landing-page call to action | `cta_id` (`start_free`, `log_in`) | 1 / `LOOP-001b` |
+| `anon_session_created` | An anonymous Firebase identity is created for a new visitor | — | 1 / `LOOP-001` |
+| `account_upgraded` | An anonymous account becomes a registered account | `method` | 1 / `LOOP-001` |
+| `project_created` | A project is created | `source` (`blank`, `template`, `duplicate`), `template_id`, `genre` | 1 / `LOOP-001`, `LOOP-015` |
+| `project_opened` | A project is opened in the editor | `project_age_bucket`, `track_count_bucket`, `is_first_open` | 1 / `LOOP-001` |
+| `project_deleted` | A project is deleted after confirmation | `project_age_bucket` | 1 / `LOOP-001` |
+| `first_edit` | The first user-authored mutation in a project, once per project | `command_id`, `seconds_since_open_bucket` | 0 / `FND-009` |
+| `feature_first_use` | An account uses a tracked feature for the first time | `feature` (see below) | 0 / `FND-001c`, then each owning feature task |
+| `transport_play` | Playback starts from a user gesture | `surface`, `is_first_play_in_session` | 1 / `LOOP-003` |
+| `track_added` | A track is added | `track_type` | 1 / `LOOP-007` |
+| `instrument_changed` | A track's instrument or its sample selection changes | `instrument_type` | 1 / `LOOP-004`, `LOOP-005` |
+| `device_added` | A processing device is added to an insert chain, return, or master | `device_type`, `chain` | 1 / `LOOP-008`, `LOOP-009` |
+| `library_audition` | A library asset is auditioned | `asset_type`, `had_genre_filter` | 1 / `LOOP-013` |
+| `clip_edited` | A step-editor or piano-roll editing gesture completes | `editor` (`step`, `piano_roll`), `event_count_bucket` | 1 / `LOOP-010`, `LOOP-011` |
+| `shortcut_used` | A registered keyboard shortcut fires | `action_id` | 1 / `LOOP-014` |
+| `undo_used` | Undo or redo is invoked | `direction`, `actor` (`user`, `assistant`) | 1 / `LOOP-002` |
+| `section_created` | A song section marker is created | `origin` (`manual`, `template`, `assistant`) | 2 / `ARR-003` |
+| `arrangement_outline_created` | A loop-to-song outline is applied | `template_id`, `section_count` | 2 / `ARR-003` |
+| `automation_lane_created` | An automation lane gets its first breakpoint | `target_kind` | 2 / `ARR-004` |
+| `arrangement_milestone` | A project first reaches ≥3 named sections and ≥2 minutes | `section_count`, `duration_bucket` | 2 / `ARR-003` |
+| `export_started` | An export begins | `export_type` (`stereo`, `stems`), `duration_bucket`, `track_count_bucket` | 2 / `EXP-002`, `EXP-003` |
+| `export_completed` | An export finishes and the file or package is delivered | `export_type`, `elapsed_ms_bucket` | 2 / `EXP-002`, `EXP-003` |
+| `export_failed` | An export fails or is cancelled | `export_type`, `error_code`, `was_cancelled` | 2 / `EXP-002`, `EXP-003` |
+| `assistant_message_sent` | The user sends a message to the assistant | `scope` (`clip`, `track`, `section`, `song`) | 3 / `AI-004` |
+| `assistant_suggestion_clicked` | A suggested next step is activated | `suggestion_id` | 3 / `AI-004` |
+| `assistant_proposal_shown` | A validated proposal is presented to the user | `capability`, `command_count_bucket` | 3 / `AI-003` |
+| `assistant_proposal_applied` | A proposal is applied | `capability`, `seconds_to_decision_bucket` | 3 / `AI-003` |
+| `assistant_proposal_cancelled` | A proposal is cancelled without applying | `capability` | 3 / `AI-003` |
+| `assistant_proposal_undone` | An applied proposal is undone | `capability`, `seconds_to_undo_bucket` | 3 / `AI-003` |
+| `assistant_result_edited` | The user manually edits an entity an applied proposal changed | `capability` | 3 / `AI-004` |
+| `save_failed` | A persistence write fails | `error_code`, `retry_count` | 0 / `FND-001c`, `LOOP-002` |
+| `save_recovered` | A previously failed save succeeds on retry | `retry_count` | 1 / `LOOP-002` |
+| `audio_start_failed` | Playback cannot start after a user gesture | `error_code`, `was_browser_blocked` | 0 / `FND-001c`, `LOOP-003` |
+| `audio_underrun` | The engine detects skipped or late scheduled events (sampled) | `dropped_event_bucket`, `sample_rate` | 1 / `LOOP-003` |
+| `asset_load_failed` | A library or user asset fails to load or decode | `asset_type`, `error_code` | 1 / `LOOP-013` |
+| `exception` | An uncaught error reaches a boundary or global handler (OPS-03) | `fatal`, `area`, `error_code` | 0 / `FND-001c` |
+
+`feature_first_use` carries a single low-cardinality `feature` key rather than a separate event name per feature, so the catalog stays well inside the Google Analytics distinct-event-name limit and first-use across features is comparable in one report. The alpha keys are: `step_editor`, `piano_roll`, `drum_machine`, `synth`, `sampler`, `audio_loop`, `device_chain`, `send_return`, `mixer`, `library_browser`, `shortcut_guide`, `sections`, `automation`, `assistant`, `export_stereo`, `export_stems`. A feature task adds its key with the feature.
+
+Acceptance criteria:
+
+- A shared typed analytics catalog declares every event name, its parameters, their allowed values or buckets, and the phase that introduces it. Logging an unregistered event or parameter is a type error, and the catalog is the only place event strings appear.
+- Every event in the table above is emitted by the task named in its `Owning task` column, at the moment described in `Fires when`, and is verifiable in the production project's Google Analytics debug view from a deployed build.
+- Automated tests assert, for each instrumented user action, that the expected event and parameters are logged exactly once, that repeated gestures do not multiply events, and that once-per-project or once-per-account events fire once.
+- A test asserts that no event parameter carries a project, track, clip, section, or asset name; assistant text; a user-entered string; a URL; or an authentication token. This test is part of the analytics catalog's own suite so it covers events added later.
+- Disabling or blocking analytics leaves every product behavior unchanged, proven by a test that runs the core journey with the analytics transport failing.
+- The section 11 success measures are each derivable from the catalog, and a check confirms no measure depends on an event that is not in it.
+
+**OPS-03 - Error and crash monitoring (P0)**  
+Crash-free sessions, save success, and successful audio start are release gates in section 11. They are only gates if they are observable, so the alpha reports uncaught errors and the specific failures those gates depend on.
+
+Firebase Crashlytics does not support the Firebase Web SDK, so "crash reporting" here means browser error reporting, not Crashlytics. The alpha uses global `error` and `unhandledrejection` handlers plus the section 10 error boundaries, which record an `exception` analytics event (OPS-02) and send a structured report to a Cloud Functions endpoint that writes to Cloud Logging. Adopting a third-party error-tracking service instead requires an ADR under the section 9.1 rules.
+
+Acceptance criteria:
+
+- An uncaught error in any surface — editor, assistant, audio engine, renderer, export, or persistence — is reported once with the release SHA, browser and engine version, the area it came from, a stable error code, and a redacted message. Duplicate reports from one error are collapsed.
+- Reports carry no project content, assistant text, user-entered strings, asset URLs, or tokens, consistent with OPS-02 and the section 10 logging rules.
+- Fatal and non-fatal errors are distinguishable, so a crash-free session rate can be computed from sessions with and without a fatal `exception`.
+- Production stack traces are readable: source maps are produced and retained for the deployed revision, and are not served publicly from Hosting.
+- The reliability gates have dedicated events, not just generic exceptions: `save_failed` / `save_recovered`, `audio_start_failed`, `audio_underrun`, `asset_load_failed`, and `export_failed` each carry an actionable error code.
+- Error reporting is best-effort and non-blocking. A failing reporting endpoint cannot stop the transport, block editing, lose unsaved state, or recurse into another report.
+- Monitoring is verified end to end from a deployed build: a deliberately triggered test error appears in the sink with its release SHA, and the check runs as part of accepting `FND-001c`.
+- Firebase Performance Monitoring may be enabled for page-load and network traces (P1). It never substitutes for the section 9.3 lab measurements of arrangement frame budgets.
+
 ## 8. Interaction requirements
 
 ### Progressive disclosure
@@ -754,6 +864,9 @@ These are hard decisions for the alpha, not provisional preferences. An implemen
 | Structured persistence | Cloud Firestore | Project metadata, versioned domain state, revisions, save acknowledgements, and permissions use Firestore |
 | Binary storage | Cloud Storage for Firebase | User audio, derived waveform data where persisted, and server-retained export artifacts use Storage rather than Firestore documents |
 | Privileged backend | Cloud Functions for Firebase | AI-provider calls, privileged validation, quotas, and future background work execute server-side; provider code never ships to the client |
+| Hosting and deployment | Firebase Hosting, deployed from CI | One hosted environment for the alpha — the production project — with rules and indexes deployed from the same pipeline (OPS-01) |
+| Product analytics | Google Analytics for Firebase | User-action events come from one typed catalog (OPS-02); no second analytics vendor and no ad-hoc event strings |
+| Error monitoring | Browser error handlers plus a Cloud Functions sink into Cloud Logging | Crashlytics does not support the Firebase Web SDK; a third-party error tracker requires an ADR (OPS-03) |
 | Arrangement rendering | Hybrid DOM plus Canvas 2D | DOM provides application structure and semantics; viewport-sized canvases render dense timeline graphics |
 | Test foundation | Vitest plus browser end-to-end and audio fixture tests | Performance and compatibility require real-browser tests in addition to unit tests |
 
@@ -1010,24 +1123,32 @@ These are alpha targets and must be measured before being treated as launch guar
 - Rich text from users or models is rendered without executable HTML.
 - Asset uploads are type/size validated and served with safe content headers when P1 import ships.
 - Users are told what project data is sent to an AI provider and can decline assistant use without losing manual DAW features.
+- Users are told what product analytics and error reports are collected (OPS-02, OPS-03) and can decline product analytics without losing any DAW or assistant capability.
+- Analytics and error events never carry project content, user-entered text, asset URLs, or authentication tokens, and this is enforced by a test rather than by reviewer memory.
+- The alpha's single hosted environment is the production project (OPS-01). Test suites run against the emulator suite and must not write to it, and deployment credentials live in CI rather than on developer machines.
 
 ## 11. Success measures
 
 The private alpha should instrument events needed to establish baselines rather than optimize for vanity usage.
 
+Every measure below is derived from the OPS-02 event catalog; the event names that produce it are listed in parentheses. A measure that no catalogued event can produce is a gap in the catalog, not a reason to add a bespoke logging path.
+
 ### Primary measure
 
-**Track progression rate:** percentage of activated projects that reach an arrangement with at least three named sections and two minutes of content, then play through or export. Two minutes is an analytics threshold, not a project-duration limit.
+**Track progression rate:** percentage of activated projects that reach an arrangement with at least three named sections and two minutes of content, then play through or export. Two minutes is an analytics threshold, not a project-duration limit. (`project_created`, `arrangement_milestone`, `transport_play`, `export_completed`.)
 
 ### Supporting measures
 
-- Time from project creation to first user-authored audible edit.
-- Percentage of projects progressing from a loop to at least three sections.
-- Percentage of activated users exporting a stereo mix, multitrack stems, or both.
-- Assistant proposal apply, cancel, undo, and follow-up rates by capability.
-- Percentage of applied assistant proposals manually edited afterward, indicating ownership rather than passive generation.
-- Project reopen rate after 1 and 7 days.
-- Save failures, missing assets, audio start failures, scheduling underruns, and export failures.
+- Time from project creation to first user-authored audible edit. (`project_created`, `first_edit`.)
+- Which features a new user reaches for first, and how quickly. (`feature_first_use`, against `app_opened` and `project_created`.)
+- When and how often people use the app: sessions, session length, and return frequency. (Google Analytics automatic session collection, plus `app_opened` and `project_opened`.)
+- Percentage of projects progressing from a loop to at least three sections. (`section_created`, `arrangement_outline_created`, `arrangement_milestone`.)
+- Percentage of activated users exporting a stereo mix, multitrack stems, or both. (`export_started`, `export_completed`.)
+- Assistant proposal apply, cancel, undo, and follow-up rates by capability. (`assistant_proposal_shown`, `assistant_proposal_applied`, `assistant_proposal_cancelled`, `assistant_proposal_undone`.)
+- Percentage of applied assistant proposals manually edited afterward, indicating ownership rather than passive generation. (`assistant_proposal_applied`, `assistant_result_edited`.)
+- Project reopen rate after 1 and 7 days. (`project_opened` with `project_age_bucket` and `is_first_open`.)
+- Save failures, missing assets, audio start failures, scheduling underruns, and export failures. (`save_failed`, `save_recovered`, `asset_load_failed`, `audio_start_failed`, `audio_underrun`, `export_failed`.)
+- Crash-free session rate. (Sessions with and without a fatal `exception`, per OPS-03.)
 
 ### Qualitative validation
 
@@ -1045,6 +1166,8 @@ The agent-ready task sequence, ownership protocol, dependencies, and completion 
 
 ### Phase 0 - Foundations
 
+- **Deploy the application to Firebase Hosting first.** Before the domain model, the audio runtime, or the renderer spike, establish the deploy pipeline so every subsequent slice can be checked in a real browser against real Firebase services. Rules and indexes deploy with the app, the release SHA is stamped into the build, and rollback is documented. The alpha's only hosted environment is the production project (OPS-01).
+- Land the analytics and error-monitoring foundation immediately after: the typed OPS-02 event catalog, the logging boundary every later feature uses, and the OPS-03 error handlers, boundaries, and reporting sink. Phase 0 emits the events it can honestly emit — `app_opened`, `first_edit`, `feature_first_use`, `save_failed`, `audio_start_failed`, and `exception` — and publishes the catalog contract that every Phase 1-4 feature task extends with its own events. Instrumentation is never deferred to a cleanup task.
 - Implement the canonical schema-v1 domain model in TypeScript with runtime validation, prefixed stable IDs, integer musical time at 192 PPQ, explicit invariants, and deterministic serialization. Existing prototype state and documents require no migration or backwards compatibility.
 - Implement the shared parameter-definition mechanism — how a parameter declares its range, unit, default, clamping policy, and automation capability, and how UI, command validation, the audio engine, and assistant tools all read one definition. Phase 0 defines the mechanism and the few parameters the vertical slice needs. Per-device values for instruments and effects are authored with their devices in Phase 1, where they can be tuned by ear, and must not be invented into schema v1 ahead of them.
 - Implement the section 9.9 v1 Firebase persistence layout in code, including the metadata/song/clip document tiers, the song-document size budget and its chunk overflow path, domain-to-storage mapping, ownership metadata, schema and revision fields, indexes, security rules, and repository adapters.
@@ -1055,7 +1178,7 @@ The agent-ready task sequence, ownership protocol, dependencies, and completion 
 - Build the hybrid DOM/Canvas 2D arrangement renderer vertical slice and automated performance fixture before expanding timeline features.
 - Add reference project fixtures and deterministic audio tests.
 
-Exit criteria: the schema-v1 code and Firebase layout pass their unit, round-trip, repository, and emulator tests; the thin vertical slice can add one note through the step grid of a sampler track, play it, undo it, save it, and reopen it through the new boundaries; no UI or assistant code directly mutates stored project data; and the renderer spike ships its fixtures, scripted traces, and measurement harness with checked-in baseline numbers. Renderer frame budgets are enforced at `ARR-005` and `HARD-001`, not here, and no Phase 0 exit condition depends on access to the physical baseline device. Prototype projects are not an exit dependency.
+Exit criteria: the schema-v1 code and Firebase layout pass their unit, round-trip, repository, and emulator tests; the thin vertical slice can add one note through the step grid of a sampler track, play it, undo it, save it, and reopen it through the new boundaries; no UI or assistant code directly mutates stored project data; the renderer spike ships its fixtures, scripted traces, and measurement harness with checked-in baseline numbers; that vertical slice is reachable in a deployed build on Firebase Hosting, deployed by CI and identifiable by its release SHA; and the slice's Phase 0 analytics events and a deliberately triggered test error are observable end to end from that deployed build. Renderer frame budgets are enforced at `ARR-005` and `HARD-001`, not here, and no Phase 0 exit condition depends on access to the physical baseline device. Prototype projects are not an exit dependency.
 
 ### Phase 1 - Complete the loop workflow
 
@@ -1063,13 +1186,15 @@ Exit criteria: the schema-v1 code and Firebase layout pass their unit, round-tri
 - Starter templates and robust project management/autosave.
 - Public landing page as an honest front door into the anonymous-start flow.
 - Desktop editor layout with collapsible panels, a typed Ableton-familiar shortcut registry, shortcut tooltips, and the `?` keyboard mapping guide.
+- The acquisition, activation, and creation events in the OPS-02 catalog, each shipped by the feature it measures: `landing_cta_click`, `anon_session_created`, `account_upgraded`, `project_created`, `project_opened`, `project_deleted`, `transport_play`, `track_added`, `instrument_changed`, `device_added`, `library_audition`, `clip_edited`, `shortcut_used`, `undo_used`, plus the `save_recovered`, `audio_underrun`, and `asset_load_failed` reliability events and each feature's `feature_first_use` key.
 
-Exit criteria: a user can create, process, save, reopen, and reliably play an original 1-8 bar multi-track electronic loop without assistant help, including a drum machine and multiple chained effects.
+Exit criteria: a user can create, process, save, reopen, and reliably play an original 1-8 bar multi-track electronic loop without assistant help, including a drum machine and multiple chained effects, and the loop-workflow events above are observable from the deployed build.
 
 ### Phase 2 - Arrangement and export
 
 - Timeline placements, section markers, clip reuse/variation, focused automation, selection tools, and manual structure templates.
 - Arrangement scheduling, master limiter, offline stereo WAV render, and aligned multitrack stem packaging.
+- The arrangement and export events in the OPS-02 catalog: `section_created`, `arrangement_outline_created`, `automation_lane_created`, `arrangement_milestone`, `export_started`, `export_completed`, and `export_failed`. `arrangement_milestone` is what makes the section 11 primary measure computable, so it ships with the sections work rather than at hardening.
 
 Exit criteria: a user can manually build arrangements from two through ten minutes, export a stereo mix, and import the exported stem package into another DAW with every track aligned.
 
@@ -1077,6 +1202,7 @@ Exit criteria: a user can manually build arrangements from two through ten minut
 
 - Compact project analysis, server model gateway, tool schema, proposal cards, atomic apply/undo, contextual explanations, and initial capability set.
 - Evaluation fixtures for arrangement, variation, transformation, and invalid/stale responses.
+- The assistant events in the OPS-02 catalog: `assistant_message_sent`, `assistant_suggestion_clicked`, `assistant_proposal_shown`, `assistant_proposal_applied`, `assistant_proposal_cancelled`, `assistant_proposal_undone`, and `assistant_result_edited`. These carry capability and scope keys only — never prompts, replies, or project content.
 
 Exit criteria: the assistant can turn a reference loop into a valid editable outline, explain the edits, survive malformed responses, and leave the project identical after one undo.
 
@@ -1086,8 +1212,9 @@ Later-vision assistant capabilities shown in the design mocks — richer instrum
 
 - Performance profiling, accessibility pass, error recovery, telemetry, browser compatibility, security-rule tests, and curated template/content review.
 - Facilitated target-user sessions and fixes for blocked core journeys.
+- Audit rather than build the analytics: confirm every OPS-02 event fires from the deployed build, that no event leaks project content, that internal traffic is excluded, and that the section 11 measures and release-gate dashboards compute from real cohort data. Hardening adds dashboards and disclosures, not the instrumentation itself — an event missing here is a defect in the phase that owned it.
 
-Exit criteria: all P0 acceptance criteria pass, release-gate reliability metrics are observable, and the qualitative validation exercise is completed.
+Exit criteria: all P0 acceptance criteria pass, release-gate reliability metrics are observable from the deployed production build, and the qualitative validation exercise is completed.
 
 ### Phase 5 - Professional handoff and sharing
 
@@ -1151,13 +1278,15 @@ Produces:
 
 ### Workstream E - Content, quality, and release
 
-Owns licensed sample/preset metadata, genre coverage, starter templates, test fixtures, end-to-end tests, telemetry schema, accessibility verification, security-rule tests, compatibility matrix, and alpha operations.
+Owns licensed sample/preset metadata, genre coverage, starter templates, test fixtures, end-to-end tests, the deploy pipeline, the analytics catalog and error-monitoring boundary, accessibility verification, security-rule tests, compatibility matrix, and alpha operations.
 
 Produces:
 
 - Validated asset manifest with provenance.
 - Audited bundled-content demo projects for every required initial genre.
 - Reference projects covering empty, typical, maximum, migrated, and corrupt states.
+- The Firebase Hosting deploy pipeline, rules/index deployment, release stamping, rollback procedure, and deployed-build smoke test.
+- The typed OPS-02 analytics catalog and logging boundary, the OPS-03 error handlers and reporting sink, and the tests that keep project content out of both. Other workstreams add their own events through this contract; this workstream does not instrument their features for them.
 - Release dashboard for the success and guardrail measures.
 - Manual test script for supported browsers and audio devices.
 
@@ -1202,7 +1331,10 @@ A feature is done only when:
 - Loading, empty, error, offline, and permission states are handled.
 - Keyboard and screen-reader semantics are present for non-audio interaction.
 - New or changed user actions register shortcuts and mapping-guide metadata where applicable, with no component-local duplicate binding.
-- Relevant telemetry contains no project content or secrets.
+- **Analytics ships with the feature.** Every new or changed user action that the OPS-02 catalog covers emits its events through the shared typed catalog, with no ad-hoc event strings, and its principal failure path emits the relevant reliability event. A feature whose events are "to be added later" is not done. If a feature introduces a user action the catalog does not cover, the catalog is extended in the same change — with a `feature_first_use` key at minimum — rather than shipping unmeasured.
+- Instrumentation is tested at the same layer as the behavior: the event fires once per action, repeated or continuous gestures do not multiply it, and disabling analytics changes nothing about the feature.
+- Relevant telemetry contains no project content or secrets, verified by the OPS-02 parameter-content test rather than by inspection.
+- The feature has been exercised in a deployed build on the hosted environment, not only against a local dev server and the emulator suite.
 - Tests cover the happy path and the principal failure path.
 - Arrangement changes do not regress the committed reference performance budgets.
 - User-facing terminology matches this document.
@@ -1225,12 +1357,18 @@ A feature is done only when:
 | Ableton's project format or behavior changes | Exported sets fail or silently lose work | Target a declared Live version, isolate the serializer, test fixture exports in Live, report conversion loss, and always include portable stems/MIDI |
 | Autosave conflicts with rapid edits | Lost changes or controls jumping backward | Optimistic local authority, coalesced writes, revision checks, and explicit save state |
 | The interface becomes a smaller but still intimidating DAW | Target users remain stuck | Progressive disclosure, task-based user tests, opinionated templates, and arrangement-first assistant suggestions |
+| Production is the alpha's only hosted environment | A bad deploy reaches the cohort, or a deploy damages real project data | Deploy rules/indexes with the app from one pipeline, stamp and smoke-test every release, keep rollback documented and practised, hold incomplete journeys behind feature flags, and revisit the single-environment decision before public launch or before data loss would be unrecoverable |
+| Instrumentation is deferred to a later "telemetry" task | The alpha ends with no baseline for its own success measures and cannot tell which features were tried first | Ship the event catalog in Phase 0, make analytics part of the definition of done for every feature task, and assign each catalogued event to the task that builds the feature it measures |
+| Analytics or error reports leak project content | A privacy failure in the product whose value is the user's own music | One typed catalog with enumerated parameters, prefixed IDs instead of names, a test that rejects content-bearing parameters and covers events added later, and a user-facing opt-out that costs no capability |
 
 ## 16. Decisions and open questions
 
 ### Decisions made for implementation
 
 - Desktop web is the alpha production surface.
+- The application deploys to Firebase Hosting from CI starting in Phase 0, and the private alpha runs on one hosted environment — the production Firebase project. Rules and indexes deploy with the app; the decision is revisited before public launch.
+- Product analytics use Google Analytics for Firebase through one typed event catalog (OPS-02), and shipping a feature's events is part of that feature's definition of done rather than a later instrumentation pass.
+- Crash and error monitoring use browser error handlers plus a Cloud Functions sink into Cloud Logging, because Firebase Crashlytics does not support the Web SDK. A third-party error tracker would require an ADR.
 - Current and previous major Firefox, Chrome, and Edge are the gating P0 browsers, with a 2019 Intel MacBook Pro class machine as the performance baseline. Safari is best-effort for the alpha and expected to return to gating status before public release.
 - Musical time is integer ticks at 192 PPQ, matching Tone.js transport resolution so stored and scheduled time need no conversion.
 - Persistent IDs are type-prefixed 21-character nanoids, for example `trk_V1StGXR8Z5jdHi6B_myT`.
@@ -1261,6 +1399,8 @@ A feature is done only when:
 - What volume normalization or loudness target should WAV export use, if any?
 - Should native Live Set generation be maintained directly or delivered through a supported partner/integration route?
 - Who are the first 8-20 target testers, and what existing tools/genres should the cohort represent?
+- What consent, retention, and regional policy applies to product analytics and error reports — is analytics on by default with an opt-out, and how long is event and error data retained? (`DEC-009`.)
+- When does the alpha stop deploying only to production: what triggers adding a separate staging or preview environment, and does it happen before the cohort grows or before public launch?
 - For the later-vision tutorial video recommendations (AI-08), which creators or sources are trusted, how does a video enter the curated set, and what embedding and data-sharing terms are acceptable? (Post-alpha.)
 
 ## Appendix A - Initial assistant command families

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -738,18 +738,22 @@ Acceptance criteria:
 **OPS-03 - Error and crash monitoring (P0)**  
 Crash-free sessions, save success, and successful audio start are release gates in section 11. They are only gates if they are observable, so the alpha reports uncaught errors and the specific failures those gates depend on.
 
-Firebase Crashlytics does not support the Firebase Web SDK, so "crash reporting" here means browser error reporting, not Crashlytics. The alpha uses global `error` and `unhandledrejection` handlers plus the section 10 error boundaries, which record an `exception` analytics event (OPS-02) and send a structured report to a Cloud Functions endpoint that writes to Cloud Logging. Adopting a third-party error-tracking service instead requires an ADR under the section 9.1 rules.
+Firebase Crashlytics does not support the Firebase Web SDK, so "crash reporting" here means browser error reporting, not Crashlytics. The alpha uses **Sentry**, through the official SolidStart SDK, as its error and crash monitoring platform. This is a committed decision recorded in [ADR 0001](./adr/0001-sentry-for-error-monitoring.md); replacing it requires a superseding ADR under the section 9.1 rules.
+
+The application's own reporting boundary — global `error` and `unhandledrejection` handlers plus the section 10 error boundaries — remains the single place errors are captured. Sentry is the transport and backend behind that boundary, not a substitute for it, so application code never calls the Sentry SDK directly and the platform stays replaceable. Google Analytics keeps the `exception` counter event from OPS-02 so the section 11 measures compute from one catalog; Sentry is where an engineer debugs a specific error, not where the product dashboard is assembled.
 
 Acceptance criteria:
 
 - An uncaught error in any surface — editor, assistant, audio engine, renderer, export, or persistence — is reported once with the release SHA, browser and engine version, the area it came from, a stable error code, and a redacted message. Duplicate reports from one error are collapsed.
-- Reports carry no project content, assistant text, user-entered strings, asset URLs, or tokens, consistent with OPS-02 and the section 10 logging rules.
-- Fatal and non-fatal errors are distinguishable, so a crash-free session rate can be computed from sessions with and without a fatal `exception`.
-- Production stack traces are readable: source maps are produced and retained for the deployed revision, and are not served publicly from Hosting.
+- Reports carry no project content, assistant text, user-entered strings, asset URLs, or tokens, consistent with OPS-02 and the section 10 logging rules. Because a third-party SDK collects more by default than a hand-built reporter does, this is enforced positively rather than assumed: `sendDefaultPii` is off, console breadcrumbs are disabled rather than filtered, network and DOM breadcrumbs are scrubbed before transmission, and the OPS-02 parameter-content test extends to the Sentry payload by exercising the scrubbing functions directly, so it also covers breadcrumbs and events added later.
+- Session Replay is not enabled. It would capture the arrangement, clip names, and assistant conversation on screen; turning it on requires a superseding ADR.
+- Fatal and non-fatal errors are distinguishable, and crash-free session rate is reported by the platform's release-health session tracking rather than derived by hand.
+- Production stack traces are readable: source maps are produced for the deployed revision, uploaded to the monitoring platform through an authenticated channel, and never served publicly from Hosting.
 - The reliability gates have dedicated events, not just generic exceptions: `save_failed` / `save_recovered`, `audio_start_failed`, `audio_underrun`, `asset_load_failed`, and `export_failed` each carry an actionable error code.
-- Error reporting is best-effort and non-blocking. A failing reporting endpoint cannot stop the transport, block editing, lose unsaved state, or recurse into another report.
-- Monitoring is verified end to end from a deployed build: a deliberately triggered test error appears in the sink with its release SHA, and the check runs as part of accepting `FND-001c`.
-- Firebase Performance Monitoring may be enabled for page-load and network traces (P1). It never substitutes for the section 9.3 lab measurements of arrangement frame budgets.
+- Error reporting is best-effort and non-blocking. A failing, blocked, or ad-blocker-suppressed reporter cannot stop the transport, block editing, lose unsaved state, or recurse into another report. Reports are not tunnelled through a first-party endpoint in the alpha; the resulting undercount is documented rather than engineered around.
+- Monitoring does not compromise the section 10 performance budgets: the SDK initializes lazily after first paint with a minimal integration set and is not loaded on the marketing landing page.
+- Monitoring is verified end to end from a deployed build: a deliberately triggered test error arrives with its release SHA and a symbolicated stack trace, and the check runs as part of accepting `FND-001c`.
+- Firebase Performance Monitoring may be enabled for page-load and network traces (P1). Neither it nor the monitoring platform's own tracing substitutes for the section 9.3 lab measurements of arrangement frame budgets.
 
 ## 8. Interaction requirements
 
@@ -855,6 +859,8 @@ Acceptance criteria:
 
 These are hard decisions for the alpha, not provisional preferences. An implementation agent must not replace one with an alternative without a written architecture decision record (ADR) approved by the product owner.
 
+Approved ADRs live in [`docs/adr`](./adr), numbered and named after the decision they record. An ADR states the context, the decision, its consequences including what it costs, and the alternatives rejected. A decision that changes a row in the table below updates that row to point at its ADR; the ADR is the reasoning, and this table stays the index.
+
 | Area | Alpha decision | Commitment |
 | --- | --- | --- |
 | Product surface | Desktop web application | No Electron/native wrapper or mobile-editor parity in the alpha |
@@ -866,7 +872,7 @@ These are hard decisions for the alpha, not provisional preferences. An implemen
 | Privileged backend | Cloud Functions for Firebase | AI-provider calls, privileged validation, quotas, and future background work execute server-side; provider code never ships to the client |
 | Hosting and deployment | Firebase Hosting, deployed from CI | One hosted environment for the alpha — the production project — with rules and indexes deployed from the same pipeline (OPS-01) |
 | Product analytics | Google Analytics for Firebase | User-action events come from one typed catalog (OPS-02); no second analytics vendor and no ad-hoc event strings |
-| Error monitoring | Browser error handlers plus a Cloud Functions sink into Cloud Logging | Crashlytics does not support the Firebase Web SDK; a third-party error tracker requires an ADR (OPS-03) |
+| Error monitoring | Sentry, behind the application's own reporting boundary | Crashlytics does not support the Firebase Web SDK, and Cloud Error Reporting cannot symbolicate browser traces without publicly served source maps; see [ADR 0001](./adr/0001-sentry-for-error-monitoring.md) |
 | Arrangement rendering | Hybrid DOM plus Canvas 2D | DOM provides application structure and semantics; viewport-sized canvases render dense timeline graphics |
 | Test foundation | Vitest plus browser end-to-end and audio fixture tests | Performance and compatibility require real-browser tests in addition to unit tests |
 
@@ -1124,7 +1130,8 @@ These are alpha targets and must be measured before being treated as launch guar
 - Asset uploads are type/size validated and served with safe content headers when P1 import ships.
 - Users are told what project data is sent to an AI provider and can decline assistant use without losing manual DAW features.
 - Users are told what product analytics and error reports are collected (OPS-02, OPS-03) and can decline product analytics without losing any DAW or assistant capability.
-- Analytics and error events never carry project content, user-entered text, asset URLs, or authentication tokens, and this is enforced by a test rather than by reviewer memory.
+- Analytics and error events never carry project content, user-entered text, asset URLs, or authentication tokens, and this is enforced by a test rather than by reviewer memory. The test covers the third-party monitoring payload as well as our own event catalog, because that SDK collects breadcrumbs by default that the rule forbids.
+- Error monitoring uses a third-party processor (Sentry, per ADR 0001). It is disclosed to the user alongside product analytics, its retention and regional storage are part of the same product decision, and no additional processor is added to the alpha without an ADR.
 - The alpha's single hosted environment is the production project (OPS-01). Test suites run against the emulator suite and must not write to it, and deployment credentials live in CI rather than on developer machines.
 
 ## 11. Success measures
@@ -1148,7 +1155,7 @@ Every measure below is derived from the OPS-02 event catalog; the event names th
 - Percentage of applied assistant proposals manually edited afterward, indicating ownership rather than passive generation. (`assistant_proposal_applied`, `assistant_result_edited`.)
 - Project reopen rate after 1 and 7 days. (`project_opened` with `project_age_bucket` and `is_first_open`.)
 - Save failures, missing assets, audio start failures, scheduling underruns, and export failures. (`save_failed`, `save_recovered`, `asset_load_failed`, `audio_start_failed`, `audio_underrun`, `export_failed`.)
-- Crash-free session rate. (Sessions with and without a fatal `exception`, per OPS-03.)
+- Crash-free session rate. (Reported by the OPS-03 monitoring platform's release-health session tracking, with the GA4 `exception` counter available to cross-check it against the other measures.)
 
 ### Qualitative validation
 
@@ -1167,7 +1174,7 @@ The agent-ready task sequence, ownership protocol, dependencies, and completion 
 ### Phase 0 - Foundations
 
 - **Deploy the application to Firebase Hosting first.** Before the domain model, the audio runtime, or the renderer spike, establish the deploy pipeline so every subsequent slice can be checked in a real browser against real Firebase services. Rules and indexes deploy with the app, the release SHA is stamped into the build, and rollback is documented. The alpha's only hosted environment is the production project (OPS-01).
-- Land the analytics and error-monitoring foundation immediately after: the typed OPS-02 event catalog, the logging boundary every later feature uses, and the OPS-03 error handlers, boundaries, and reporting sink. Phase 0 emits the events it can honestly emit — `app_opened`, `first_edit`, `feature_first_use`, `save_failed`, `audio_start_failed`, and `exception` — and publishes the catalog contract that every Phase 1-4 feature task extends with its own events. Instrumentation is never deferred to a cleanup task.
+- Land the analytics and error-monitoring foundation immediately after: the typed OPS-02 event catalog, the logging boundary every later feature uses, and the OPS-03 error handlers, error boundaries, and Sentry integration with its scrubbing and source-map upload. Phase 0 emits the events it can honestly emit — `app_opened`, `first_edit`, `feature_first_use`, `save_failed`, `audio_start_failed`, and `exception` — and publishes the catalog contract that every Phase 1-4 feature task extends with its own events. Instrumentation is never deferred to a cleanup task.
 - Implement the canonical schema-v1 domain model in TypeScript with runtime validation, prefixed stable IDs, integer musical time at 192 PPQ, explicit invariants, and deterministic serialization. Existing prototype state and documents require no migration or backwards compatibility.
 - Implement the shared parameter-definition mechanism — how a parameter declares its range, unit, default, clamping policy, and automation capability, and how UI, command validation, the audio engine, and assistant tools all read one definition. Phase 0 defines the mechanism and the few parameters the vertical slice needs. Per-device values for instruments and effects are authored with their devices in Phase 1, where they can be tuned by ear, and must not be invented into schema v1 ahead of them.
 - Implement the section 9.9 v1 Firebase persistence layout in code, including the metadata/song/clip document tiers, the song-document size budget and its chunk overflow path, domain-to-storage mapping, ownership metadata, schema and revision fields, indexes, security rules, and repository adapters.
@@ -1286,7 +1293,7 @@ Produces:
 - Audited bundled-content demo projects for every required initial genre.
 - Reference projects covering empty, typical, maximum, migrated, and corrupt states.
 - The Firebase Hosting deploy pipeline, rules/index deployment, release stamping, rollback procedure, and deployed-build smoke test.
-- The typed OPS-02 analytics catalog and logging boundary, the OPS-03 error handlers and reporting sink, and the tests that keep project content out of both. Other workstreams add their own events through this contract; this workstream does not instrument their features for them.
+- The typed OPS-02 analytics catalog and logging boundary, the OPS-03 error-reporting boundary and its Sentry integration including scrubbing and release/source-map upload, and the tests that keep project content out of both. Other workstreams add their own events through this contract; this workstream does not instrument their features for them.
 - Release dashboard for the success and guardrail measures.
 - Manual test script for supported browsers and audio devices.
 
@@ -1360,6 +1367,7 @@ A feature is done only when:
 | Production is the alpha's only hosted environment | A bad deploy reaches the cohort, or a deploy damages real project data | Deploy rules/indexes with the app from one pipeline, stamp and smoke-test every release, keep rollback documented and practised, hold incomplete journeys behind feature flags, and revisit the single-environment decision before public launch or before data loss would be unrecoverable |
 | Instrumentation is deferred to a later "telemetry" task | The alpha ends with no baseline for its own success measures and cannot tell which features were tried first | Ship the event catalog in Phase 0, make analytics part of the definition of done for every feature task, and assign each catalogued event to the task that builds the feature it measures |
 | Analytics or error reports leak project content | A privacy failure in the product whose value is the user's own music | One typed catalog with enumerated parameters, prefixed IDs instead of names, a test that rejects content-bearing parameters and covers events added later, and a user-facing opt-out that costs no capability |
+| A third-party monitoring SDK collects more than the product allows | Clip names, console output, or on-screen music reach an external processor by default rather than by decision | Keep the reporting boundary in application code, disable console breadcrumbs and `sendDefaultPii`, scrub before transmission, forbid Session Replay without a superseding ADR, and extend the content test to the SDK payload rather than only our own events |
 
 ## 16. Decisions and open questions
 
@@ -1368,7 +1376,8 @@ A feature is done only when:
 - Desktop web is the alpha production surface.
 - The application deploys to Firebase Hosting from CI starting in Phase 0, and the private alpha runs on one hosted environment — the production Firebase project. Rules and indexes deploy with the app; the decision is revisited before public launch.
 - Product analytics use Google Analytics for Firebase through one typed event catalog (OPS-02), and shipping a feature's events is part of that feature's definition of done rather than a later instrumentation pass.
-- Crash and error monitoring use browser error handlers plus a Cloud Functions sink into Cloud Logging, because Firebase Crashlytics does not support the Web SDK. A third-party error tracker would require an ADR.
+- Crash and error monitoring use Sentry behind the application's own reporting boundary ([ADR 0001](./adr/0001-sentry-for-error-monitoring.md)). Firebase Crashlytics does not support the Web SDK, and Google Cloud Error Reporting cannot symbolicate browser stack traces without publicly serving our source maps — which `OPS-03` forbids. Session Replay stays off, and replacing Sentry requires a superseding ADR.
+- Approved architecture decision records live in [`docs/adr`](./adr); the section 9.1 stack table indexes them.
 - Current and previous major Firefox, Chrome, and Edge are the gating P0 browsers, with a 2019 Intel MacBook Pro class machine as the performance baseline. Safari is best-effort for the alpha and expected to return to gating status before public release.
 - Musical time is integer ticks at 192 PPQ, matching Tone.js transport resolution so stored and scheduled time need no conversion.
 - Persistent IDs are type-prefixed 21-character nanoids, for example `trk_V1StGXR8Z5jdHi6B_myT`.
@@ -1399,7 +1408,7 @@ A feature is done only when:
 - What volume normalization or loudness target should WAV export use, if any?
 - Should native Live Set generation be maintained directly or delivered through a supported partner/integration route?
 - Who are the first 8-20 target testers, and what existing tools/genres should the cohort represent?
-- What consent, retention, and regional policy applies to product analytics and error reports — is analytics on by default with an opt-out, and how long is event and error data retained? (`DEC-009`.)
+- What consent, retention, and regional policy applies to product analytics and error reports — is analytics on by default with an opt-out, how long is event and error data retained, and does the Sentry data region satisfy any regional constraint, or does that constraint reopen self-hosting? (`DEC-009`.)
 - When does the alpha stop deploying only to production: what triggers adding a separate staging or preview environment, and does it happen before the cohort grows or before public launch?
 - For the later-vision tutorial video recommendations (AI-08), which creators or sources are trusted, how does a video enter the curated set, and what embedding and data-sharing terms are acceptable? (Post-alpha.)
 


### PR DESCRIPTION
Adds PRD section 7.10 covering three P0 requirements:

- OPS-01: deploy to Firebase Hosting from CI starting in Phase 0, with
  one hosted environment for the alpha (the production project), rules
  and indexes deployed from the same pipeline, release SHA stamping,
  documented rollback, and a post-deploy smoke test.
- OPS-02: a typed analytics event catalog naming every user action
  logged to Google Analytics for Firebase, its parameters, and the
  backlog task that ships it with the feature it measures.
- OPS-03: browser error and crash monitoring via global handlers plus a
  Cloud Functions sink into Cloud Logging, since Crashlytics does not
  support the Firebase Web SDK.

Ties the catalog into the rest of the document: the section 11 success
measures now name the events that produce them, each delivery phase
lists the events it owns, the section 14 definition of done requires
analytics to ship with the feature, and the stack table, privacy rules,
risks, and decisions are updated.

Backlog: adds FND-001b (deployment) and FND-001c (analytics and error
monitoring) as the earliest Phase 0 tasks with a G0.5 gate, adds DEC-009
for the consent and retention decision, and adds the owning event
checkboxes to the feature tasks across phases 1-4.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gj6Q4u6AMbNTh1Y1s9W95p