### PR TITLE
FND-003 - Command, transaction, and history kernel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,13 @@ src/
 │   ├── serialize.ts         # Deterministic JSON serialization
 │   ├── factories.ts         # Blank/entity factories
 │   └── fixtures.ts          # Deterministic reference projects
+├── commands/           # Shared command, transaction, and history kernel
+│   ├── types.ts             # Actors, envelopes, issues, command definitions
+│   ├── registry.ts          # The one typed command registry
+│   ├── execute.ts           # Validation, atomic transactions, revisions
+│   ├── history.ts           # Local bounded undo/redo and gestures
+│   ├── projectEdits.ts      # Immutable edit helpers with structural sharing
+│   └── definitions/         # Registered commands, grouped by entity
 ├── model/              # Prototype state, superseded by src/domain
 │   ├── types.ts             # Prototype types (removed by the FND-009 slice)
 │   ├── project.ts           # Project store and update functions
@@ -178,6 +185,14 @@ See [`docs/testing.md`](./docs/testing.md) for what each suite covers, how CI ga
 - A user-controlled numeric value declares its range, unit, default, clamping policy, and automation capability once in `src/domain/parameters.ts`; UI, validation, audio, and assistant tools read that definition instead of repeating literals.
 - `parseProject` is the only way to obtain a `Project`. It either returns a fully valid project or a list of issues, and never partially repairs input.
 - Changing this contract is its own backlog task, not incidental work inside a feature.
+
+### Shared command layer (`src/commands`)
+- Every project mutation — pointer, keyboard, or assistant — is a registered command (PRD section 9.6). Components never write to project state; they build a typed command and hand it to `CommandHistory`.
+- A command declares a versioned type, a Zod payload schema, a pure `apply`, a generated `invert`, and a one-line `summarize`. Payloads carry explicit IDs for anything they create, so replay, redo, and assistant previews reproduce the same project.
+- `executeTransaction` is the atomic unit: commands apply to a working copy, the result is checked against every domain invariant, and any failure returns the original project object untouched. One committed transaction produces exactly one revision and one history entry.
+- Continuous gestures use `history.beginGesture()`; every step applies immediately but the whole drag commits as one entry and one revision.
+- Undo/redo is session-local, bounded, and replays inverse commands rather than project snapshots. Only an explicit `replaceProject` clears it — a save acknowledgement or remote echo must never touch it.
+- Like `src/domain`, this layer imports no Firebase, Tone, or Solid. Adding or changing a command is a contract change; see the registry test's pinned command list.
 
 ### Service Layer
 - Create service modules for external integrations (authService, dataService)

--- a/src/commands/boundaries.test.ts
+++ b/src/commands/boundaries.test.ts
@@ -1,0 +1,89 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The command kernel is framework-free (PRD sections 9.2 and 9.6).
+ *
+ * Undo history is "local ... and does not depend on Firestore snapshots", the
+ * assistant sends approved commands through this same layer, and the audio
+ * engine consumes the resulting projection — none of which works if a command
+ * can reach for a Firestore document, a Tone node, or a Solid signal. The
+ * dependency runs one way: persistence, audio, and UI import commands, never
+ * the reverse.
+ */
+
+const commandsDirectory = join(process.cwd(), "src", "commands");
+
+const FORBIDDEN_IMPORTS = [
+	"firebase",
+	"solid-js",
+	"@solidjs/",
+	"tone",
+	"vitest",
+];
+
+function sourceFiles(): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(commandsDirectory, { withFileTypes: true })) {
+		if (entry.isDirectory()) {
+			for (const nested of readdirSync(join(commandsDirectory, entry.name))) {
+				files.push(join(entry.name, nested));
+			}
+			continue;
+		}
+		files.push(entry.name);
+	}
+	return files.filter(
+		(file) =>
+			file.endsWith(".ts") &&
+			!file.endsWith(".test.ts") &&
+			// Test-only fixtures are not part of the shipped kernel.
+			!file.endsWith("testProjects.ts"),
+	);
+}
+
+describe("command layer boundaries", () => {
+	it("has source files to check", () => {
+		expect(sourceFiles().length).toBeGreaterThan(5);
+	});
+
+	it("imports no Firebase, Tone, Solid, or test-framework module", () => {
+		for (const file of sourceFiles()) {
+			const source = readFileSync(join(commandsDirectory, file), "utf8");
+			const imports = [...source.matchAll(/from\s+"([^"]+)"/g)].map(
+				(match) => match[1],
+			);
+			for (const specifier of imports) {
+				for (const forbidden of FORBIDDEN_IMPORTS) {
+					expect(
+						specifier.startsWith(forbidden),
+						`${file} imports "${specifier}"`,
+					).toBe(false);
+				}
+			}
+		}
+	});
+
+	it("reads the domain contract without reaching into other feature code", () => {
+		const sourceRoot = join(process.cwd(), "src");
+		for (const file of sourceFiles()) {
+			const path = join(commandsDirectory, file);
+			const source = readFileSync(path, "utf8");
+			const relativeImports = [...source.matchAll(/from\s+"(\.[^"]+)"/g)].map(
+				(match) => resolve(dirname(path), match[1]),
+			);
+			for (const target of relativeImports) {
+				if (target.startsWith(commandsDirectory)) {
+					continue;
+				}
+				const withinSource = relative(sourceRoot, target);
+				expect(
+					withinSource.startsWith("domain/") ||
+						withinSource.startsWith("shared/"),
+					`${file} imports "${withinSource}" from outside the domain and shared modules`,
+				).toBe(true);
+			}
+		}
+	});
+});

--- a/src/commands/definitions/clips.ts
+++ b/src/commands/definitions/clips.ts
@@ -1,0 +1,210 @@
+import { z } from "zod";
+import {
+	type Clip,
+	clipSchema,
+	type Placement,
+	placementSchema,
+} from "../../domain/entities";
+import { type ClipId, clipIdSchema } from "../../domain/ids";
+import {
+	clipLabel,
+	findClip,
+	replaceClip,
+	withClips,
+	withSong,
+} from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+
+/**
+ * Clip lifecycle commands.
+ *
+ * Deleting a clip also removes the arrangement placements that reference it,
+ * because a placement pointing at a missing clip is an invalid project
+ * (invariant 5). The inverse therefore restores the clip *and* its placements
+ * in one command, so undo of a delete is exact rather than approximate.
+ */
+
+export const clipCreatePayloadSchema = z.strictObject({
+	clip: clipSchema,
+	/** Placements restored alongside the clip; empty when creating a new one. */
+	placements: z.array(placementSchema).default([]),
+});
+export type ClipCreatePayload = z.infer<typeof clipCreatePayloadSchema>;
+
+export const clipDeletePayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+});
+export type ClipDeletePayload = z.infer<typeof clipDeletePayloadSchema>;
+
+export const clipChangesSchema = z
+	.strictObject({
+		name: clipSchema.shape.name.optional(),
+		color: clipSchema.shape.color.optional(),
+		lengthTicks: clipSchema.shape.lengthTicks.optional(),
+	})
+	.refine(
+		(changes) => Object.values(changes).some((value) => value !== undefined),
+		{ message: "An update must change at least one field" },
+	);
+export type ClipChanges = z.infer<typeof clipChangesSchema>;
+
+export const clipUpdatePayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	changes: clipChangesSchema,
+});
+export type ClipUpdatePayload = z.infer<typeof clipUpdatePayloadSchema>;
+
+export const clipCreateCommand = defineCommand<ClipCreatePayload>({
+	type: "clip.create",
+	version: 1,
+	schema: clipCreatePayloadSchema,
+	summarize: (payload) =>
+		payload.placements.length > 0
+			? `Restore clip "${payload.clip.name}"`
+			: `Add clip "${payload.clip.name}"`,
+	apply(project, payload) {
+		if (findClip(project, payload.clip.id)) {
+			return rejected(`Clip ${payload.clip.id} already exists`);
+		}
+		const foreign = payload.placements.find(
+			(placement) => placement.clipId !== payload.clip.id,
+		);
+		if (foreign) {
+			return rejected(
+				`Placement ${foreign.id} does not belong to clip ${payload.clip.id}`,
+			);
+		}
+		const withClip = withClips(project, [...project.clips, payload.clip]);
+		return applied(
+			withSong(withClip, {
+				...withClip.song,
+				placements: [...withClip.song.placements, ...payload.placements],
+			}),
+		);
+	},
+	invert: (payload) => [removeClip(payload.clip.id)],
+});
+
+export const clipDeleteCommand = defineCommand<ClipDeletePayload>({
+	type: "clip.delete",
+	version: 1,
+	schema: clipDeletePayloadSchema,
+	summarize: (payload, project) =>
+		`Delete clip ${clipLabel(project, payload.clipId)}`,
+	apply(project, payload) {
+		const clip = findClip(project, payload.clipId);
+		if (!clip) {
+			return rejected(`Clip ${payload.clipId} does not exist`);
+		}
+		const remaining = withClips(
+			project,
+			project.clips.filter((candidate) => candidate.id !== clip.id),
+		);
+		return applied(
+			withSong(remaining, {
+				...remaining.song,
+				placements: remaining.song.placements.filter(
+					(placement) => placement.clipId !== clip.id,
+				),
+			}),
+		);
+	},
+	invert(payload, before) {
+		const clip = findClip(before, payload.clipId);
+		if (!clip) {
+			return [];
+		}
+		return [
+			addClip(
+				clip,
+				before.song.placements.filter(
+					(placement) => placement.clipId === clip.id,
+				),
+			),
+		];
+	},
+});
+
+export const clipUpdateCommand = defineCommand<ClipUpdatePayload>({
+	type: "clip.update",
+	version: 1,
+	schema: clipUpdatePayloadSchema,
+	summarize(payload, project) {
+		const label = clipLabel(project, payload.clipId);
+		if (payload.changes.name !== undefined) {
+			return `Rename clip ${label} to "${payload.changes.name}"`;
+		}
+		if (payload.changes.lengthTicks !== undefined) {
+			return `Resize clip ${label} to ${payload.changes.lengthTicks} ticks`;
+		}
+		return `Recolor clip ${label}`;
+	},
+	apply(project, payload) {
+		const clip = findClip(project, payload.clipId);
+		if (!clip) {
+			return rejected(`Clip ${payload.clipId} does not exist`);
+		}
+		return applied(
+			replaceClip(project, { ...clip, ...definedOnly(payload.changes) }),
+		);
+	},
+	invert(payload, before) {
+		const clip = findClip(before, payload.clipId);
+		if (!clip) {
+			return [];
+		}
+		return [
+			updateClip(payload.clipId, {
+				...(payload.changes.name !== undefined ? { name: clip.name } : {}),
+				...(payload.changes.color !== undefined ? { color: clip.color } : {}),
+				...(payload.changes.lengthTicks !== undefined
+					? { lengthTicks: clip.lengthTicks }
+					: {}),
+			}),
+		];
+	},
+});
+
+/** Drops absent keys so a spread never overwrites a field with `undefined`. */
+function definedOnly<T extends object>(changes: T): Partial<T> {
+	return Object.fromEntries(
+		Object.entries(changes).filter(([, value]) => value !== undefined),
+	) as Partial<T>;
+}
+
+// --- Typed builders -------------------------------------------------------
+
+export function addClip(
+	clip: Clip,
+	placements: readonly Placement[] = [],
+): CommandInput<ClipCreatePayload> {
+	return {
+		type: clipCreateCommand.type,
+		payload: { clip, placements: [...placements] },
+	};
+}
+
+export function removeClip(clipId: ClipId): CommandInput<ClipDeletePayload> {
+	return { type: clipDeleteCommand.type, payload: { clipId } };
+}
+
+export function updateClip(
+	clipId: ClipId,
+	changes: ClipChanges,
+): CommandInput<ClipUpdatePayload> {
+	return { type: clipUpdateCommand.type, payload: { clipId, changes } };
+}
+
+/** Registered, payload-erased commands from this module. */
+export const clipCommands: readonly RegisteredCommand[] = [
+	eraseCommand(clipCreateCommand),
+	eraseCommand(clipDeleteCommand),
+	eraseCommand(clipUpdateCommand),
+];

--- a/src/commands/definitions/notes.ts
+++ b/src/commands/definitions/notes.ts
@@ -1,0 +1,306 @@
+import { z } from "zod";
+import {
+	type NoteEvent,
+	noteEventSchema,
+	noteTriggerSchema,
+} from "../../domain/entities";
+import {
+	type ClipId,
+	clipIdSchema,
+	type EventId,
+	eventIdSchema,
+	type IdFactory,
+} from "../../domain/ids";
+import {
+	NOTE_PROBABILITY,
+	NOTE_VELOCITY,
+	parameterValueSchema,
+} from "../../domain/parameters";
+import { durationTickSchema, tickSchema } from "../../domain/time";
+import {
+	clipLabel,
+	findClip,
+	findNoteEvent,
+	noteEventsOf,
+	pluralize,
+	replaceClip,
+	withNoteEvents,
+} from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+
+/**
+ * Note editing commands — the `FND-009` slice's write path.
+ *
+ * Payloads carry explicit event IDs rather than minting them inside `apply`,
+ * so a command is a pure function of its payload: replaying it on redo, on a
+ * peer, or in a test reproduces the same IDs and the same project.
+ */
+
+export const noteAddPayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	notes: z.array(noteEventSchema).min(1),
+});
+export type NoteAddPayload = z.infer<typeof noteAddPayloadSchema>;
+
+export const noteRemovePayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	eventIds: z.array(eventIdSchema).min(1),
+});
+export type NoteRemovePayload = z.infer<typeof noteRemovePayloadSchema>;
+
+/**
+ * Which fields of a note an update may set. An absent key means "leave alone";
+ * `probability: null` clears a probability that was set.
+ */
+export const noteChangesSchema = z
+	.strictObject({
+		trigger: noteTriggerSchema.optional(),
+		startTicks: tickSchema.optional(),
+		durationTicks: durationTickSchema.optional(),
+		velocity: parameterValueSchema(NOTE_VELOCITY).optional(),
+		probability: parameterValueSchema(NOTE_PROBABILITY).nullable().optional(),
+	})
+	.refine(
+		(changes) => Object.values(changes).some((value) => value !== undefined),
+		{ message: "An update must change at least one field" },
+	);
+export type NoteChanges = z.infer<typeof noteChangesSchema>;
+
+export const noteUpdatePayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	updates: z
+		.array(
+			z.strictObject({ eventId: eventIdSchema, changes: noteChangesSchema }),
+		)
+		.min(1),
+});
+export type NoteUpdatePayload = z.infer<typeof noteUpdatePayloadSchema>;
+
+export const noteAddCommand = defineCommand<NoteAddPayload>({
+	type: "note.add",
+	version: 1,
+	schema: noteAddPayloadSchema,
+	summarize: (payload, project) =>
+		`Add ${pluralize(payload.notes.length, "note")} to ${clipLabel(project, payload.clipId)}`,
+	apply(project, payload) {
+		const clip = findClip(project, payload.clipId);
+		if (!clip) {
+			return rejected(`Clip ${payload.clipId} does not exist`);
+		}
+		const events = noteEventsOf(clip);
+		if (!events) {
+			return rejected(`Clip ${clip.id} does not hold note content`);
+		}
+		const existing = new Set(events.map((event) => event.id));
+		const duplicate = payload.notes.find((note) => existing.has(note.id));
+		if (duplicate) {
+			return rejected(`Note ${duplicate.id} already exists in clip ${clip.id}`);
+		}
+		return applied(
+			replaceClip(project, withNoteEvents(clip, [...events, ...payload.notes])),
+		);
+	},
+	invert: (payload) => [
+		removeNotes(
+			payload.clipId,
+			payload.notes.map((note) => note.id),
+		),
+	],
+});
+
+export const noteRemoveCommand = defineCommand<NoteRemovePayload>({
+	type: "note.remove",
+	version: 1,
+	schema: noteRemovePayloadSchema,
+	summarize: (payload, project) =>
+		`Delete ${pluralize(payload.eventIds.length, "note")} from ${clipLabel(project, payload.clipId)}`,
+	apply(project, payload) {
+		const clip = findClip(project, payload.clipId);
+		if (!clip) {
+			return rejected(`Clip ${payload.clipId} does not exist`);
+		}
+		const events = noteEventsOf(clip);
+		if (!events) {
+			return rejected(`Clip ${clip.id} does not hold note content`);
+		}
+		const removing = new Set<string>(payload.eventIds);
+		const missing = payload.eventIds.filter(
+			(eventId) => !events.some((event) => event.id === eventId),
+		);
+		if (missing.length > 0) {
+			return rejected(
+				`Clip ${clip.id} has no note ${missing.join(", ")} to delete`,
+			);
+		}
+		return applied(
+			replaceClip(
+				project,
+				withNoteEvents(
+					clip,
+					events.filter((event) => !removing.has(event.id)),
+				),
+			),
+		);
+	},
+	invert(payload, before) {
+		const clip = findClip(before, payload.clipId);
+		const events = clip ? (noteEventsOf(clip) ?? []) : [];
+		const removed = events.filter((event) =>
+			payload.eventIds.includes(event.id),
+		);
+		return removed.length > 0 ? [addNotes(payload.clipId, removed)] : [];
+	},
+});
+
+export const noteUpdateCommand = defineCommand<NoteUpdatePayload>({
+	type: "note.update",
+	version: 1,
+	schema: noteUpdatePayloadSchema,
+	summarize: (payload, project) =>
+		`Edit ${pluralize(payload.updates.length, "note")} in ${clipLabel(project, payload.clipId)}`,
+	apply(project, payload) {
+		const clip = findClip(project, payload.clipId);
+		if (!clip) {
+			return rejected(`Clip ${payload.clipId} does not exist`);
+		}
+		const events = noteEventsOf(clip);
+		if (!events) {
+			return rejected(`Clip ${clip.id} does not hold note content`);
+		}
+		const changed = new Map<string, NoteEvent>();
+		for (const update of payload.updates) {
+			const source =
+				changed.get(update.eventId) ?? findNoteEvent(clip, update.eventId);
+			if (!source) {
+				return rejected(
+					`Clip ${clip.id} has no note ${update.eventId} to edit`,
+				);
+			}
+			changed.set(update.eventId, applyNoteChanges(source, update.changes));
+		}
+		return applied(
+			replaceClip(
+				project,
+				withNoteEvents(
+					clip,
+					events.map((event) => changed.get(event.id) ?? event),
+				),
+			),
+		);
+	},
+	invert(payload, before) {
+		const clip = findClip(before, payload.clipId);
+		if (!clip) {
+			return [];
+		}
+		const updates = payload.updates.flatMap((update) => {
+			const event = findNoteEvent(clip, update.eventId);
+			return event
+				? [
+						{
+							eventId: update.eventId,
+							changes: previousValues(event, update.changes),
+						},
+					]
+				: [];
+		});
+		return updates.length > 0 ? [updateNotes(payload.clipId, updates)] : [];
+	},
+});
+
+export function applyNoteChanges(
+	event: NoteEvent,
+	changes: NoteChanges,
+): NoteEvent {
+	return {
+		...event,
+		...(changes.trigger !== undefined ? { trigger: changes.trigger } : {}),
+		...(changes.startTicks !== undefined
+			? { startTicks: changes.startTicks }
+			: {}),
+		...(changes.durationTicks !== undefined
+			? { durationTicks: changes.durationTicks }
+			: {}),
+		...(changes.velocity !== undefined ? { velocity: changes.velocity } : {}),
+		...(changes.probability !== undefined
+			? { probability: changes.probability }
+			: {}),
+	};
+}
+
+/** The event's current values for exactly the fields `changes` would set. */
+function previousValues(event: NoteEvent, changes: NoteChanges): NoteChanges {
+	return {
+		...(changes.trigger !== undefined ? { trigger: event.trigger } : {}),
+		...(changes.startTicks !== undefined
+			? { startTicks: event.startTicks }
+			: {}),
+		...(changes.durationTicks !== undefined
+			? { durationTicks: event.durationTicks }
+			: {}),
+		...(changes.velocity !== undefined ? { velocity: event.velocity } : {}),
+		...(changes.probability !== undefined
+			? { probability: event.probability }
+			: {}),
+	};
+}
+
+// --- Typed builders -------------------------------------------------------
+//
+// Callers construct commands through these rather than object literals, so a
+// payload is type-checked at the call site as well as validated at execution.
+
+export function addNotes(
+	clipId: ClipId,
+	notes: readonly NoteEvent[],
+): CommandInput<NoteAddPayload> {
+	return { type: noteAddCommand.type, payload: { clipId, notes: [...notes] } };
+}
+
+export function removeNotes(
+	clipId: ClipId,
+	eventIds: readonly EventId[],
+): CommandInput<NoteRemovePayload> {
+	return {
+		type: noteRemoveCommand.type,
+		payload: { clipId, eventIds: [...eventIds] },
+	};
+}
+
+export function updateNotes(
+	clipId: ClipId,
+	updates: readonly { eventId: EventId; changes: NoteChanges }[],
+): CommandInput<NoteUpdatePayload> {
+	return {
+		type: noteUpdateCommand.type,
+		payload: { clipId, updates: updates.map((update) => ({ ...update })) },
+	};
+}
+
+/** Convenience for the single-note case the step grid dispatches. */
+export function updateNote(
+	clipId: ClipId,
+	eventId: EventId,
+	changes: NoteChanges,
+): CommandInput<NoteUpdatePayload> {
+	return updateNotes(clipId, [{ eventId, changes }]);
+}
+
+/** Mints an event ID for a new note, so callers never hand-write one. */
+export function newEventId(ids: IdFactory): EventId {
+	return ids("event");
+}
+
+/** Registered, payload-erased commands from this module. */
+export const noteCommands: readonly RegisteredCommand[] = [
+	eraseCommand(noteAddCommand),
+	eraseCommand(noteRemoveCommand),
+	eraseCommand(noteUpdateCommand),
+];

--- a/src/commands/definitions/parameters.ts
+++ b/src/commands/definitions/parameters.ts
@@ -1,0 +1,339 @@
+import { z } from "zod";
+import type { Project } from "../../domain/entities";
+import {
+	deviceIdSchema,
+	returnIdSchema,
+	trackIdSchema,
+} from "../../domain/ids";
+import {
+	coerceParameterValue,
+	getParameterDefinition,
+	MASTER_VOLUME,
+	type ParameterDefinition,
+	RETURN_PAN,
+	RETURN_VOLUME,
+	SONG_TEMPO,
+	TRACK_PAN,
+	TRACK_SEND_LEVEL,
+	TRACK_VOLUME,
+} from "../../domain/parameters";
+import { findTrack, replaceTrack, withSong } from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+
+/**
+ * One generic parameter command for every user-controlled numeric value
+ * (PRD invariants 4 and 10).
+ *
+ * The command never repeats a range, a default, or a clamping rule: it looks
+ * the target's definition up in `src/domain/parameters.ts` and applies that
+ * definition's policy. Adding a device parameter in Phase 1 therefore makes it
+ * settable by the UI, the keyboard, and the assistant without a new command.
+ */
+
+export const parameterTargetSchema = z.discriminatedUnion("scope", [
+	z.strictObject({
+		scope: z.literal("song"),
+		parameterId: z.string().min(1),
+	}),
+	z.strictObject({
+		scope: z.literal("track"),
+		trackId: trackIdSchema,
+		parameterId: z.string().min(1),
+	}),
+	z.strictObject({
+		scope: z.literal("trackDevice"),
+		trackId: trackIdSchema,
+		deviceId: deviceIdSchema,
+		parameterId: z.string().min(1),
+	}),
+	z.strictObject({
+		scope: z.literal("send"),
+		trackId: trackIdSchema,
+		returnId: returnIdSchema,
+		parameterId: z.string().min(1),
+	}),
+	z.strictObject({
+		scope: z.literal("return"),
+		returnId: returnIdSchema,
+		parameterId: z.string().min(1),
+	}),
+	z.strictObject({
+		scope: z.literal("master"),
+		parameterId: z.string().min(1),
+	}),
+]);
+export type ParameterTarget = z.infer<typeof parameterTargetSchema>;
+
+export const parameterSetPayloadSchema = z.strictObject({
+	target: parameterTargetSchema,
+	value: z.number(),
+});
+export type ParameterSetPayload = z.infer<typeof parameterSetPayloadSchema>;
+
+interface ResolvedParameter {
+	readonly definition: ParameterDefinition;
+	readonly current: number;
+	write(value: number): Project;
+}
+
+type Resolution = ResolvedParameter | { readonly error: string };
+
+function isUnresolved(
+	resolution: Resolution,
+): resolution is { readonly error: string } {
+	return "error" in resolution;
+}
+
+/**
+ * Maps a target onto its parameter definition and the single place in the
+ * project that stores its value.
+ */
+function resolveParameter(
+	project: Project,
+	target: ParameterTarget,
+): Resolution {
+	switch (target.scope) {
+		case "song":
+			return expectParameter(
+				target.parameterId,
+				[SONG_TEMPO],
+				(definition) => ({
+					definition,
+					current: project.song.tempo,
+					write: (value) =>
+						withSong(project, { ...project.song, tempo: value }),
+				}),
+			);
+		case "master":
+			return expectParameter(
+				target.parameterId,
+				[MASTER_VOLUME],
+				(definition) => ({
+					definition,
+					current: project.song.master.volume,
+					write: (value) =>
+						withSong(project, {
+							...project.song,
+							master: { ...project.song.master, volume: value },
+						}),
+				}),
+			);
+		case "track": {
+			const track = findTrack(project, target.trackId);
+			if (!track) {
+				return { error: `Track ${target.trackId} does not exist` };
+			}
+			return expectParameter(
+				target.parameterId,
+				[TRACK_VOLUME, TRACK_PAN],
+				(definition) => ({
+					definition,
+					current:
+						definition === TRACK_VOLUME ? track.mixer.volume : track.mixer.pan,
+					write: (value) =>
+						replaceTrack(project, {
+							...track,
+							mixer: {
+								...track.mixer,
+								[definition === TRACK_VOLUME ? "volume" : "pan"]: value,
+							},
+						}),
+				}),
+			);
+		}
+		case "send": {
+			const track = findTrack(project, target.trackId);
+			if (!track) {
+				return { error: `Track ${target.trackId} does not exist` };
+			}
+			const send = track.sendConfig.find(
+				(candidate) => candidate.returnId === target.returnId,
+			);
+			if (!send) {
+				return {
+					error: `Track ${track.id} has no send to return bus ${target.returnId}`,
+				};
+			}
+			return expectParameter(
+				target.parameterId,
+				[TRACK_SEND_LEVEL],
+				(definition) => ({
+					definition,
+					current: send.level,
+					write: (value) =>
+						replaceTrack(project, {
+							...track,
+							sendConfig: track.sendConfig.map((candidate) =>
+								candidate.returnId === send.returnId
+									? { ...candidate, level: value }
+									: candidate,
+							),
+						}),
+				}),
+			);
+		}
+		case "return": {
+			const bus = project.song.returns.find(
+				(candidate) => candidate.id === target.returnId,
+			);
+			if (!bus) {
+				return { error: `Return bus ${target.returnId} does not exist` };
+			}
+			return expectParameter(
+				target.parameterId,
+				[RETURN_VOLUME, RETURN_PAN],
+				(definition) => ({
+					definition,
+					current:
+						definition === RETURN_VOLUME ? bus.mixer.volume : bus.mixer.pan,
+					write: (value) =>
+						withSong(project, {
+							...project.song,
+							returns: project.song.returns.map((candidate) =>
+								candidate.id === bus.id
+									? {
+											...candidate,
+											mixer: {
+												...candidate.mixer,
+												[definition === RETURN_VOLUME ? "volume" : "pan"]:
+													value,
+											},
+										}
+									: candidate,
+							),
+						}),
+				}),
+			);
+		}
+		case "trackDevice": {
+			const track = findTrack(project, target.trackId);
+			if (!track) {
+				return { error: `Track ${target.trackId} does not exist` };
+			}
+			const device = track.devices.find(
+				(candidate) => candidate.id === target.deviceId,
+			);
+			if (!device) {
+				return {
+					error: `Track ${track.id} has no device ${target.deviceId}`,
+				};
+			}
+			// Device parameters are namespaced by device type, matching how the
+			// domain validates a stored device parameter value.
+			const definition = getParameterDefinition(
+				`${device.type}.${target.parameterId}`,
+			);
+			if (!definition) {
+				return {
+					error: `Device ${device.type} has no registered parameter "${target.parameterId}"`,
+				};
+			}
+			return {
+				definition,
+				current:
+					device.parameters[target.parameterId] ?? definition.defaultValue,
+				write: (value) =>
+					replaceTrack(project, {
+						...track,
+						devices: track.devices.map((candidate) =>
+							candidate.id === device.id
+								? {
+										...candidate,
+										parameters: {
+											...candidate.parameters,
+											[target.parameterId]: value,
+										},
+									}
+								: candidate,
+						),
+					}),
+			};
+		}
+	}
+}
+
+/** Accepts only the parameters that this scope actually owns. */
+function expectParameter(
+	parameterId: string,
+	allowed: readonly ParameterDefinition[],
+	build: (definition: ParameterDefinition) => ResolvedParameter,
+): Resolution {
+	const definition = allowed.find((candidate) => candidate.id === parameterId);
+	if (!definition) {
+		return {
+			error: `"${parameterId}" is not a parameter of this target (expected ${allowed
+				.map((candidate) => `"${candidate.id}"`)
+				.join(" or ")})`,
+		};
+	}
+	return build(definition);
+}
+
+const UNIT_SUFFIX: Record<ParameterDefinition["unit"], string> = {
+	bpm: " BPM",
+	decibels: " dB",
+	hertz: " Hz",
+	seconds: " s",
+	semitones: " semitones",
+	normalized: "",
+	bipolar: "",
+};
+
+/** Human-readable value for a summary line, in the parameter's own unit. */
+export function formatParameterValue(
+	definition: ParameterDefinition,
+	value: number,
+): string {
+	return `${Number(value.toFixed(4))}${UNIT_SUFFIX[definition.unit]}`;
+}
+
+export const parameterSetCommand = defineCommand<ParameterSetPayload>({
+	type: "parameter.set",
+	version: 1,
+	schema: parameterSetPayloadSchema,
+	summarize(payload, project) {
+		const resolution = resolveParameter(project, payload.target);
+		if (isUnresolved(resolution)) {
+			return `Set ${payload.target.parameterId}`;
+		}
+		return `Set ${resolution.definition.label} to ${formatParameterValue(resolution.definition, payload.value)}`;
+	},
+	apply(project, payload) {
+		const resolution = resolveParameter(project, payload.target);
+		if (isUnresolved(resolution)) {
+			return rejected(resolution.error);
+		}
+		const coerced = coerceParameterValue(resolution.definition, payload.value);
+		if (!coerced.ok) {
+			return rejected(coerced.reason);
+		}
+		return applied(resolution.write(coerced.value));
+	},
+	invert(payload, before) {
+		const resolution = resolveParameter(before, payload.target);
+		return isUnresolved(resolution)
+			? []
+			: [setParameter(payload.target, resolution.current)];
+	},
+});
+
+// --- Typed builders -------------------------------------------------------
+
+export function setParameter(
+	target: ParameterTarget,
+	value: number,
+): CommandInput<ParameterSetPayload> {
+	return { type: parameterSetCommand.type, payload: { target, value } };
+}
+
+/** Registered, payload-erased commands from this module. */
+export const parameterCommands: readonly RegisteredCommand[] = [
+	eraseCommand(parameterSetCommand),
+];

--- a/src/commands/definitions/placements.ts
+++ b/src/commands/definitions/placements.ts
@@ -1,0 +1,217 @@
+import { z } from "zod";
+import { type Placement, placementSchema } from "../../domain/entities";
+import { type PlacementId, placementIdSchema } from "../../domain/ids";
+import {
+	clipLabel,
+	findPlacement,
+	replacePlacement,
+	withSong,
+} from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+
+/**
+ * Arrangement placement commands.
+ *
+ * A placement is the arrangement's reference to a clip, kept separate from the
+ * clip's content (invariant 3) so the same clip can appear many times. Moving
+ * a placement to another track is allowed only when that track already owns
+ * the clip; the integrity check enforces it, so a cross-track drag has to
+ * create a compatible clip first rather than silently re-parenting one.
+ */
+
+export const placementCreatePayloadSchema = z.strictObject({
+	placement: placementSchema,
+});
+export type PlacementCreatePayload = z.infer<
+	typeof placementCreatePayloadSchema
+>;
+
+export const placementDeletePayloadSchema = z.strictObject({
+	placementId: placementIdSchema,
+});
+export type PlacementDeletePayload = z.infer<
+	typeof placementDeletePayloadSchema
+>;
+
+export const placementChangesSchema = z
+	.strictObject({
+		trackId: placementSchema.shape.trackId.optional(),
+		startTicks: placementSchema.shape.startTicks.optional(),
+		durationTicks: placementSchema.shape.durationTicks.optional(),
+		clipOffsetTicks: placementSchema.shape.clipOffsetTicks.optional(),
+		looped: placementSchema.shape.looped.optional(),
+	})
+	.refine(
+		(changes) => Object.values(changes).some((value) => value !== undefined),
+		{ message: "An update must change at least one field" },
+	);
+export type PlacementChanges = z.infer<typeof placementChangesSchema>;
+
+export const placementUpdatePayloadSchema = z.strictObject({
+	placementId: placementIdSchema,
+	changes: placementChangesSchema,
+});
+export type PlacementUpdatePayload = z.infer<
+	typeof placementUpdatePayloadSchema
+>;
+
+export const placementCreateCommand = defineCommand<PlacementCreatePayload>({
+	type: "placement.create",
+	version: 1,
+	schema: placementCreatePayloadSchema,
+	summarize: (payload, project) =>
+		`Place ${clipLabel(project, payload.placement.clipId)} at tick ${payload.placement.startTicks}`,
+	apply(project, payload) {
+		if (findPlacement(project, payload.placement.id)) {
+			return rejected(`Placement ${payload.placement.id} already exists`);
+		}
+		return applied(
+			withSong(project, {
+				...project.song,
+				placements: [...project.song.placements, payload.placement],
+			}),
+		);
+	},
+	invert: (payload) => [removePlacement(payload.placement.id)],
+});
+
+export const placementDeleteCommand = defineCommand<PlacementDeletePayload>({
+	type: "placement.delete",
+	version: 1,
+	schema: placementDeletePayloadSchema,
+	summarize(payload, project) {
+		const placement = findPlacement(project, payload.placementId);
+		return placement
+			? `Remove ${clipLabel(project, placement.clipId)} from the arrangement`
+			: "Remove a placement from the arrangement";
+	},
+	apply(project, payload) {
+		const placement = findPlacement(project, payload.placementId);
+		if (!placement) {
+			return rejected(`Placement ${payload.placementId} does not exist`);
+		}
+		return applied(
+			withSong(project, {
+				...project.song,
+				placements: project.song.placements.filter(
+					(candidate) => candidate.id !== placement.id,
+				),
+			}),
+		);
+	},
+	invert(payload, before) {
+		const placement = findPlacement(before, payload.placementId);
+		return placement ? [addPlacement(placement)] : [];
+	},
+});
+
+export const placementUpdateCommand = defineCommand<PlacementUpdatePayload>({
+	type: "placement.update",
+	version: 1,
+	schema: placementUpdatePayloadSchema,
+	summarize(payload, project) {
+		const placement = findPlacement(project, payload.placementId);
+		const label = placement
+			? clipLabel(project, placement.clipId)
+			: "a placement";
+		if (payload.changes.startTicks !== undefined) {
+			return `Move ${label} to tick ${payload.changes.startTicks}`;
+		}
+		if (payload.changes.durationTicks !== undefined) {
+			return `Resize ${label} to ${payload.changes.durationTicks} ticks`;
+		}
+		if (payload.changes.looped !== undefined) {
+			return `${payload.changes.looped ? "Loop" : "Unloop"} ${label}`;
+		}
+		return `Edit ${label}`;
+	},
+	apply(project, payload) {
+		const placement = findPlacement(project, payload.placementId);
+		if (!placement) {
+			return rejected(`Placement ${payload.placementId} does not exist`);
+		}
+		return applied(
+			replacePlacement(project, {
+				...placement,
+				...(payload.changes.trackId !== undefined
+					? { trackId: payload.changes.trackId }
+					: {}),
+				...(payload.changes.startTicks !== undefined
+					? { startTicks: payload.changes.startTicks }
+					: {}),
+				...(payload.changes.durationTicks !== undefined
+					? { durationTicks: payload.changes.durationTicks }
+					: {}),
+				...(payload.changes.clipOffsetTicks !== undefined
+					? { clipOffsetTicks: payload.changes.clipOffsetTicks }
+					: {}),
+				...(payload.changes.looped !== undefined
+					? { looped: payload.changes.looped }
+					: {}),
+			}),
+		);
+	},
+	invert(payload, before) {
+		const placement = findPlacement(before, payload.placementId);
+		if (!placement) {
+			return [];
+		}
+		return [
+			updatePlacement(payload.placementId, {
+				...(payload.changes.trackId !== undefined
+					? { trackId: placement.trackId }
+					: {}),
+				...(payload.changes.startTicks !== undefined
+					? { startTicks: placement.startTicks }
+					: {}),
+				...(payload.changes.durationTicks !== undefined
+					? { durationTicks: placement.durationTicks }
+					: {}),
+				...(payload.changes.clipOffsetTicks !== undefined
+					? { clipOffsetTicks: placement.clipOffsetTicks }
+					: {}),
+				...(payload.changes.looped !== undefined
+					? { looped: placement.looped }
+					: {}),
+			}),
+		];
+	},
+});
+
+// --- Typed builders -------------------------------------------------------
+
+export function addPlacement(
+	placement: Placement,
+): CommandInput<PlacementCreatePayload> {
+	return { type: placementCreateCommand.type, payload: { placement } };
+}
+
+export function removePlacement(
+	placementId: PlacementId,
+): CommandInput<PlacementDeletePayload> {
+	return { type: placementDeleteCommand.type, payload: { placementId } };
+}
+
+export function updatePlacement(
+	placementId: PlacementId,
+	changes: PlacementChanges,
+): CommandInput<PlacementUpdatePayload> {
+	return {
+		type: placementUpdateCommand.type,
+		payload: { placementId, changes },
+	};
+}
+
+/** Registered, payload-erased commands from this module. */
+export const placementCommands: readonly RegisteredCommand[] = [
+	eraseCommand(placementCreateCommand),
+	eraseCommand(placementDeleteCommand),
+	eraseCommand(placementUpdateCommand),
+];

--- a/src/commands/definitions/tracks.ts
+++ b/src/commands/definitions/tracks.ts
@@ -1,0 +1,342 @@
+import { z } from "zod";
+import {
+	type AutomationLane,
+	automationLaneSchema,
+	type Clip,
+	clipSchema,
+	type Placement,
+	placementSchema,
+	type Track,
+	trackSchema,
+} from "../../domain/entities";
+import { type TrackId, trackIdSchema } from "../../domain/ids";
+import {
+	byOrder,
+	findTrack,
+	renumber,
+	replaceTrack,
+	trackLabel,
+	withClips,
+	withSong,
+} from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+
+/**
+ * Track lifecycle and mixer-flag commands.
+ *
+ * Deleting a track cascades to everything that cannot outlive it — its clips,
+ * the placements on it, and any automation lane targeting it — because leaving
+ * one behind is a dangling reference. `track.create` therefore accepts those
+ * companions, so the inverse of a delete restores the whole track in one
+ * atomic command rather than a best-effort sequence.
+ */
+
+export const trackCreatePayloadSchema = z.strictObject({
+	track: trackSchema,
+	clips: z.array(clipSchema).default([]),
+	placements: z.array(placementSchema).default([]),
+	automation: z.array(automationLaneSchema).default([]),
+});
+export type TrackCreatePayload = z.infer<typeof trackCreatePayloadSchema>;
+
+export const trackDeletePayloadSchema = z.strictObject({
+	trackId: trackIdSchema,
+});
+export type TrackDeletePayload = z.infer<typeof trackDeletePayloadSchema>;
+
+export const trackChangesSchema = z
+	.strictObject({
+		name: trackSchema.shape.name.optional(),
+		color: trackSchema.shape.color.optional(),
+	})
+	.refine(
+		(changes) => Object.values(changes).some((value) => value !== undefined),
+		{ message: "An update must change at least one field" },
+	);
+export type TrackChanges = z.infer<typeof trackChangesSchema>;
+
+export const trackUpdatePayloadSchema = z.strictObject({
+	trackId: trackIdSchema,
+	changes: trackChangesSchema,
+});
+export type TrackUpdatePayload = z.infer<typeof trackUpdatePayloadSchema>;
+
+export const trackReorderPayloadSchema = z.strictObject({
+	trackId: trackIdSchema,
+	toIndex: z.int().min(0),
+});
+export type TrackReorderPayload = z.infer<typeof trackReorderPayloadSchema>;
+
+export const trackFlagSchema = z.enum(["muted", "soloed"]);
+export type TrackFlag = z.infer<typeof trackFlagSchema>;
+
+export const trackSetFlagPayloadSchema = z.strictObject({
+	trackId: trackIdSchema,
+	flag: trackFlagSchema,
+	value: z.boolean(),
+});
+export type TrackSetFlagPayload = z.infer<typeof trackSetFlagPayloadSchema>;
+
+/** Does this automation lane point at the given track in any of its scopes? */
+function targetsTrack(lane: AutomationLane, trackId: TrackId): boolean {
+	return "trackId" in lane.target && lane.target.trackId === trackId;
+}
+
+export const trackCreateCommand = defineCommand<TrackCreatePayload>({
+	type: "track.create",
+	version: 1,
+	schema: trackCreatePayloadSchema,
+	summarize: (payload) =>
+		payload.clips.length > 0 || payload.placements.length > 0
+			? `Restore track "${payload.track.name}"`
+			: `Add track "${payload.track.name}"`,
+	apply(project, payload) {
+		if (findTrack(project, payload.track.id)) {
+			return rejected(`Track ${payload.track.id} already exists`);
+		}
+		const sorted = byOrder(project.song.tracks);
+		if (payload.track.order > sorted.length) {
+			return rejected(
+				`Cannot insert a track at position ${payload.track.order} of ${sorted.length}`,
+			);
+		}
+		const foreignClip = payload.clips.find(
+			(clip) => clip.trackId !== payload.track.id,
+		);
+		if (foreignClip) {
+			return rejected(
+				`Clip ${foreignClip.id} does not belong to track ${payload.track.id}`,
+			);
+		}
+		const tracks = renumber([
+			...sorted.slice(0, payload.track.order),
+			payload.track,
+			...sorted.slice(payload.track.order),
+		]);
+		const next = withClips(project, [...project.clips, ...payload.clips]);
+		return applied(
+			withSong(next, {
+				...next.song,
+				tracks,
+				placements: [...next.song.placements, ...payload.placements],
+				automation: [...next.song.automation, ...payload.automation],
+			}),
+		);
+	},
+	invert: (payload) => [removeTrack(payload.track.id)],
+});
+
+export const trackDeleteCommand = defineCommand<TrackDeletePayload>({
+	type: "track.delete",
+	version: 1,
+	schema: trackDeletePayloadSchema,
+	summarize: (payload, project) =>
+		`Delete track ${trackLabel(project, payload.trackId)}`,
+	apply(project, payload) {
+		const track = findTrack(project, payload.trackId);
+		if (!track) {
+			return rejected(`Track ${payload.trackId} does not exist`);
+		}
+		const next = withClips(
+			project,
+			project.clips.filter((clip) => clip.trackId !== track.id),
+		);
+		return applied(
+			withSong(next, {
+				...next.song,
+				tracks: renumber(
+					byOrder(next.song.tracks).filter(
+						(candidate) => candidate.id !== track.id,
+					),
+				),
+				placements: next.song.placements.filter(
+					(placement) => placement.trackId !== track.id,
+				),
+				automation: next.song.automation.filter(
+					(lane) => !targetsTrack(lane, track.id),
+				),
+			}),
+		);
+	},
+	invert(payload, before) {
+		const track = findTrack(before, payload.trackId);
+		if (!track) {
+			return [];
+		}
+		return [
+			addTrack(track, {
+				clips: before.clips.filter((clip) => clip.trackId === track.id),
+				placements: before.song.placements.filter(
+					(placement) => placement.trackId === track.id,
+				),
+				automation: before.song.automation.filter((lane) =>
+					targetsTrack(lane, track.id),
+				),
+			}),
+		];
+	},
+});
+
+export const trackUpdateCommand = defineCommand<TrackUpdatePayload>({
+	type: "track.update",
+	version: 1,
+	schema: trackUpdatePayloadSchema,
+	summarize(payload, project) {
+		const label = trackLabel(project, payload.trackId);
+		return payload.changes.name !== undefined
+			? `Rename track ${label} to "${payload.changes.name}"`
+			: `Recolor track ${label}`;
+	},
+	apply(project, payload) {
+		const track = findTrack(project, payload.trackId);
+		if (!track) {
+			return rejected(`Track ${payload.trackId} does not exist`);
+		}
+		return applied(
+			replaceTrack(project, {
+				...track,
+				...(payload.changes.name !== undefined
+					? { name: payload.changes.name }
+					: {}),
+				...(payload.changes.color !== undefined
+					? { color: payload.changes.color }
+					: {}),
+			}),
+		);
+	},
+	invert(payload, before) {
+		const track = findTrack(before, payload.trackId);
+		if (!track) {
+			return [];
+		}
+		return [
+			updateTrack(payload.trackId, {
+				...(payload.changes.name !== undefined ? { name: track.name } : {}),
+				...(payload.changes.color !== undefined ? { color: track.color } : {}),
+			}),
+		];
+	},
+});
+
+export const trackReorderCommand = defineCommand<TrackReorderPayload>({
+	type: "track.reorder",
+	version: 1,
+	schema: trackReorderPayloadSchema,
+	summarize: (payload, project) =>
+		`Move track ${trackLabel(project, payload.trackId)} to position ${payload.toIndex + 1}`,
+	apply(project, payload) {
+		const sorted = byOrder(project.song.tracks);
+		const from = sorted.findIndex((track) => track.id === payload.trackId);
+		if (from < 0) {
+			return rejected(`Track ${payload.trackId} does not exist`);
+		}
+		if (payload.toIndex >= sorted.length) {
+			return rejected(
+				`Cannot move a track to position ${payload.toIndex} of ${sorted.length}`,
+			);
+		}
+		const moved = sorted[from];
+		const without = sorted.filter((_, index) => index !== from);
+		const tracks = renumber([
+			...without.slice(0, payload.toIndex),
+			moved,
+			...without.slice(payload.toIndex),
+		]);
+		return applied(withSong(project, { ...project.song, tracks }));
+	},
+	invert(payload, before) {
+		const track = findTrack(before, payload.trackId);
+		return track ? [reorderTrack(payload.trackId, track.order)] : [];
+	},
+});
+
+export const trackSetFlagCommand = defineCommand<TrackSetFlagPayload>({
+	type: "track.setFlag",
+	version: 1,
+	schema: trackSetFlagPayloadSchema,
+	summarize: (payload, project) =>
+		`${payload.value ? "Enable" : "Disable"} ${payload.flag === "muted" ? "mute" : "solo"} on track ${trackLabel(project, payload.trackId)}`,
+	apply(project, payload) {
+		const track = findTrack(project, payload.trackId);
+		if (!track) {
+			return rejected(`Track ${payload.trackId} does not exist`);
+		}
+		return applied(
+			replaceTrack(project, {
+				...track,
+				mixer: { ...track.mixer, [payload.flag]: payload.value },
+			}),
+		);
+	},
+	invert(payload, before) {
+		const track = findTrack(before, payload.trackId);
+		return track
+			? [setTrackFlag(payload.trackId, payload.flag, track.mixer[payload.flag])]
+			: [];
+	},
+});
+
+// --- Typed builders -------------------------------------------------------
+
+export function addTrack(
+	track: Track,
+	restore: {
+		clips?: readonly Clip[];
+		placements?: readonly Placement[];
+		automation?: readonly AutomationLane[];
+	} = {},
+): CommandInput<TrackCreatePayload> {
+	return {
+		type: trackCreateCommand.type,
+		payload: {
+			track,
+			clips: [...(restore.clips ?? [])],
+			placements: [...(restore.placements ?? [])],
+			automation: [...(restore.automation ?? [])],
+		},
+	};
+}
+
+export function removeTrack(
+	trackId: TrackId,
+): CommandInput<TrackDeletePayload> {
+	return { type: trackDeleteCommand.type, payload: { trackId } };
+}
+
+export function updateTrack(
+	trackId: TrackId,
+	changes: TrackChanges,
+): CommandInput<TrackUpdatePayload> {
+	return { type: trackUpdateCommand.type, payload: { trackId, changes } };
+}
+
+export function reorderTrack(
+	trackId: TrackId,
+	toIndex: number,
+): CommandInput<TrackReorderPayload> {
+	return { type: trackReorderCommand.type, payload: { trackId, toIndex } };
+}
+
+export function setTrackFlag(
+	trackId: TrackId,
+	flag: TrackFlag,
+	value: boolean,
+): CommandInput<TrackSetFlagPayload> {
+	return { type: trackSetFlagCommand.type, payload: { trackId, flag, value } };
+}
+
+/** Registered, payload-erased commands from this module. */
+export const trackCommands: readonly RegisteredCommand[] = [
+	eraseCommand(trackCreateCommand),
+	eraseCommand(trackDeleteCommand),
+	eraseCommand(trackUpdateCommand),
+	eraseCommand(trackReorderCommand),
+	eraseCommand(trackSetFlagCommand),
+];

--- a/src/commands/definitions/transforms.ts
+++ b/src/commands/definitions/transforms.ts
@@ -1,0 +1,586 @@
+import { z } from "zod";
+import type { Clip, NoteEvent, Project } from "../../domain/entities";
+import {
+	type ClipId,
+	clipIdSchema,
+	type EventId,
+	eventIdSchema,
+	type IdFactory,
+} from "../../domain/ids";
+import { clampParameterValue, NOTE_VELOCITY } from "../../domain/parameters";
+import { type Ticks, toTicks } from "../../domain/time";
+import {
+	clipLabel,
+	findClip,
+	noteEventsOf,
+	pluralize,
+	replaceClip,
+	selectEvents,
+	withNoteEvents,
+} from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RawCommandInput,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+import { addNotes, type NoteChanges, removeNotes, updateNotes } from "./notes";
+
+/**
+ * Musical transformations (PRD CLP-04): transpose, velocity scaling,
+ * quantize, duplicate, clear, and deterministic rhythmic variation.
+ *
+ * Each one is available to the pointer UI, the keyboard, and the assistant
+ * through the same registered command, and each is a pure function of its
+ * payload — including `notes.vary`, whose randomness comes from a seed in the
+ * payload rather than from `Math.random`, so a proposal previews and applies
+ * identically and redo reproduces it exactly.
+ */
+
+/** `null` selects every note in the clip; a list selects exactly those notes. */
+const eventSelectionSchema = z.array(eventIdSchema).min(1).nullable();
+
+export const notesTransposePayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	eventIds: eventSelectionSchema,
+	semitones: z.int().min(-127).max(127),
+});
+export type NotesTransposePayload = z.infer<typeof notesTransposePayloadSchema>;
+
+export const notesScaleVelocityPayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	eventIds: eventSelectionSchema,
+	factor: z.number().positive().finite(),
+});
+export type NotesScaleVelocityPayload = z.infer<
+	typeof notesScaleVelocityPayloadSchema
+>;
+
+export const notesQuantizePayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	eventIds: eventSelectionSchema,
+	gridTicks: z.int().min(1),
+	/** 0 leaves notes where they are; 1 snaps them fully onto the grid. */
+	strength: z.number().min(0).max(1),
+});
+export type NotesQuantizePayload = z.infer<typeof notesQuantizePayloadSchema>;
+
+export const notesDuplicatePayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	eventIds: eventSelectionSchema,
+	offsetTicks: z.int().min(1),
+	/** One new event ID per duplicated note, minted by the caller. */
+	newIds: z.array(eventIdSchema),
+});
+export type NotesDuplicatePayload = z.infer<typeof notesDuplicatePayloadSchema>;
+
+export const notesClearPayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+});
+export type NotesClearPayload = z.infer<typeof notesClearPayloadSchema>;
+
+export const notesVaryPayloadSchema = z.strictObject({
+	clipId: clipIdSchema,
+	eventIds: eventSelectionSchema,
+	/** Same seed, same variation — this is what makes the command replayable. */
+	seed: z.string().min(1),
+	/** Share of notes the variation may touch, 0..1. */
+	amount: z.number().min(0).max(1),
+	gridTicks: z.int().min(1),
+});
+export type NotesVaryPayload = z.infer<typeof notesVaryPayloadSchema>;
+
+interface Selection {
+	clip: Clip;
+	events: NoteEvent[];
+}
+
+/**
+ * Resolves a payload's clip and selection, rejecting a clip that is missing,
+ * holds audio rather than notes, has a stale selection, or selects nothing.
+ * An empty selection is a rejection rather than a silent no-op so a
+ * transformation never records a history entry that changed nothing.
+ */
+function resolveSelection(
+	project: Project,
+	clipId: ClipId,
+	eventIds: readonly EventId[] | null,
+): Selection | { error: string } {
+	const clip = findClip(project, clipId);
+	if (!clip) {
+		return { error: `Clip ${clipId} does not exist` };
+	}
+	if (!noteEventsOf(clip)) {
+		return { error: `Clip ${clip.id} does not hold note content` };
+	}
+	const { selected, missing } = selectEvents(clip, eventIds ?? null);
+	if (missing.length > 0) {
+		return {
+			error: `Clip ${clip.id} has no note ${missing.join(", ")} to transform`,
+		};
+	}
+	if (selected.length === 0) {
+		return { error: `Clip ${clip.id} has no notes to transform` };
+	}
+	return { clip, events: selected };
+}
+
+function isError(
+	selection: Selection | { error: string },
+): selection is { error: string } {
+	return "error" in selection;
+}
+
+/** Writes changed events back into the clip, leaving untouched events identical. */
+function withChangedEvents(
+	project: Project,
+	clip: Clip,
+	changed: ReadonlyMap<string, NoteEvent>,
+): Project {
+	const events = noteEventsOf(clip) ?? [];
+	return replaceClip(
+		project,
+		withNoteEvents(
+			clip,
+			events.map((event) => changed.get(event.id) ?? event),
+		),
+	);
+}
+
+/** An inverse that restores exact previous values for the events it changed. */
+function restoreCommand(
+	project: Project,
+	clipId: ClipId,
+	eventIds: readonly EventId[] | null,
+	fields: (event: NoteEvent) => NoteChanges,
+): RawCommandInput[] {
+	const selection = resolveSelection(project, clipId, eventIds ?? null);
+	if (isError(selection)) {
+		return [];
+	}
+	const updates = selection.events.map((event) => ({
+		eventId: event.id,
+		changes: fields(event),
+	}));
+	return updates.length > 0 ? [updateNotes(clipId, updates)] : [];
+}
+
+export const notesTransposeCommand = defineCommand<NotesTransposePayload>({
+	type: "notes.transpose",
+	version: 1,
+	schema: notesTransposePayloadSchema,
+	summarize: (payload, project) =>
+		`Transpose ${clipLabel(project, payload.clipId)} by ${signed(payload.semitones)} semitones`,
+	apply(project, payload) {
+		const selection = resolveSelection(
+			project,
+			payload.clipId,
+			payload.eventIds,
+		);
+		if (isError(selection)) {
+			return rejected(selection.error);
+		}
+		const changed = new Map<string, NoteEvent>();
+		for (const event of selection.events) {
+			if (event.trigger.kind !== "pitch") {
+				continue;
+			}
+			const pitch = event.trigger.pitch + payload.semitones;
+			if (pitch < 0 || pitch > 127) {
+				return rejected(
+					`Transposing note ${event.id} by ${payload.semitones} would leave the 0-127 pitch range`,
+				);
+			}
+			changed.set(event.id, {
+				...event,
+				trigger: { kind: "pitch", pitch },
+			});
+		}
+		return applied(withChangedEvents(project, selection.clip, changed));
+	},
+	invert(payload, before) {
+		const selection = resolveSelection(
+			before,
+			payload.clipId,
+			payload.eventIds,
+		);
+		if (isError(selection)) {
+			return [];
+		}
+		// Transposition is exact (out-of-range input is rejected, never
+		// clamped), so the inverse is the opposite transposition of the same
+		// notes rather than a list of restored pitches.
+		return [
+			transposeNotes(
+				payload.clipId,
+				selection.events.map((event) => event.id),
+				-payload.semitones,
+			),
+		];
+	},
+});
+
+export const notesScaleVelocityCommand =
+	defineCommand<NotesScaleVelocityPayload>({
+		type: "notes.scaleVelocity",
+		version: 1,
+		schema: notesScaleVelocityPayloadSchema,
+		summarize: (payload, project) =>
+			`Scale velocity in ${clipLabel(project, payload.clipId)} by ${round(payload.factor)}x`,
+		apply(project, payload) {
+			const selection = resolveSelection(
+				project,
+				payload.clipId,
+				payload.eventIds,
+			);
+			if (isError(selection)) {
+				return rejected(selection.error);
+			}
+			const changed = new Map<string, NoteEvent>();
+			for (const event of selection.events) {
+				changed.set(event.id, {
+					...event,
+					velocity: clampParameterValue(
+						NOTE_VELOCITY,
+						event.velocity * payload.factor,
+					),
+				});
+			}
+			return applied(withChangedEvents(project, selection.clip, changed));
+		},
+		// Scaling clamps at the ends of the velocity range, so the inverse
+		// restores the recorded values instead of dividing by the factor.
+		invert: (payload, before) =>
+			restoreCommand(before, payload.clipId, payload.eventIds, (event) => ({
+				velocity: event.velocity,
+			})),
+	});
+
+export const notesQuantizeCommand = defineCommand<NotesQuantizePayload>({
+	type: "notes.quantize",
+	version: 1,
+	schema: notesQuantizePayloadSchema,
+	summarize: (payload, project) =>
+		`Quantize ${clipLabel(project, payload.clipId)} to ${payload.gridTicks} ticks`,
+	apply(project, payload) {
+		const selection = resolveSelection(
+			project,
+			payload.clipId,
+			payload.eventIds,
+		);
+		if (isError(selection)) {
+			return rejected(selection.error);
+		}
+		const changed = new Map<string, NoteEvent>();
+		for (const event of selection.events) {
+			const startTicks = quantizedStart(
+				event.startTicks,
+				payload.gridTicks,
+				payload.strength,
+				selection.clip.lengthTicks,
+			);
+			changed.set(event.id, { ...event, startTicks });
+		}
+		return applied(withChangedEvents(project, selection.clip, changed));
+	},
+	invert: (payload, before) =>
+		restoreCommand(before, payload.clipId, payload.eventIds, (event) => ({
+			startTicks: event.startTicks,
+		})),
+});
+
+/**
+ * Snaps toward the nearest grid line, never past the end of the clip: a note
+ * whose nearest line is the clip boundary snaps back to the previous line
+ * instead of moving outside its clip.
+ */
+function quantizedStart(
+	startTicks: number,
+	gridTicks: number,
+	strength: number,
+	lengthTicks: number,
+): Ticks {
+	let target = Math.round(startTicks / gridTicks) * gridTicks;
+	while (target >= lengthTicks && target - gridTicks >= 0) {
+		target -= gridTicks;
+	}
+	if (target >= lengthTicks) {
+		target = lengthTicks - 1;
+	}
+	return toTicks(Math.round(startTicks + (target - startTicks) * strength));
+}
+
+export const notesDuplicateCommand = defineCommand<NotesDuplicatePayload>({
+	type: "notes.duplicate",
+	version: 1,
+	schema: notesDuplicatePayloadSchema,
+	summarize: (payload, project) =>
+		`Duplicate ${pluralize(payload.newIds.length, "note")} in ${clipLabel(project, payload.clipId)}`,
+	apply(project, payload) {
+		const selection = resolveSelection(
+			project,
+			payload.clipId,
+			payload.eventIds,
+		);
+		if (isError(selection)) {
+			return rejected(selection.error);
+		}
+		if (payload.newIds.length !== selection.events.length) {
+			return rejected(
+				`Duplicating ${selection.events.length} notes needs ${selection.events.length} new ids, received ${payload.newIds.length}`,
+			);
+		}
+		const existing = new Set(
+			(noteEventsOf(selection.clip) ?? []).map((event) => event.id),
+		);
+		const copies: NoteEvent[] = [];
+		selection.events.forEach((event, index) => {
+			const id = payload.newIds[index];
+			if (existing.has(id)) {
+				return;
+			}
+			copies.push({
+				...event,
+				id,
+				startTicks: toTicks(event.startTicks + payload.offsetTicks),
+			});
+		});
+		if (copies.length !== payload.newIds.length) {
+			return rejected("Duplicate note ids must be new");
+		}
+		const outside = copies.find(
+			(copy) => copy.startTicks >= selection.clip.lengthTicks,
+		);
+		if (outside) {
+			return rejected(
+				`Duplicating by ${payload.offsetTicks} ticks would push a note past the end of clip ${selection.clip.id}`,
+			);
+		}
+		return applied(
+			replaceClip(
+				project,
+				withNoteEvents(selection.clip, [
+					...(noteEventsOf(selection.clip) ?? []),
+					...copies,
+				]),
+			),
+		);
+	},
+	invert: (payload) =>
+		payload.newIds.length > 0
+			? [removeNotes(payload.clipId, payload.newIds)]
+			: [],
+});
+
+export const notesClearCommand = defineCommand<NotesClearPayload>({
+	type: "notes.clear",
+	version: 1,
+	schema: notesClearPayloadSchema,
+	summarize: (payload, project) =>
+		`Clear notes from ${clipLabel(project, payload.clipId)}`,
+	apply(project, payload) {
+		const selection = resolveSelection(project, payload.clipId, null);
+		if (isError(selection)) {
+			return rejected(selection.error);
+		}
+		return applied(replaceClip(project, withNoteEvents(selection.clip, [])));
+	},
+	invert(payload, before) {
+		const clip = findClip(before, payload.clipId);
+		const events = clip ? (noteEventsOf(clip) ?? []) : [];
+		return events.length > 0 ? [addNotes(payload.clipId, events)] : [];
+	},
+});
+
+export const notesVaryCommand = defineCommand<NotesVaryPayload>({
+	type: "notes.vary",
+	version: 1,
+	schema: notesVaryPayloadSchema,
+	summarize: (payload, project) =>
+		`Vary ${clipLabel(project, payload.clipId)} (seed ${payload.seed})`,
+	apply(project, payload) {
+		const selection = resolveSelection(
+			project,
+			payload.clipId,
+			payload.eventIds,
+		);
+		if (isError(selection)) {
+			return rejected(selection.error);
+		}
+		const random = seededRandom(payload.seed);
+		const changed = new Map<string, NoteEvent>();
+		for (const event of selection.events) {
+			// Three draws per note regardless of the outcome, so one note's
+			// result never depends on whether an earlier note was varied.
+			const roll = random();
+			const direction = random() < 0.5 ? -1 : 1;
+			const accent = random();
+			if (roll >= payload.amount) {
+				continue;
+			}
+			const startTicks = shiftedStart(
+				event.startTicks,
+				direction * payload.gridTicks,
+				selection.clip.lengthTicks,
+			);
+			const velocity = clampParameterValue(
+				NOTE_VELOCITY,
+				event.velocity * (0.7 + accent * 0.6),
+			);
+			if (startTicks === event.startTicks && velocity === event.velocity) {
+				continue;
+			}
+			changed.set(event.id, { ...event, startTicks, velocity });
+		}
+		return applied(withChangedEvents(project, selection.clip, changed));
+	},
+	invert: (payload, before) =>
+		restoreCommand(before, payload.clipId, payload.eventIds, (event) => ({
+			startTicks: event.startTicks,
+			velocity: event.velocity,
+		})),
+});
+
+/** Shifts a note, reflecting off either end of the clip rather than leaving it. */
+function shiftedStart(
+	startTicks: number,
+	delta: number,
+	lengthTicks: number,
+): Ticks {
+	const forward = startTicks + delta;
+	if (forward >= 0 && forward < lengthTicks) {
+		return toTicks(forward);
+	}
+	const back = startTicks - delta;
+	if (back >= 0 && back < lengthTicks) {
+		return toTicks(back);
+	}
+	return toTicks(startTicks);
+}
+
+/**
+ * Mulberry32 seeded from the payload's seed string. Deterministic across
+ * engines and processes, which is what makes `notes.vary` replayable.
+ */
+function seededRandom(seed: string): () => number {
+	let state = hashSeed(seed);
+	return () => {
+		state = (state + 0x6d2b79f5) | 0;
+		let value = Math.imul(state ^ (state >>> 15), 1 | state);
+		value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value;
+		return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function hashSeed(seed: string): number {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < seed.length; index += 1) {
+		hash ^= seed.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	return hash === 0 ? 0x9e3779b9 : hash;
+}
+
+function signed(value: number): string {
+	return value >= 0 ? `+${value}` : `${value}`;
+}
+
+function round(value: number): string {
+	return `${Number(value.toFixed(3))}`;
+}
+
+// --- Typed builders -------------------------------------------------------
+
+export function transposeNotes(
+	clipId: ClipId,
+	eventIds: readonly EventId[] | null,
+	semitones: number,
+): CommandInput<NotesTransposePayload> {
+	return {
+		type: notesTransposeCommand.type,
+		payload: { clipId, eventIds: selectionOf(eventIds), semitones },
+	};
+}
+
+export function scaleNoteVelocity(
+	clipId: ClipId,
+	eventIds: readonly EventId[] | null,
+	factor: number,
+): CommandInput<NotesScaleVelocityPayload> {
+	return {
+		type: notesScaleVelocityCommand.type,
+		payload: { clipId, eventIds: selectionOf(eventIds), factor },
+	};
+}
+
+export function quantizeNotes(
+	clipId: ClipId,
+	eventIds: readonly EventId[] | null,
+	gridTicks: number,
+	strength = 1,
+): CommandInput<NotesQuantizePayload> {
+	return {
+		type: notesQuantizeCommand.type,
+		payload: { clipId, eventIds: selectionOf(eventIds), gridTicks, strength },
+	};
+}
+
+export function clearNotes(clipId: ClipId): CommandInput<NotesClearPayload> {
+	return { type: notesClearCommand.type, payload: { clipId } };
+}
+
+export function varyNotes(
+	clipId: ClipId,
+	eventIds: readonly EventId[] | null,
+	options: { seed: string; amount: number; gridTicks: number },
+): CommandInput<NotesVaryPayload> {
+	return {
+		type: notesVaryCommand.type,
+		payload: { clipId, eventIds: selectionOf(eventIds), ...options },
+	};
+}
+
+/**
+ * Builds a duplicate command, minting one event ID per selected note. The IDs
+ * live in the payload, so undo/redo and an assistant preview all reproduce the
+ * same events.
+ */
+export function duplicateNotes(
+	ids: IdFactory,
+	project: Project,
+	options: {
+		clipId: ClipId;
+		eventIds?: readonly EventId[] | null;
+		offsetTicks: number;
+	},
+): CommandInput<NotesDuplicatePayload> {
+	const eventIds = options.eventIds ?? null;
+	const selection = resolveSelection(project, options.clipId, eventIds);
+	const count = isError(selection) ? 0 : selection.events.length;
+	return {
+		type: notesDuplicateCommand.type,
+		payload: {
+			clipId: options.clipId,
+			eventIds: selectionOf(eventIds),
+			offsetTicks: options.offsetTicks,
+			newIds: Array.from({ length: count }, () => ids("event")),
+		},
+	};
+}
+
+function selectionOf(eventIds: readonly EventId[] | null): EventId[] | null {
+	return eventIds === null ? null : [...eventIds];
+}
+
+/** Registered, payload-erased commands from this module. */
+export const transformCommands: readonly RegisteredCommand[] = [
+	eraseCommand(notesTransposeCommand),
+	eraseCommand(notesScaleVelocityCommand),
+	eraseCommand(notesQuantizeCommand),
+	eraseCommand(notesDuplicateCommand),
+	eraseCommand(notesClearCommand),
+	eraseCommand(notesVaryCommand),
+];

--- a/src/commands/definitions/transforms.ts
+++ b/src/commands/definitions/transforms.ts
@@ -8,7 +8,7 @@ import {
 	type IdFactory,
 } from "../../domain/ids";
 import { clampParameterValue, NOTE_VELOCITY } from "../../domain/parameters";
-import { type Ticks, toTicks } from "../../domain/time";
+import { isTicks, type Ticks, toTicks } from "../../domain/time";
 import {
 	clipLabel,
 	findClip,
@@ -337,27 +337,25 @@ export const notesDuplicateCommand = defineCommand<NotesDuplicatePayload>({
 			(noteEventsOf(selection.clip) ?? []).map((event) => event.id),
 		);
 		const copies: NoteEvent[] = [];
-		selection.events.forEach((event, index) => {
+		for (const [index, event] of selection.events.entries()) {
 			const id = payload.newIds[index];
 			if (existing.has(id)) {
-				return;
+				continue;
 			}
-			copies.push({
-				...event,
-				id,
-				startTicks: toTicks(event.startTicks + payload.offsetTicks),
-			});
-		});
+			// The offset is only bounded below by the schema, so the copy's
+			// position is range-checked before it becomes a tick: an offset that
+			// leaves the safe-integer range is a rejection with a reason, not a
+			// throw out of `toTicks`.
+			const startTicks = event.startTicks + payload.offsetTicks;
+			if (!isTicks(startTicks) || startTicks >= selection.clip.lengthTicks) {
+				return rejected(
+					`Duplicating by ${payload.offsetTicks} ticks would push a note past the end of clip ${selection.clip.id}`,
+				);
+			}
+			copies.push({ ...event, id, startTicks });
+		}
 		if (copies.length !== payload.newIds.length) {
 			return rejected("Duplicate note ids must be new");
-		}
-		const outside = copies.find(
-			(copy) => copy.startTicks >= selection.clip.lengthTicks,
-		);
-		if (outside) {
-			return rejected(
-				`Duplicating by ${payload.offsetTicks} ticks would push a note past the end of clip ${selection.clip.id}`,
-			);
 		}
 		return applied(
 			replaceClip(

--- a/src/commands/execute.test.ts
+++ b/src/commands/execute.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH, toTicks } from "../domain";
 import { createManualClock } from "../shared/clock";
 import { updateNote, updateTrack } from ".";
 import { executeCommand, executeTransaction } from "./execute";
 import { findClip, findTrack, noteEventsOf } from "./projectEdits";
+import { requireCommand } from "./registry";
 import {
 	ABSENT_IDS,
 	type CommandTestProject,
@@ -145,6 +146,37 @@ describe("command execution", () => {
 		});
 		expect(result.project).toBe(fixture.project);
 	});
+
+	// A command that throws would otherwise escape the kernel, so a caller that
+	// correctly handles `result.ok === false` would still crash. Every phase a
+	// definition contributes — transition, summary, inverse — is covered.
+	it.each(["apply", "summarize", "invert"] as const)(
+		"turns a command that throws in %s into a rejection",
+		(phase) => {
+			const definition = requireCommand("track.update");
+			const spy = vi.spyOn(definition, phase).mockImplementation(() => {
+				throw new Error("kaboom");
+			});
+			try {
+				const result = executeCommand(
+					fixture.project,
+					updateTrack(fixture.trackAId, { name: "Sub bass" }),
+				);
+
+				expect(result.ok).toBe(false);
+				if (result.ok) return;
+				expect(result.issues[0]).toMatchObject({
+					code: "rejected",
+					commandType: "track.update",
+					commandIndex: 0,
+				});
+				expect(result.issues[0].message).toMatch(/kaboom/);
+				expect(result.project).toBe(fixture.project);
+			} finally {
+				spy.mockRestore();
+			}
+		},
+	);
 
 	it("refuses an unregistered command type", () => {
 		const result = executeCommand(fixture.project, {

--- a/src/commands/execute.test.ts
+++ b/src/commands/execute.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH, toTicks } from "../domain";
+import { createManualClock } from "../shared/clock";
+import { updateNote, updateTrack } from ".";
+import { executeCommand, executeTransaction } from "./execute";
+import { findClip, findTrack, noteEventsOf } from "./projectEdits";
+import {
+	ABSENT_IDS,
+	type CommandTestProject,
+	contentSignature,
+	createCommandTestProject,
+} from "./testProjects";
+
+describe("command execution", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	it("produces one new revision and a fresh modified time", () => {
+		const clock = createManualClock(1_700_000_500_000);
+		const result = executeCommand(
+			fixture.project,
+			updateTrack(fixture.trackAId, { name: "Sub bass" }),
+			{ clock },
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.revision).toBe(fixture.project.metadata.revision + 1);
+		expect(result.project.metadata.revision).toBe(1);
+		expect(result.project.metadata.modifiedAt).toBe(1_700_000_500_000);
+		expect(findTrack(result.project, fixture.trackAId)?.name).toBe("Sub bass");
+	});
+
+	it("never mutates the project it was given", () => {
+		const before = contentSignature(fixture.project);
+		const result = executeCommand(
+			fixture.project,
+			updateTrack(fixture.trackAId, { name: "Sub bass" }),
+		);
+
+		expect(result.ok).toBe(true);
+		expect(contentSignature(fixture.project)).toBe(before);
+		expect(findTrack(fixture.project, fixture.trackAId)?.name).toBe("Bass");
+	});
+
+	it("reuses every object it did not change", () => {
+		const result = executeCommand(
+			fixture.project,
+			updateNote(fixture.clipAId, fixture.eventIds[0], { velocity: 0.9 }),
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		// A note edit must not look like a topology change to the audio engine.
+		expect(result.project.song.tracks).toBe(fixture.project.song.tracks);
+		expect(result.project.song.placements).toBe(
+			fixture.project.song.placements,
+		);
+		expect(findClip(result.project, fixture.clipBId)).toBe(
+			findClip(fixture.project, fixture.clipBId),
+		);
+		expect(findClip(result.project, fixture.clipAId)).not.toBe(
+			findClip(fixture.project, fixture.clipAId),
+		);
+	});
+
+	it("carries actor, correlation ID, version, and base revision on each envelope", () => {
+		const result = executeCommand(
+			fixture.project,
+			updateTrack(fixture.trackAId, { name: "Assistant pick" }),
+			{ actor: "assistant", correlationId: "cor_test" },
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.commands).toHaveLength(1);
+		expect(result.commands[0]).toMatchObject({
+			type: "track.update",
+			version: 1,
+			actor: "assistant",
+			correlationId: "cor_test",
+			baseRevision: 0,
+		});
+		expect(result.actor).toBe("assistant");
+	});
+
+	it("generates a correlation ID when the caller does not supply one", () => {
+		const result = executeCommand(
+			fixture.project,
+			updateTrack(fixture.trackAId, { name: "Auto" }),
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.correlationId).toMatch(/^cor_[\w-]{21}$/);
+	});
+
+	it("applies a multi-command transaction atomically", () => {
+		const result = executeTransaction(fixture.project, [
+			updateTrack(fixture.trackAId, { name: "One" }),
+			updateTrack(fixture.trackBId, { name: "Two" }),
+		]);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(findTrack(result.project, fixture.trackAId)?.name).toBe("One");
+		expect(findTrack(result.project, fixture.trackBId)?.name).toBe("Two");
+		// Two commands, still one revision.
+		expect(result.project.metadata.revision).toBe(1);
+		expect(result.summary).toContain("+1 more change");
+	});
+
+	it("rolls the whole transaction back when a later command fails", () => {
+		const before = contentSignature(fixture.project);
+		const result = executeTransaction(fixture.project, [
+			updateTrack(fixture.trackAId, { name: "Applied first" }),
+			{
+				type: "track.update",
+				payload: { trackId: "trk_missing", changes: {} },
+			},
+		]);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.project).toBe(fixture.project);
+		expect(contentSignature(result.project)).toBe(before);
+		expect(result.issues[0].commandIndex).toBe(1);
+		expect(result.issues[0].code).toBe("invalid_payload");
+	});
+
+	it("reports a rejected precondition without changing anything", () => {
+		const result = executeTransaction(fixture.project, [
+			updateTrack(fixture.trackAId, { name: "Applied first" }),
+			updateTrack(ABSENT_IDS.track, { name: "Nope" }),
+		]);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0]).toMatchObject({
+			code: "rejected",
+			commandType: "track.update",
+			commandIndex: 1,
+		});
+		expect(result.project).toBe(fixture.project);
+	});
+
+	it("refuses an unregistered command type", () => {
+		const result = executeCommand(fixture.project, {
+			type: "note.explode",
+			payload: {},
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0].code).toBe("unknown_command");
+	});
+
+	it("refuses a command built for a different version", () => {
+		const result = executeCommand(fixture.project, {
+			...updateTrack(fixture.trackAId, { name: "From the future" }),
+			version: 2,
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0].code).toBe("unsupported_command_version");
+	});
+
+	it("refuses an empty transaction", () => {
+		const result = executeTransaction(fixture.project, []);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0].message).toMatch(/at least one command/);
+	});
+
+	it("refuses a command built against a stale revision", () => {
+		const first = executeCommand(
+			fixture.project,
+			updateTrack(fixture.trackAId, { name: "First" }),
+		);
+		expect(first.ok).toBe(true);
+		if (!first.ok) return;
+
+		const stale = executeCommand(
+			first.project,
+			updateTrack(fixture.trackAId, { name: "Stale" }),
+			{ baseRevision: 0 },
+		);
+		expect(stale.ok).toBe(false);
+		if (stale.ok) return;
+		expect(stale.issues[0].code).toBe("revision_conflict");
+		expect(stale.project).toBe(first.project);
+	});
+
+	it("accepts a command whose base revision still matches", () => {
+		const result = executeCommand(
+			fixture.project,
+			updateTrack(fixture.trackAId, { name: "Fresh" }),
+			{ baseRevision: 0 },
+		);
+		expect(result.ok).toBe(true);
+	});
+
+	it("refuses a transition that would break a domain invariant", () => {
+		const result = executeCommand(
+			fixture.project,
+			updateNote(fixture.clipAId, fixture.eventIds[0], {
+				startTicks: toTicks(TICKS_PER_BAR * 4),
+			}),
+		);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0].code).toBe("invalid_project");
+		expect(result.issues[0].domainIssues?.[0].code).toBe(
+			"invalid_musical_time",
+		);
+		expect(result.project).toBe(fixture.project);
+	});
+
+	it("can apply without committing a revision, for gesture steps", () => {
+		const result = executeCommand(
+			fixture.project,
+			updateNote(fixture.clipAId, fixture.eventIds[0], {
+				startTicks: toTicks(TICKS_PER_SIXTEENTH),
+			}),
+			{ commitRevision: false },
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.project.metadata.revision).toBe(0);
+		expect(result.project.metadata.modifiedAt).toBe(
+			fixture.project.metadata.modifiedAt,
+		);
+		const clip = findClip(result.project, fixture.clipAId);
+		expect(clip && noteEventsOf(clip)?.[0].startTicks).toBe(
+			TICKS_PER_SIXTEENTH,
+		);
+	});
+
+	it("never lets modifiedAt fall behind createdAt", () => {
+		const result = executeCommand(
+			fixture.project,
+			updateTrack(fixture.trackAId, { name: "Backdated" }),
+			{ clock: createManualClock(0) },
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.project.metadata.modifiedAt).toBe(
+			fixture.project.metadata.createdAt,
+		);
+	});
+});

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -9,6 +9,7 @@ import type {
 	CommandIssue,
 	CommandIssueCode,
 	RawCommandInput,
+	RegisteredCommand,
 } from "./types";
 
 /**
@@ -19,6 +20,8 @@ import type {
  * then does it become the new project. Any failure at any step returns the
  * original project object untouched — "leaves the project valid or makes no
  * change" (invariant 6) is enforced here rather than trusted to each command.
+ * Failure is always a returned `CommandIssue`: a command that throws is caught
+ * and reported, so no caller of the kernel has to guard against exceptions.
  *
  * Exactly one revision is produced per committed transaction, so a revision
  * number, a history entry, and an autosave write all mean the same thing.
@@ -90,6 +93,49 @@ function fail(
 		project,
 		issues: [{ code, commandType, commandIndex, message, domainIssues }],
 	};
+}
+
+interface CommandStep {
+	readonly project: Project;
+	readonly summary: string;
+	readonly inverse: readonly RawCommandInput[];
+}
+
+function describeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Runs one command's transition, summary, and inverse.
+ *
+ * A command that throws instead of rejecting is caught here. The kernel's
+ * contract is that a command either produces the next project or reports an
+ * issue, so a payload that passes a command's schema but drives its arithmetic
+ * out of range — or an outright bug in a definition — becomes a `rejected`
+ * issue rather than an exception escaping into the caller. That matters most
+ * for assistant-generated and remotely replayed commands, whose payloads are
+ * not built by the editor UI.
+ */
+function runCommand(
+	definition: RegisteredCommand,
+	project: Project,
+	payload: unknown,
+): CommandStep | { readonly error: string } {
+	try {
+		const result = definition.apply(project, payload);
+		if (!result.ok) {
+			return { error: result.message };
+		}
+		return {
+			project: result.project,
+			summary: definition.summarize(payload, project),
+			inverse: definition.invert(payload, project, result.project),
+		};
+	} catch (error) {
+		return {
+			error: `Command "${definition.type}" failed: ${describeError(error)}`,
+		};
+	}
 }
 
 /** Applies one command as a single-command transaction. */
@@ -172,16 +218,14 @@ export function executeTransaction(
 				parsed.message,
 			);
 		}
-		const result = definition.apply(working, parsed.payload);
-		if (!result.ok) {
-			return fail(project, "rejected", input.type, index, result.message);
+		const step = runCommand(definition, working, parsed.payload);
+		if ("error" in step) {
+			return fail(project, "rejected", input.type, index, step.error);
 		}
-		summaries.push(definition.summarize(parsed.payload, working));
+		summaries.push(step.summary);
 		// Inverses run newest-first, and each command's inverse is generated
 		// against the state it saw, not the final state.
-		inverse.unshift(
-			...definition.invert(parsed.payload, working, result.project),
-		);
+		inverse.unshift(...step.inverse);
 		envelopes.push({
 			type: definition.type,
 			version: definition.version,
@@ -190,7 +234,7 @@ export function executeTransaction(
 			correlationId,
 			baseRevision,
 		});
-		working = result.project;
+		working = step.project;
 	}
 
 	const clock = options.clock ?? systemClock;

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -1,0 +1,245 @@
+import { nanoid } from "nanoid";
+import type { Project } from "../domain/entities";
+import { checkProjectIntegrity } from "../domain/parse";
+import { type Clock, systemClock } from "../shared/clock";
+import { findCommand } from "./registry";
+import type {
+	CommandActor,
+	CommandEnvelope,
+	CommandIssue,
+	CommandIssueCode,
+	RawCommandInput,
+} from "./types";
+
+/**
+ * Command and transaction execution.
+ *
+ * A transaction is the atomic unit: its commands are applied in order to a
+ * working copy, the result is checked against every domain invariant, and only
+ * then does it become the new project. Any failure at any step returns the
+ * original project object untouched — "leaves the project valid or makes no
+ * change" (invariant 6) is enforced here rather than trusted to each command.
+ *
+ * Exactly one revision is produced per committed transaction, so a revision
+ * number, a history entry, and an autosave write all mean the same thing.
+ */
+
+export interface TransactionOptions {
+	/** Who asked for the change. Defaults to `user`. */
+	readonly actor?: CommandActor;
+	/** Groups the commands of one request; generated when omitted. */
+	readonly correlationId?: string;
+	/**
+	 * Refuses the transaction unless the project is still at this revision.
+	 * Used for commands built earlier, remotely, or by the assistant.
+	 */
+	readonly baseRevision?: number;
+	/** Overrides the summary derived from the commands. */
+	readonly summary?: string;
+	readonly clock?: Clock;
+	/**
+	 * When false the project's revision and `modifiedAt` are left alone. A
+	 * gesture uses this for its intermediate steps and commits one revision
+	 * when it ends.
+	 */
+	readonly commitRevision?: boolean;
+}
+
+export interface TransactionSuccess {
+	readonly ok: true;
+	readonly project: Project;
+	readonly commands: readonly CommandEnvelope[];
+	/** Commands that undo this transaction, already in reverse order. */
+	readonly inverse: readonly RawCommandInput[];
+	readonly summary: string;
+	readonly actor: CommandActor;
+	readonly correlationId: string;
+	readonly baseRevision: number;
+	readonly revision: number;
+	readonly timestamp: number;
+}
+
+export interface TransactionFailure {
+	readonly ok: false;
+	/** The original project, unchanged and referentially identical. */
+	readonly project: Project;
+	readonly issues: readonly CommandIssue[];
+}
+
+export type TransactionResult = TransactionSuccess | TransactionFailure;
+
+/**
+ * Correlation IDs group the commands of one user action, request, or
+ * assistant proposal. They are not entity IDs — nothing persists or resolves
+ * them — so they use their own `cor_` prefix outside the domain ID table.
+ */
+export function createCorrelationId(prefix = "cor"): string {
+	return `${prefix}_${nanoid(21)}`;
+}
+
+function fail(
+	project: Project,
+	code: CommandIssueCode,
+	commandType: string,
+	commandIndex: number,
+	message: string,
+	domainIssues?: CommandIssue["domainIssues"],
+): TransactionFailure {
+	return {
+		ok: false,
+		project,
+		issues: [{ code, commandType, commandIndex, message, domainIssues }],
+	};
+}
+
+/** Applies one command as a single-command transaction. */
+export function executeCommand(
+	project: Project,
+	command: RawCommandInput,
+	options: TransactionOptions = {},
+): TransactionResult {
+	return executeTransaction(project, [command], options);
+}
+
+/**
+ * Applies a list of commands atomically. Either every command applies and the
+ * result is a valid project, or nothing changes.
+ */
+export function executeTransaction(
+	project: Project,
+	commands: readonly RawCommandInput[],
+	options: TransactionOptions = {},
+): TransactionResult {
+	const actor = options.actor ?? "user";
+	const correlationId = options.correlationId ?? createCorrelationId();
+	const baseRevision = project.metadata.revision;
+
+	if (commands.length === 0) {
+		return fail(
+			project,
+			"rejected",
+			"(transaction)",
+			0,
+			"A transaction needs at least one command",
+		);
+	}
+	if (
+		options.baseRevision !== undefined &&
+		options.baseRevision !== baseRevision
+	) {
+		return fail(
+			project,
+			"revision_conflict",
+			commands[0].type,
+			0,
+			`Command was built against revision ${options.baseRevision}, but the project is at revision ${baseRevision}`,
+		);
+	}
+
+	const envelopes: CommandEnvelope[] = [];
+	const inverse: RawCommandInput[] = [];
+	const summaries: string[] = [];
+	let working = project;
+
+	for (let index = 0; index < commands.length; index += 1) {
+		const input = commands[index];
+		const definition = findCommand(input.type);
+		if (!definition) {
+			return fail(
+				project,
+				"unknown_command",
+				input.type,
+				index,
+				`No command is registered as "${input.type}"`,
+			);
+		}
+		if (input.version !== undefined && input.version !== definition.version) {
+			return fail(
+				project,
+				"unsupported_command_version",
+				input.type,
+				index,
+				`This build implements "${input.type}" version ${definition.version}, received version ${input.version}`,
+			);
+		}
+		const parsed = definition.parsePayload(input.payload);
+		if (!parsed.ok) {
+			return fail(
+				project,
+				"invalid_payload",
+				input.type,
+				index,
+				parsed.message,
+			);
+		}
+		const result = definition.apply(working, parsed.payload);
+		if (!result.ok) {
+			return fail(project, "rejected", input.type, index, result.message);
+		}
+		summaries.push(definition.summarize(parsed.payload, working));
+		// Inverses run newest-first, and each command's inverse is generated
+		// against the state it saw, not the final state.
+		inverse.unshift(
+			...definition.invert(parsed.payload, working, result.project),
+		);
+		envelopes.push({
+			type: definition.type,
+			version: definition.version,
+			payload: parsed.payload,
+			actor,
+			correlationId,
+			baseRevision,
+		});
+		working = result.project;
+	}
+
+	const clock = options.clock ?? systemClock;
+	const timestamp = clock.now();
+	const commitRevision = options.commitRevision !== false;
+	const committed = commitRevision
+		? {
+				...working,
+				metadata: {
+					...working.metadata,
+					revision: baseRevision + 1,
+					// A clock set behind the project's creation time must not
+					// produce metadata that fails its own invariant.
+					modifiedAt: Math.max(timestamp, working.metadata.createdAt),
+				},
+			}
+		: working;
+
+	const domainIssues = checkProjectIntegrity(committed);
+	if (domainIssues.length > 0) {
+		return fail(
+			project,
+			"invalid_project",
+			envelopes[envelopes.length - 1].type,
+			envelopes.length - 1,
+			`The change would leave the project invalid: ${domainIssues[0].message}`,
+			domainIssues,
+		);
+	}
+
+	return {
+		ok: true,
+		project: committed,
+		commands: envelopes,
+		inverse,
+		summary: options.summary ?? summarize(summaries),
+		actor,
+		correlationId,
+		baseRevision,
+		revision: committed.metadata.revision,
+		timestamp,
+	};
+}
+
+function summarize(summaries: readonly string[]): string {
+	if (summaries.length === 1) {
+		return summaries[0];
+	}
+	return `${summaries[0]} (+${summaries.length - 1} more ${
+		summaries.length === 2 ? "change" : "changes"
+	})`;
+}

--- a/src/commands/history.test.ts
+++ b/src/commands/history.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createBlankProject,
+	createSeededIdFactory,
+	type Project,
+	TRACK_VOLUME,
+} from "../domain";
+import { createManualClock } from "../shared/clock";
+import { setParameter, updateTrack } from ".";
+import {
+	type CommandHistory,
+	createCommandHistory,
+	DEFAULT_HISTORY_LIMIT,
+} from "./history";
+import { findTrack } from "./projectEdits";
+import {
+	ABSENT_IDS,
+	type CommandTestProject,
+	contentSignature,
+	createCommandTestProject,
+} from "./testProjects";
+
+function volumeOf(project: Project, trackId: CommandTestProject["trackAId"]) {
+	return findTrack(project, trackId)?.mixer.volume;
+}
+
+describe("CommandHistory", () => {
+	let fixture: CommandTestProject;
+	let history: CommandHistory;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+		history = createCommandHistory(fixture.project, {
+			clock: createManualClock(1_700_000_600_000),
+		});
+	});
+
+	it("starts empty", () => {
+		expect(history.canUndo).toBe(false);
+		expect(history.canRedo).toBe(false);
+		expect(history.undoSummary).toBeNull();
+		expect(history.undo()).toBeNull();
+		expect(history.redo()).toBeNull();
+		expect(history.project).toBe(fixture.project);
+	});
+
+	it("records one entry per command with a readable summary", () => {
+		history.execute(updateTrack(fixture.trackAId, { name: "Sub" }));
+
+		expect(history.entries).toHaveLength(1);
+		expect(history.undoSummary).toBe('Rename track "Bass" to "Sub"');
+		expect(history.canUndo).toBe(true);
+		expect(findTrack(history.project, fixture.trackAId)?.name).toBe("Sub");
+	});
+
+	it("undoes and redoes without rewinding the revision counter", () => {
+		const before = contentSignature(fixture.project);
+		history.execute(updateTrack(fixture.trackAId, { name: "Sub" }));
+		expect(history.project.metadata.revision).toBe(1);
+
+		history.undo();
+		expect(contentSignature(history.project)).toBe(before);
+		// Undo is a new state to persist, not a rollback of the revision.
+		expect(history.project.metadata.revision).toBe(2);
+		expect(history.canUndo).toBe(false);
+		expect(history.canRedo).toBe(true);
+		expect(history.redoSummary).toBe('Rename track "Bass" to "Sub"');
+
+		history.redo();
+		expect(findTrack(history.project, fixture.trackAId)?.name).toBe("Sub");
+		expect(history.project.metadata.revision).toBe(3);
+		expect(history.canRedo).toBe(false);
+	});
+
+	it("drops the redo branch as soon as a new command is executed", () => {
+		history.execute(updateTrack(fixture.trackAId, { name: "One" }));
+		history.undo();
+		expect(history.canRedo).toBe(true);
+
+		history.execute(updateTrack(fixture.trackAId, { name: "Two" }));
+		expect(history.canRedo).toBe(false);
+		expect(history.entries).toHaveLength(1);
+	});
+
+	it("keeps history bounded", () => {
+		const bounded = createCommandHistory(fixture.project, { limit: 3 });
+		for (const name of ["a", "b", "c", "d", "e"]) {
+			bounded.execute(updateTrack(fixture.trackAId, { name }));
+		}
+		expect(bounded.entries).toHaveLength(3);
+		expect(bounded.entries[0].summary).toContain('"c"');
+		expect(bounded.limit).toBe(3);
+		expect(DEFAULT_HISTORY_LIMIT).toBeGreaterThan(3);
+	});
+
+	it("keeps the project unchanged when a command is refused", () => {
+		const result = history.execute(
+			updateTrack(ABSENT_IDS.track, { name: "Nope" }),
+		);
+		expect(result.ok).toBe(false);
+		expect(history.entries).toHaveLength(0);
+		expect(history.project).toBe(fixture.project);
+	});
+
+	it("records a multi-command transaction as one entry", () => {
+		history.execute(
+			[
+				updateTrack(fixture.trackAId, { name: "One" }),
+				updateTrack(fixture.trackBId, { name: "Two" }),
+			],
+			{ summary: "Rename both tracks" },
+		);
+
+		expect(history.entries).toHaveLength(1);
+		expect(history.undoSummary).toBe("Rename both tracks");
+
+		history.undo();
+		expect(findTrack(history.project, fixture.trackAId)?.name).toBe("Bass");
+		expect(findTrack(history.project, fixture.trackBId)?.name).toBe("Drums");
+	});
+
+	describe("gestures", () => {
+		const volumeTarget = (trackId: CommandTestProject["trackAId"]) =>
+			({
+				scope: "track",
+				trackId,
+				parameterId: TRACK_VOLUME.id,
+			}) as const;
+
+		it("collapses a continuous drag into one entry and one revision", () => {
+			const gesture = history.beginGesture({ summary: "Set track volume" });
+			for (const value of [-1, -2, -3, -4]) {
+				gesture.apply(setParameter(volumeTarget(fixture.trackAId), value));
+			}
+			expect(history.project.metadata.revision).toBe(0);
+			expect(volumeOf(history.project, fixture.trackAId)).toBe(-4);
+
+			const entry = gesture.commit();
+			expect(entry?.summary).toBe("Set track volume");
+			expect(entry?.commands).toHaveLength(4);
+			expect(history.entries).toHaveLength(1);
+			expect(history.project.metadata.revision).toBe(1);
+
+			history.undo();
+			expect(volumeOf(history.project, fixture.trackAId)).toBe(0);
+		});
+
+		it("redoes a committed gesture in one step", () => {
+			const gesture = history.beginGesture();
+			gesture.apply(setParameter(volumeTarget(fixture.trackAId), -5));
+			gesture.apply(setParameter(volumeTarget(fixture.trackAId), -9));
+			gesture.commit();
+
+			history.undo();
+			expect(volumeOf(history.project, fixture.trackAId)).toBe(0);
+			history.redo();
+			expect(volumeOf(history.project, fixture.trackAId)).toBe(-9);
+		});
+
+		it("restores the starting state when a gesture is cancelled", () => {
+			const before = contentSignature(fixture.project);
+			const gesture = history.beginGesture();
+			gesture.apply(setParameter(volumeTarget(fixture.trackAId), -12));
+			expect(volumeOf(history.project, fixture.trackAId)).toBe(-12);
+
+			gesture.cancel();
+			expect(contentSignature(history.project)).toBe(before);
+			expect(history.project).toBe(fixture.project);
+			expect(history.entries).toHaveLength(0);
+			expect(gesture.active).toBe(false);
+		});
+
+		it("records nothing for a gesture that applied nothing", () => {
+			const gesture = history.beginGesture();
+			expect(gesture.commit()).toBeNull();
+			expect(history.entries).toHaveLength(0);
+			expect(history.gestureActive).toBe(false);
+		});
+
+		it("keeps a failed step out of the gesture", () => {
+			const gesture = history.beginGesture();
+			gesture.apply(setParameter(volumeTarget(fixture.trackAId), -3));
+			const failed = gesture.apply(
+				setParameter(volumeTarget(ABSENT_IDS.track), -3),
+			);
+			expect(failed.ok).toBe(false);
+
+			const entry = gesture.commit();
+			expect(entry?.commands).toHaveLength(1);
+			expect(volumeOf(history.project, fixture.trackAId)).toBe(-3);
+		});
+
+		it("routes commands issued mid-gesture into the same entry", () => {
+			const gesture = history.beginGesture({ summary: "Drag" });
+			gesture.apply(setParameter(volumeTarget(fixture.trackAId), -3));
+			history.execute(updateTrack(fixture.trackAId, { name: "Mid-drag" }));
+			gesture.commit();
+
+			expect(history.entries).toHaveLength(1);
+			expect(history.entries[0].commands).toHaveLength(2);
+		});
+
+		it("refuses to nest gestures or undo inside one", () => {
+			const gesture = history.beginGesture();
+			expect(() => history.beginGesture()).toThrow(/already in progress/);
+			expect(() => history.undo()).toThrow(/while a gesture/);
+			expect(() => history.redo()).toThrow(/while a gesture/);
+			gesture.cancel();
+		});
+
+		it("refuses to reuse a finished gesture", () => {
+			const gesture = history.beginGesture();
+			gesture.apply(setParameter(volumeTarget(fixture.trackAId), -3));
+			gesture.commit();
+			expect(() =>
+				gesture.apply(setParameter(volumeTarget(fixture.trackAId), -4)),
+			).toThrow(/already finished/);
+			expect(() => gesture.commit()).toThrow(/already finished/);
+		});
+	});
+
+	describe("project replacement", () => {
+		it("resets history deliberately", () => {
+			history.execute(updateTrack(fixture.trackAId, { name: "Sub" }));
+			history.undo();
+			expect(history.canRedo).toBe(true);
+
+			const other = createBlankProject({
+				ownerId: "user_other",
+				ids: createSeededIdFactory("other"),
+				now: 1_700_000_000_000,
+			});
+			history.replaceProject(other);
+
+			expect(history.project).toBe(other);
+			expect(history.canUndo).toBe(false);
+			expect(history.canRedo).toBe(false);
+			expect(history.entries).toHaveLength(0);
+		});
+
+		it("clears history without touching the project", () => {
+			history.execute(updateTrack(fixture.trackAId, { name: "Sub" }));
+			const current = history.project;
+			history.clear();
+			expect(history.project).toBe(current);
+			expect(history.canUndo).toBe(false);
+		});
+	});
+
+	describe("subscriptions", () => {
+		it("notifies subscribers with a snapshot and stops on unsubscribe", () => {
+			const listener = vi.fn();
+			const unsubscribe = history.subscribe(listener);
+
+			history.execute(updateTrack(fixture.trackAId, { name: "Sub" }));
+			expect(listener).toHaveBeenCalledTimes(1);
+			expect(listener.mock.calls[0][0]).toMatchObject({
+				canUndo: true,
+				canRedo: false,
+				undoDepth: 1,
+				gestureActive: false,
+			});
+
+			unsubscribe();
+			history.execute(updateTrack(fixture.trackAId, { name: "Again" }));
+			expect(listener).toHaveBeenCalledTimes(1);
+		});
+
+		it("releases every subscriber on dispose", () => {
+			const listener = vi.fn();
+			history.subscribe(listener);
+			history.dispose();
+			history.execute(updateTrack(fixture.trackAId, { name: "Sub" }));
+			expect(listener).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,0 +1,435 @@
+import { nanoid } from "nanoid";
+import type { Project } from "../domain/entities";
+import { type Clock, systemClock } from "../shared/clock";
+import {
+	createCorrelationId,
+	executeTransaction,
+	type TransactionOptions,
+	type TransactionResult,
+} from "./execute";
+import type { CommandActor, CommandEnvelope, RawCommandInput } from "./types";
+
+/**
+ * Local undo/redo history (PRD section 8, "Undo and redo").
+ *
+ * Session-scoped and bounded: history holds commands and their generated
+ * inverses, never project snapshots, so undoing is replaying an inverse rather
+ * than restoring a copy. It is deliberately independent of persistence — a
+ * Firestore acknowledgement or a remote echo must not push, drop, or rewrite
+ * an entry, and only an explicit `replaceProject` (opening a different project
+ * or reloading this one) clears it. Durable, named history is `PRJ-05` in
+ * Phase 1 and does not change this contract.
+ *
+ * One history entry always equals one revision: a single command, a
+ * multi-command transaction, and a continuous gesture each produce exactly one
+ * of each.
+ */
+
+export interface HistoryEntry {
+	readonly id: string;
+	/** One line, shown next to Undo/Redo and used in assistant proposal diffs. */
+	readonly summary: string;
+	readonly actor: CommandActor;
+	readonly correlationId: string;
+	readonly commands: readonly CommandEnvelope[];
+	readonly inverse: readonly RawCommandInput[];
+	readonly baseRevision: number;
+	readonly revision: number;
+	readonly timestamp: number;
+}
+
+export interface HistorySnapshot {
+	readonly project: Project;
+	readonly canUndo: boolean;
+	readonly canRedo: boolean;
+	readonly undoSummary: string | null;
+	readonly redoSummary: string | null;
+	readonly undoDepth: number;
+	readonly redoDepth: number;
+	/** True while a continuous gesture is open and not yet committed. */
+	readonly gestureActive: boolean;
+}
+
+/**
+ * Entries kept per session. Undo depth is a memory budget, not a product
+ * promise: entries hold commands, so the cost is proportional to what was
+ * edited rather than to project size.
+ */
+export const DEFAULT_HISTORY_LIMIT = 100;
+
+export interface CommandHistoryOptions {
+	readonly limit?: number;
+	readonly clock?: Clock;
+}
+
+export interface GestureOptions {
+	/** Summary for the single entry the gesture produces. */
+	readonly summary?: string;
+	readonly actor?: CommandActor;
+	readonly correlationId?: string;
+}
+
+/**
+ * A continuous gesture — a fader drag, a note drag, a paint stroke. Every step
+ * applies immediately so the UI and audio engine stay live, but the whole
+ * gesture lands as one history entry and one revision when it commits.
+ */
+export interface Gesture {
+	readonly active: boolean;
+	apply(
+		commands: RawCommandInput | readonly RawCommandInput[],
+	): TransactionResult;
+	/** Records the gesture as one entry. Returns null when nothing applied. */
+	commit(summary?: string): HistoryEntry | null;
+	/** Abandons the gesture and restores the project as it was when it began. */
+	cancel(): void;
+}
+
+interface GestureState {
+	readonly startProject: Project;
+	readonly startRevision: number;
+	readonly actor: CommandActor;
+	readonly correlationId: string;
+	readonly summary?: string;
+	readonly commands: CommandEnvelope[];
+	readonly inverse: RawCommandInput[];
+	readonly summaries: string[];
+}
+
+export type HistoryListener = (snapshot: HistorySnapshot) => void;
+
+export class CommandHistory {
+	#project: Project;
+	#undo: HistoryEntry[] = [];
+	#redo: HistoryEntry[] = [];
+	#gesture: GestureState | null = null;
+	readonly #limit: number;
+	readonly #clock: Clock;
+	readonly #listeners = new Set<HistoryListener>();
+
+	constructor(project: Project, options: CommandHistoryOptions = {}) {
+		this.#project = project;
+		this.#limit = Math.max(1, options.limit ?? DEFAULT_HISTORY_LIMIT);
+		this.#clock = options.clock ?? systemClock;
+	}
+
+	get project(): Project {
+		return this.#project;
+	}
+
+	get canUndo(): boolean {
+		return this.#undo.length > 0;
+	}
+
+	get canRedo(): boolean {
+		return this.#redo.length > 0;
+	}
+
+	get undoSummary(): string | null {
+		return this.#undo[this.#undo.length - 1]?.summary ?? null;
+	}
+
+	get redoSummary(): string | null {
+		return this.#redo[this.#redo.length - 1]?.summary ?? null;
+	}
+
+	/** Oldest entry first. */
+	get entries(): readonly HistoryEntry[] {
+		return this.#undo;
+	}
+
+	get redoEntries(): readonly HistoryEntry[] {
+		return this.#redo;
+	}
+
+	get limit(): number {
+		return this.#limit;
+	}
+
+	get gestureActive(): boolean {
+		return this.#gesture !== null;
+	}
+
+	snapshot(): HistorySnapshot {
+		return {
+			project: this.#project,
+			canUndo: this.canUndo,
+			canRedo: this.canRedo,
+			undoSummary: this.undoSummary,
+			redoSummary: this.redoSummary,
+			undoDepth: this.#undo.length,
+			redoDepth: this.#redo.length,
+			gestureActive: this.gestureActive,
+		};
+	}
+
+	/** Framework-free change notification; a Solid store subscribes to this. */
+	subscribe(listener: HistoryListener): () => void {
+		this.#listeners.add(listener);
+		return () => {
+			this.#listeners.delete(listener);
+		};
+	}
+
+	/**
+	 * Applies one command or an atomic multi-command transaction and records a
+	 * single history entry. While a gesture is open the commands join that
+	 * gesture instead, so a shortcut fired mid-drag cannot split the drag into
+	 * two entries.
+	 */
+	execute(
+		commands: RawCommandInput | readonly RawCommandInput[],
+		options: TransactionOptions = {},
+	): TransactionResult {
+		const list = toList(commands);
+		if (this.#gesture) {
+			return this.#applyToGesture(list, options);
+		}
+		const result = executeTransaction(this.#project, list, {
+			clock: this.#clock,
+			...options,
+		});
+		if (!result.ok) {
+			return result;
+		}
+		this.#project = result.project;
+		this.#push({
+			id: createEntryId(),
+			summary: result.summary,
+			actor: result.actor,
+			correlationId: result.correlationId,
+			commands: result.commands,
+			inverse: result.inverse,
+			baseRevision: result.baseRevision,
+			revision: result.revision,
+			timestamp: result.timestamp,
+		});
+		this.#notify();
+		return result;
+	}
+
+	beginGesture(options: GestureOptions = {}): Gesture {
+		if (this.#gesture) {
+			throw new Error(
+				"A gesture is already in progress; commit or cancel it first",
+			);
+		}
+		const state: GestureState = {
+			startProject: this.#project,
+			startRevision: this.#project.metadata.revision,
+			actor: options.actor ?? "user",
+			correlationId: options.correlationId ?? createCorrelationId(),
+			summary: options.summary,
+			commands: [],
+			inverse: [],
+			summaries: [],
+		};
+		this.#gesture = state;
+		this.#notify();
+
+		const history = this;
+		return {
+			get active() {
+				return history.#gesture === state;
+			},
+			apply(commands) {
+				if (history.#gesture !== state) {
+					throw new Error("This gesture has already finished");
+				}
+				return history.#applyToGesture(toList(commands));
+			},
+			commit(summary) {
+				if (history.#gesture !== state) {
+					throw new Error("This gesture has already finished");
+				}
+				return history.#commitGesture(state, summary);
+			},
+			cancel() {
+				if (history.#gesture !== state) {
+					return;
+				}
+				history.#gesture = null;
+				history.#project = state.startProject;
+				history.#notify();
+			},
+		};
+	}
+
+	/** Undoes the newest entry. Returns null when there is nothing to undo. */
+	undo(): TransactionResult | null {
+		if (this.#gesture) {
+			throw new Error("Cannot undo while a gesture is in progress");
+		}
+		const entry = this.#undo[this.#undo.length - 1];
+		if (!entry) {
+			return null;
+		}
+		const result = executeTransaction(this.#project, entry.inverse, {
+			actor: entry.actor,
+			correlationId: entry.correlationId,
+			summary: `Undo ${entry.summary}`,
+			clock: this.#clock,
+		});
+		if (!result.ok) {
+			return result;
+		}
+		this.#undo.pop();
+		this.#redo.push(entry);
+		this.#project = result.project;
+		this.#notify();
+		return result;
+	}
+
+	/** Redoes the newest undone entry. Returns null when there is nothing to redo. */
+	redo(): TransactionResult | null {
+		if (this.#gesture) {
+			throw new Error("Cannot redo while a gesture is in progress");
+		}
+		const entry = this.#redo[this.#redo.length - 1];
+		if (!entry) {
+			return null;
+		}
+		const result = executeTransaction(
+			this.#project,
+			entry.commands.map((command) => ({
+				type: command.type,
+				version: command.version,
+				payload: command.payload,
+			})),
+			{
+				actor: entry.actor,
+				correlationId: entry.correlationId,
+				summary: entry.summary,
+				clock: this.#clock,
+			},
+		);
+		if (!result.ok) {
+			return result;
+		}
+		this.#redo.pop();
+		this.#undo.push(entry);
+		this.#project = result.project;
+		this.#notify();
+		return result;
+	}
+
+	/**
+	 * Installs a different project and drops the history. This is the only way
+	 * history is discarded, and it is deliberate: opening another project or
+	 * reloading this one. A save acknowledgement or a remote echo must never
+	 * call it, or an undo would silently stop working.
+	 */
+	replaceProject(project: Project): void {
+		this.#gesture = null;
+		this.#project = project;
+		this.#undo = [];
+		this.#redo = [];
+		this.#notify();
+	}
+
+	/** Drops undo/redo without touching the project. */
+	clear(): void {
+		this.#undo = [];
+		this.#redo = [];
+		this.#notify();
+	}
+
+	/** Releases every subscriber. Call from the owning component's cleanup. */
+	dispose(): void {
+		this.#listeners.clear();
+	}
+
+	#applyToGesture(
+		commands: readonly RawCommandInput[],
+		options: TransactionOptions = {},
+	): TransactionResult {
+		const gesture = this.#gesture;
+		if (!gesture) {
+			throw new Error("No gesture is in progress");
+		}
+		const result = executeTransaction(this.#project, commands, {
+			...options,
+			actor: gesture.actor,
+			correlationId: gesture.correlationId,
+			clock: this.#clock,
+			// The gesture commits one revision when it ends, so its steps do
+			// not each bump the revision the way a standalone command does.
+			commitRevision: false,
+		});
+		if (!result.ok) {
+			return result;
+		}
+		gesture.commands.push(...result.commands);
+		gesture.inverse.unshift(...result.inverse);
+		gesture.summaries.push(result.summary);
+		this.#project = result.project;
+		this.#notify();
+		return result;
+	}
+
+	#commitGesture(state: GestureState, summary?: string): HistoryEntry | null {
+		this.#gesture = null;
+		if (state.commands.length === 0) {
+			this.#notify();
+			return null;
+		}
+		const timestamp = this.#clock.now();
+		this.#project = {
+			...this.#project,
+			metadata: {
+				...this.#project.metadata,
+				revision: state.startRevision + 1,
+				modifiedAt: Math.max(timestamp, this.#project.metadata.createdAt),
+			},
+		};
+		const entry: HistoryEntry = {
+			id: createEntryId(),
+			summary: summary ?? state.summary ?? state.summaries[0] ?? "Edit project",
+			actor: state.actor,
+			correlationId: state.correlationId,
+			commands: state.commands,
+			inverse: state.inverse,
+			baseRevision: state.startRevision,
+			revision: this.#project.metadata.revision,
+			timestamp,
+		};
+		this.#push(entry);
+		this.#notify();
+		return entry;
+	}
+
+	#push(entry: HistoryEntry): void {
+		this.#undo.push(entry);
+		// A new edit invalidates the redo branch: history is linear.
+		this.#redo = [];
+		while (this.#undo.length > this.#limit) {
+			this.#undo.shift();
+		}
+	}
+
+	#notify(): void {
+		const snapshot = this.snapshot();
+		for (const listener of this.#listeners) {
+			listener(snapshot);
+		}
+	}
+}
+
+export function createCommandHistory(
+	project: Project,
+	options: CommandHistoryOptions = {},
+): CommandHistory {
+	return new CommandHistory(project, options);
+}
+
+function createEntryId(): string {
+	return `hst_${nanoid(21)}`;
+}
+
+function toList(
+	commands: RawCommandInput | readonly RawCommandInput[],
+): readonly RawCommandInput[] {
+	return Array.isArray(commands)
+		? (commands as readonly RawCommandInput[])
+		: [commands as RawCommandInput];
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,26 @@
+/**
+ * The shared command layer (PRD section 9.6).
+ *
+ * Every project mutation — pointer, keyboard, or assistant — goes through a
+ * registered command here. Components never write to project state directly:
+ * they build a typed command, hand it to `CommandHistory`, and read the new
+ * project back. That gives validation, atomic transactions, one history entry
+ * per gesture, deterministic undo/redo, and a human-readable summary of every
+ * change in one place instead of once per feature.
+ *
+ * Nothing in this directory imports Firebase, Tone, or Solid: the kernel is a
+ * pure function of domain state, and the editor, the audio engine, the
+ * repository, and the assistant all sit outside it.
+ */
+
+export * from "./definitions/clips";
+export * from "./definitions/notes";
+export * from "./definitions/parameters";
+export * from "./definitions/placements";
+export * from "./definitions/tracks";
+export * from "./definitions/transforms";
+export * from "./execute";
+export * from "./history";
+export * from "./projectEdits";
+export * from "./registry";
+export * from "./types";

--- a/src/commands/inverse.test.ts
+++ b/src/commands/inverse.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import {
+	bars,
+	createNoteClip,
+	createNoteEvent,
+	createPlacement,
+	createSeededIdFactory,
+	createTrack as createTrackEntity,
+	TICKS_PER_BAR,
+	TICKS_PER_SIXTEENTH,
+	TRACK_VOLUME,
+	toTicks,
+} from "../domain";
+import {
+	addClip,
+	addNotes,
+	addPlacement,
+	addTrack,
+	clearNotes,
+	duplicateNotes,
+	quantizeNotes,
+	removeClip,
+	removeNotes,
+	removePlacement,
+	removeTrack,
+	reorderTrack,
+	scaleNoteVelocity,
+	setParameter,
+	setTrackFlag,
+	transposeNotes,
+	updateClip,
+	updateNote,
+	updatePlacement,
+	updateTrack,
+	varyNotes,
+} from ".";
+import { executeCommand } from "./execute";
+import { createCommandHistory } from "./history";
+import { COMMAND_TYPES } from "./registry";
+import {
+	type CommandTestProject,
+	contentSignature,
+	createCommandTestProject,
+	createTestFactoryContext,
+} from "./testProjects";
+import type { RawCommandInput } from "./types";
+
+/**
+ * Undo is only as good as the generated inverses, so every registered command
+ * is round-tripped here: apply it, undo it, and require the musical content to
+ * be byte-identical to where it started, then redo it and require the same
+ * result as the first application.
+ *
+ * The case list is checked against the registry, so a new command cannot be
+ * added without an inverse test.
+ */
+
+interface InverseCase {
+	readonly type: string;
+	build(fixture: CommandTestProject): RawCommandInput;
+}
+
+const cases: InverseCase[] = [
+	{
+		type: "note.add",
+		build: (fixture) =>
+			addNotes(fixture.clipAId, [
+				createNoteEvent(createTestFactoryContext("inverse-note"), {
+					startTicks: TICKS_PER_SIXTEENTH,
+					durationTicks: TICKS_PER_SIXTEENTH,
+					pitch: 60,
+				}),
+			]),
+	},
+	{
+		type: "note.remove",
+		build: (fixture) =>
+			removeNotes(fixture.clipAId, [fixture.eventIds[0], fixture.eventIds[2]]),
+	},
+	{
+		type: "note.update",
+		build: (fixture) =>
+			updateNote(fixture.clipAId, fixture.eventIds[1], {
+				startTicks: toTicks(TICKS_PER_SIXTEENTH),
+				velocity: 0.9,
+				probability: 0.4,
+			}),
+	},
+	{
+		type: "notes.transpose",
+		build: (fixture) => transposeNotes(fixture.clipAId, null, 7),
+	},
+	{
+		type: "notes.scaleVelocity",
+		// A factor big enough to clamp, so the inverse cannot cheat by dividing.
+		build: (fixture) => scaleNoteVelocity(fixture.clipAId, null, 8),
+	},
+	{
+		type: "notes.quantize",
+		build: (fixture) => quantizeNotes(fixture.clipAId, null, 100, 1),
+	},
+	{
+		type: "notes.duplicate",
+		build: (fixture) =>
+			duplicateNotes(createSeededIdFactory("inverse-dup"), fixture.project, {
+				clipId: fixture.clipAId,
+				offsetTicks: TICKS_PER_SIXTEENTH,
+			}),
+	},
+	{
+		type: "notes.clear",
+		build: (fixture) => clearNotes(fixture.clipAId),
+	},
+	{
+		type: "notes.vary",
+		build: (fixture) =>
+			varyNotes(fixture.clipAId, null, {
+				seed: "inverse",
+				amount: 1,
+				gridTicks: 24,
+			}),
+	},
+	{
+		type: "clip.create",
+		build: (fixture) =>
+			addClip(
+				createNoteClip(createTestFactoryContext("inverse-clip"), {
+					trackId: fixture.trackAId,
+					name: "Extra",
+				}),
+			),
+	},
+	{
+		type: "clip.delete",
+		build: (fixture) => removeClip(fixture.clipAId),
+	},
+	{
+		type: "clip.update",
+		build: (fixture) =>
+			updateClip(fixture.clipAId, {
+				name: "Renamed",
+				lengthTicks: toTicks(TICKS_PER_BAR * 2),
+			}),
+	},
+	{
+		type: "track.create",
+		build: () =>
+			addTrack(
+				createTrackEntity(createTestFactoryContext("inverse-track"), {
+					name: "Extra",
+					order: 1,
+				}),
+			),
+	},
+	{
+		type: "track.delete",
+		build: (fixture) => removeTrack(fixture.trackAId),
+	},
+	{
+		type: "track.update",
+		build: (fixture) => updateTrack(fixture.trackBId, { name: "Percussion" }),
+	},
+	{
+		type: "track.reorder",
+		build: (fixture) => reorderTrack(fixture.trackAId, 1),
+	},
+	{
+		type: "track.setFlag",
+		build: (fixture) => setTrackFlag(fixture.trackAId, "muted", true),
+	},
+	{
+		type: "placement.create",
+		build: (fixture) =>
+			addPlacement(
+				createPlacement(createTestFactoryContext("inverse-placement"), {
+					clipId: fixture.clipAId,
+					trackId: fixture.trackAId,
+					startTicks: bars(4),
+					durationTicks: bars(1),
+				}),
+			),
+	},
+	{
+		type: "placement.delete",
+		build: (fixture) => removePlacement(fixture.placementAId),
+	},
+	{
+		type: "placement.update",
+		build: (fixture) =>
+			updatePlacement(fixture.placementAId, {
+				startTicks: bars(2),
+				looped: true,
+			}),
+	},
+	{
+		type: "parameter.set",
+		build: (fixture) =>
+			setParameter(
+				{
+					scope: "track",
+					trackId: fixture.trackAId,
+					parameterId: TRACK_VOLUME.id,
+				},
+				-11,
+			),
+	},
+];
+
+describe("generated inverses", () => {
+	it("covers every registered command", () => {
+		expect(cases.map((entry) => entry.type).sort()).toEqual(
+			[...COMMAND_TYPES].sort(),
+		);
+	});
+
+	for (const testCase of cases) {
+		it(`${testCase.type} undoes and redoes exactly`, () => {
+			const fixture = createCommandTestProject();
+			const history = createCommandHistory(fixture.project);
+			const command = testCase.build(fixture);
+			expect(command.type).toBe(testCase.type);
+
+			const before = contentSignature(fixture.project);
+			const result = history.execute(command);
+			expect(result.ok, result.ok ? "" : result.issues[0].message).toBe(true);
+
+			const after = contentSignature(history.project);
+			expect(after).not.toBe(before);
+
+			const undone = history.undo();
+			expect(undone?.ok).toBe(true);
+			expect(contentSignature(history.project)).toBe(before);
+
+			const redone = history.redo();
+			expect(redone?.ok).toBe(true);
+			expect(contentSignature(history.project)).toBe(after);
+		});
+
+		it(`${testCase.type} is deterministic`, () => {
+			// The same payload on the same project must produce the same project,
+			// or an assistant preview, a redo, and a peer would each land
+			// somewhere different.
+			const fixture = createCommandTestProject();
+			const command = testCase.build(fixture);
+			const first = executeCommand(fixture.project, command);
+			const second = executeCommand(fixture.project, command);
+
+			expect(first.ok && second.ok).toBe(true);
+			if (!first.ok || !second.ok) return;
+			expect(contentSignature(second.project)).toBe(
+				contentSignature(first.project),
+			);
+			expect(second.summary).toBe(first.summary);
+		});
+	}
+});

--- a/src/commands/notes.test.ts
+++ b/src/commands/notes.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	createDrumMachineFixtureProject,
+	createNoteEvent,
+	type NoteEvent,
+	type Project,
+	TICKS_PER_SIXTEENTH,
+	toTicks,
+} from "../domain";
+import { addNotes, removeNotes, updateNote, updateNotes } from ".";
+import { executeCommand } from "./execute";
+import { findClip, noteEventsOf } from "./projectEdits";
+import {
+	ABSENT_IDS,
+	type CommandTestProject,
+	createCommandTestProject,
+	createTestFactoryContext,
+} from "./testProjects";
+
+function eventsOf(project: Project, clipId: CommandTestProject["clipAId"]) {
+	const clip = findClip(project, clipId);
+	return clip ? (noteEventsOf(clip) ?? []) : [];
+}
+
+describe("note commands", () => {
+	let fixture: CommandTestProject;
+	let note: NoteEvent;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+		note = createNoteEvent(createTestFactoryContext("new-note"), {
+			startTicks: 2 * TICKS_PER_SIXTEENTH,
+			durationTicks: TICKS_PER_SIXTEENTH,
+			pitch: 48,
+			velocity: 0.7,
+		});
+	});
+
+	describe("note.add", () => {
+		it("adds a note to a note clip", () => {
+			const result = executeCommand(
+				fixture.project,
+				addNotes(fixture.clipAId, [note]),
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			const events = eventsOf(result.project, fixture.clipAId);
+			expect(events).toHaveLength(5);
+			expect(events.find((event) => event.id === note.id)).toMatchObject({
+				velocity: 0.7,
+				trigger: { kind: "pitch", pitch: 48 },
+			});
+			expect(result.summary).toBe('Add 1 note to "Bassline"');
+		});
+
+		it("summarizes a multi-note add in plural", () => {
+			const other = createNoteEvent(createTestFactoryContext("second-note"), {
+				startTicks: 3 * TICKS_PER_SIXTEENTH,
+				durationTicks: TICKS_PER_SIXTEENTH,
+			});
+			const result = executeCommand(
+				fixture.project,
+				addNotes(fixture.clipAId, [note, other]),
+			);
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.summary).toBe('Add 2 notes to "Bassline"');
+		});
+
+		it("rejects a well-formed but unknown clip ID", () => {
+			const result = executeCommand(
+				fixture.project,
+				addNotes(ABSENT_IDS.clip, [note]),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0]).toMatchObject({
+				code: "rejected",
+				commandType: "note.add",
+			});
+		});
+
+		it("rejects a note whose ID is already in the clip", () => {
+			const existing = eventsOf(fixture.project, fixture.clipAId)[0];
+			const result = executeCommand(
+				fixture.project,
+				addNotes(fixture.clipAId, [{ ...note, id: existing.id }]),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/already exists/);
+		});
+
+		it("rejects a note that starts outside its clip", () => {
+			const result = executeCommand(
+				fixture.project,
+				addNotes(fixture.clipAId, [{ ...note, startTicks: toTicks(10_000) }]),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("invalid_project");
+		});
+
+		it("rejects an audio-loop clip", () => {
+			const audioProject = createDrumMachineFixtureProject();
+			const loopClip = audioProject.clips.find(
+				(clip) => clip.content.kind === "audioLoop",
+			);
+			expect(loopClip).toBeDefined();
+			if (!loopClip) return;
+			const result = executeCommand(
+				audioProject,
+				addNotes(loopClip.id, [note]),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/does not hold note content/);
+		});
+
+		it("rejects an empty note list at the schema", () => {
+			const result = executeCommand(
+				fixture.project,
+				addNotes(fixture.clipAId, []),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("invalid_payload");
+		});
+	});
+
+	describe("note.remove", () => {
+		it("removes the listed notes and leaves the rest", () => {
+			const [first, second] = fixture.eventIds;
+			const result = executeCommand(
+				fixture.project,
+				removeNotes(fixture.clipAId, [first, second]),
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			const remaining = eventsOf(result.project, fixture.clipAId).map(
+				(event) => event.id,
+			);
+			expect(remaining).toEqual(fixture.eventIds.slice(2));
+			expect(result.summary).toBe('Delete 2 notes from "Bassline"');
+		});
+
+		it("rejects a stale selection rather than deleting fewer notes", () => {
+			const result = executeCommand(
+				fixture.project,
+				removeNotes(fixture.clipAId, [fixture.eventIds[0], ABSENT_IDS.event]),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/has no note/);
+			expect(eventsOf(fixture.project, fixture.clipAId)).toHaveLength(4);
+		});
+	});
+
+	describe("note.update", () => {
+		it("changes only the fields it was given", () => {
+			const target = fixture.eventIds[1];
+			const before = eventsOf(fixture.project, fixture.clipAId)[1];
+			const result = executeCommand(
+				fixture.project,
+				updateNote(fixture.clipAId, target, { velocity: 0.95 }),
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			const after = eventsOf(result.project, fixture.clipAId)[1];
+			expect(after.velocity).toBe(0.95);
+			expect(after.startTicks).toBe(before.startTicks);
+			expect(after.durationTicks).toBe(before.durationTicks);
+			expect(after.trigger).toEqual(before.trigger);
+		});
+
+		it("moves several notes in one command", () => {
+			const result = executeCommand(
+				fixture.project,
+				updateNotes(fixture.clipAId, [
+					{ eventId: fixture.eventIds[0], changes: { velocity: 0.1 } },
+					{ eventId: fixture.eventIds[1], changes: { velocity: 0.2 } },
+				]),
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			const velocities = eventsOf(result.project, fixture.clipAId).map(
+				(event) => event.velocity,
+			);
+			expect(velocities.slice(0, 2)).toEqual([0.1, 0.2]);
+			expect(result.summary).toBe('Edit 2 notes in "Bassline"');
+		});
+
+		it("clears a probability with an explicit null", () => {
+			const withProbability = executeCommand(
+				fixture.project,
+				updateNote(fixture.clipAId, fixture.eventIds[0], { probability: 0.5 }),
+			);
+			expect(withProbability.ok).toBe(true);
+			if (!withProbability.ok) return;
+			expect(
+				eventsOf(withProbability.project, fixture.clipAId)[0].probability,
+			).toBe(0.5);
+
+			const cleared = executeCommand(
+				withProbability.project,
+				updateNote(fixture.clipAId, fixture.eventIds[0], {
+					probability: null,
+				}),
+			);
+			expect(cleared.ok).toBe(true);
+			if (!cleared.ok) return;
+			expect(eventsOf(cleared.project, fixture.clipAId)[0].probability).toBe(
+				null,
+			);
+		});
+
+		it("rejects an update with no fields", () => {
+			const result = executeCommand(
+				fixture.project,
+				updateNote(fixture.clipAId, fixture.eventIds[0], {}),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("invalid_payload");
+		});
+
+		it("rejects a note that is not in the clip", () => {
+			const result = executeCommand(
+				fixture.project,
+				updateNote(fixture.clipAId, ABSENT_IDS.event, { velocity: 0.5 }),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("rejected");
+		});
+
+		it("rejects a velocity outside the shared parameter range", () => {
+			const result = executeCommand(
+				fixture.project,
+				updateNote(fixture.clipAId, fixture.eventIds[0], { velocity: 4 }),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("invalid_payload");
+		});
+	});
+});

--- a/src/commands/parameters.test.ts
+++ b/src/commands/parameters.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	MASTER_VOLUME,
+	type Project,
+	RETURN_VOLUME,
+	registerParameter,
+	SONG_TEMPO,
+	TRACK_PAN,
+	TRACK_SEND_LEVEL,
+	TRACK_VOLUME,
+} from "../domain";
+import { setParameter } from ".";
+import { executeCommand } from "./execute";
+import { findTrack } from "./projectEdits";
+import {
+	ABSENT_IDS,
+	type CommandTestProject,
+	createCommandTestProject,
+	TEST_DEVICE_PARAMETER,
+	TEST_DEVICE_TYPE,
+} from "./testProjects";
+
+// Phase 1 authors real device parameters; this stands in for one so the
+// generic command can be tested against a registered device definition.
+const DEVICE_TIME = registerParameter({
+	id: `${TEST_DEVICE_TYPE}.${TEST_DEVICE_PARAMETER}`,
+	label: "Delay time",
+	unit: "seconds",
+	min: 0,
+	max: 2,
+	defaultValue: 0.25,
+	automatable: true,
+});
+
+function apply(
+	project: Project,
+	command: Parameters<typeof executeCommand>[1],
+): Project {
+	const result = executeCommand(project, command);
+	if (!result.ok) {
+		throw new Error(`Expected success: ${result.issues[0].message}`);
+	}
+	return result.project;
+}
+
+describe("parameter.set", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	it("sets the song tempo", () => {
+		const next = apply(
+			fixture.project,
+			setParameter({ scope: "song", parameterId: SONG_TEMPO.id }, 128),
+		);
+		expect(next.song.tempo).toBe(128);
+	});
+
+	it("sets track volume and pan", () => {
+		const volume = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "track",
+					trackId: fixture.trackAId,
+					parameterId: TRACK_VOLUME.id,
+				},
+				-6,
+			),
+		);
+		expect(findTrack(volume, fixture.trackAId)?.mixer.volume).toBe(-6);
+
+		const panned = apply(
+			volume,
+			setParameter(
+				{
+					scope: "track",
+					trackId: fixture.trackAId,
+					parameterId: TRACK_PAN.id,
+				},
+				-0.5,
+			),
+		);
+		expect(findTrack(panned, fixture.trackAId)?.mixer.pan).toBe(-0.5);
+		expect(findTrack(panned, fixture.trackAId)?.mixer.volume).toBe(-6);
+	});
+
+	it("sets a send level", () => {
+		const next = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "send",
+					trackId: fixture.trackAId,
+					returnId: fixture.returnId,
+					parameterId: TRACK_SEND_LEVEL.id,
+				},
+				0.8,
+			),
+		);
+		expect(findTrack(next, fixture.trackAId)?.sendConfig[0].level).toBe(0.8);
+	});
+
+	it("sets a return bus and master volume", () => {
+		const next = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "return",
+					returnId: fixture.returnId,
+					parameterId: RETURN_VOLUME.id,
+				},
+				-3,
+			),
+		);
+		expect(next.song.returns[0].mixer.volume).toBe(-3);
+
+		const mastered = apply(
+			next,
+			setParameter({ scope: "master", parameterId: MASTER_VOLUME.id }, -1),
+		);
+		expect(mastered.song.master.volume).toBe(-1);
+	});
+
+	it("sets a registered device parameter", () => {
+		const next = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "trackDevice",
+					trackId: fixture.trackAId,
+					deviceId: fixture.deviceId,
+					parameterId: TEST_DEVICE_PARAMETER,
+				},
+				1.5,
+			),
+		);
+		expect(
+			findTrack(next, fixture.trackAId)?.devices[0].parameters[
+				TEST_DEVICE_PARAMETER
+			],
+		).toBe(1.5);
+		expect(DEVICE_TIME.max).toBe(2);
+	});
+
+	it("clamps to the definition's range instead of storing an illegal value", () => {
+		const next = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "track",
+					trackId: fixture.trackAId,
+					parameterId: TRACK_VOLUME.id,
+				},
+				999,
+			),
+		);
+		expect(findTrack(next, fixture.trackAId)?.mixer.volume).toBe(
+			TRACK_VOLUME.max,
+		);
+	});
+
+	it("rejects a non-finite value", () => {
+		const result = executeCommand(
+			fixture.project,
+			setParameter({ scope: "song", parameterId: SONG_TEMPO.id }, Number.NaN),
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0].code).toBe("invalid_payload");
+	});
+
+	it("rejects a parameter that does not belong to the target", () => {
+		const result = executeCommand(
+			fixture.project,
+			setParameter(
+				{
+					scope: "track",
+					trackId: fixture.trackAId,
+					parameterId: SONG_TEMPO.id,
+				},
+				120,
+			),
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0].message).toMatch(
+			/is not a parameter of this target/,
+		);
+	});
+
+	it("rejects an unregistered device parameter", () => {
+		const result = executeCommand(
+			fixture.project,
+			setParameter(
+				{
+					scope: "trackDevice",
+					trackId: fixture.trackAId,
+					deviceId: fixture.deviceId,
+					parameterId: "mystery",
+				},
+				1,
+			),
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues[0].message).toMatch(/no registered parameter/);
+	});
+
+	it("rejects a missing track, device, or return bus", () => {
+		for (const target of [
+			{
+				scope: "track" as const,
+				trackId: ABSENT_IDS.track,
+				parameterId: TRACK_VOLUME.id,
+			},
+			{
+				scope: "trackDevice" as const,
+				trackId: fixture.trackAId,
+				deviceId: ABSENT_IDS.device,
+				parameterId: TEST_DEVICE_PARAMETER,
+			},
+			{
+				scope: "return" as const,
+				returnId: ABSENT_IDS.return,
+				parameterId: RETURN_VOLUME.id,
+			},
+			{
+				scope: "send" as const,
+				trackId: fixture.trackBId,
+				returnId: fixture.returnId,
+				parameterId: TRACK_SEND_LEVEL.id,
+			},
+		]) {
+			const result = executeCommand(fixture.project, setParameter(target, 0.5));
+			expect(result.ok, `${target.scope} should reject`).toBe(false);
+		}
+	});
+
+	it("summarizes with the parameter's label and unit", () => {
+		const result = executeCommand(
+			fixture.project,
+			setParameter(
+				{
+					scope: "track",
+					trackId: fixture.trackAId,
+					parameterId: TRACK_VOLUME.id,
+				},
+				-6,
+			),
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.summary).toBe("Set Track volume to -6 dB");
+	});
+});

--- a/src/commands/projectEdits.ts
+++ b/src/commands/projectEdits.ts
@@ -1,0 +1,180 @@
+import type {
+	Clip,
+	NoteEvent,
+	Placement,
+	Project,
+	Song,
+	Track,
+} from "../domain/entities";
+import type { ClipId, EventId, PlacementId, TrackId } from "../domain/ids";
+
+/**
+ * Immutable edit helpers shared by command definitions.
+ *
+ * Every helper returns new objects along the path it changed and reuses every
+ * untouched object, so a note edit on a 50-track project leaves 49 track
+ * objects referentially identical. That structural sharing is what lets
+ * `FND-005` projections and the audio engine tell "this changed" from "this
+ * did not" by identity instead of deep comparison, and it is why history keeps
+ * commands rather than deep project copies.
+ */
+
+export function findTrack(
+	project: Project,
+	trackId: TrackId,
+): Track | undefined {
+	return project.song.tracks.find((track) => track.id === trackId);
+}
+
+export function findClip(project: Project, clipId: ClipId): Clip | undefined {
+	return project.clips.find((clip) => clip.id === clipId);
+}
+
+export function findPlacement(
+	project: Project,
+	placementId: PlacementId,
+): Placement | undefined {
+	return project.song.placements.find(
+		(placement) => placement.id === placementId,
+	);
+}
+
+export function findNoteEvent(
+	clip: Clip,
+	eventId: EventId,
+): NoteEvent | undefined {
+	return clip.content.kind === "notes"
+		? clip.content.events.find((event) => event.id === eventId)
+		: undefined;
+}
+
+/** The clip's note events, or `undefined` when the clip is not note content. */
+export function noteEventsOf(clip: Clip): readonly NoteEvent[] | undefined {
+	return clip.content.kind === "notes" ? clip.content.events : undefined;
+}
+
+export function withSong(project: Project, song: Song): Project {
+	return { ...project, song };
+}
+
+export function withClips(project: Project, clips: readonly Clip[]): Project {
+	return { ...project, clips: [...clips] };
+}
+
+/** Replaces one clip by ID, leaving every other clip object untouched. */
+export function replaceClip(project: Project, next: Clip): Project {
+	return withClips(
+		project,
+		project.clips.map((clip) => (clip.id === next.id ? next : clip)),
+	);
+}
+
+export function withNoteEvents(clip: Clip, events: readonly NoteEvent[]): Clip {
+	return { ...clip, content: { kind: "notes", events: [...events] } };
+}
+
+export function replaceTrack(project: Project, next: Track): Project {
+	return withSong(project, {
+		...project.song,
+		tracks: project.song.tracks.map((track) =>
+			track.id === next.id ? next : track,
+		),
+	});
+}
+
+export function replacePlacement(project: Project, next: Placement): Project {
+	return withSong(project, {
+		...project.song,
+		placements: project.song.placements.map((placement) =>
+			placement.id === next.id ? next : placement,
+		),
+	});
+}
+
+/** Rewrites `order` to 0..n-1 in array order, satisfying the ordering invariant. */
+export function renumber<T extends { order: number }>(
+	items: readonly T[],
+): T[] {
+	return items.map((item, index) =>
+		item.order === index ? item : { ...item, order: index },
+	);
+}
+
+/** Sorts a copy by `order` without mutating the input array. */
+export function byOrder<T extends { order: number }>(items: readonly T[]): T[] {
+	return [...items].sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Resolves a selection of note events: an explicit ID list, or every event in
+ * the clip when the payload asks for "all". Returns the missing IDs so a
+ * command can reject a stale selection instead of silently editing fewer notes
+ * than the user selected.
+ */
+export function selectEvents(
+	clip: Clip,
+	eventIds: readonly EventId[] | null,
+): { selected: NoteEvent[]; missing: EventId[] } {
+	const events = noteEventsOf(clip) ?? [];
+	if (eventIds === null) {
+		return { selected: sortEvents(events), missing: [] };
+	}
+	const byId = new Map(events.map((event) => [event.id, event]));
+	const selected: NoteEvent[] = [];
+	const missing: EventId[] = [];
+	for (const eventId of eventIds) {
+		const event = byId.get(eventId);
+		if (event) {
+			selected.push(event);
+		} else {
+			missing.push(eventId);
+		}
+	}
+	return { selected: sortEvents(selected), missing };
+}
+
+/**
+ * Deterministic event order: start tick, then ID. Transformations iterate in
+ * this order so their result never depends on the order a UI happened to
+ * collect a selection in.
+ */
+export function sortEvents(events: readonly NoteEvent[]): NoteEvent[] {
+	return [...events].sort(
+		(a, b) => a.startTicks - b.startTicks || compareIds(a.id, b.id),
+	);
+}
+
+function compareIds(a: string, b: string): number {
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Applies `changes` to the listed events, leaving the rest identical. */
+export function mapEvents(
+	clip: Clip,
+	changed: ReadonlyMap<EventId, NoteEvent>,
+): Clip {
+	const events = noteEventsOf(clip) ?? [];
+	return withNoteEvents(
+		clip,
+		events.map((event) => changed.get(event.id) ?? event),
+	);
+}
+
+export function pluralize(count: number, singular: string): string {
+	return count === 1 ? `1 ${singular}` : `${count} ${singular}s`;
+}
+
+/** Quotes a user-authored name for a summary line. */
+export function quoted(name: string): string {
+	return `"${name}"`;
+}
+
+/** A clip's name for a summary line, falling back to its ID once deleted. */
+export function clipLabel(project: Project, clipId: ClipId): string {
+	return quoted(findClip(project, clipId)?.name ?? clipId);
+}
+
+/** A track's name for a summary line, falling back to its ID once deleted. */
+export function trackLabel(project: Project, trackId: TrackId): string {
+	return quoted(findTrack(project, trackId)?.name ?? trackId);
+}

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+	COMMAND_TYPES,
+	commandRegistry,
+	findCommand,
+	isRegisteredCommand,
+	requireCommand,
+} from "./registry";
+import { ABSENT_IDS } from "./testProjects";
+
+/**
+ * The registry is a published contract: `FND-009`, Phase 1 features, and the
+ * assistant all dispatch through these types. Adding one is deliberate work,
+ * so the expected set is pinned here rather than derived from the registry it
+ * is meant to check.
+ */
+const EXPECTED_COMMANDS = [
+	"note.add",
+	"note.remove",
+	"note.update",
+	"notes.transpose",
+	"notes.scaleVelocity",
+	"notes.quantize",
+	"notes.duplicate",
+	"notes.clear",
+	"notes.vary",
+	"clip.create",
+	"clip.delete",
+	"clip.update",
+	"track.create",
+	"track.delete",
+	"track.update",
+	"track.reorder",
+	"track.setFlag",
+	"placement.create",
+	"placement.delete",
+	"placement.update",
+	"parameter.set",
+];
+
+describe("command registry", () => {
+	it("registers exactly the published command set", () => {
+		expect([...COMMAND_TYPES].sort()).toEqual([...EXPECTED_COMMANDS].sort());
+	});
+
+	it("registers each type once", () => {
+		expect(new Set(COMMAND_TYPES).size).toBe(COMMAND_TYPES.length);
+		expect(commandRegistry().size).toBe(COMMAND_TYPES.length);
+	});
+
+	it("namespaces every command type and versions it", () => {
+		for (const type of COMMAND_TYPES) {
+			expect(type, `${type} should be namespaced`).toMatch(
+				/^[a-z]+\.[a-zA-Z]+$/,
+			);
+			expect(requireCommand(type).version).toBe(1);
+		}
+	});
+
+	it("reports an unregistered type rather than guessing", () => {
+		expect(findCommand("note.explode")).toBeUndefined();
+		expect(isRegisteredCommand("note.explode")).toBe(false);
+		expect(() => requireCommand("note.explode")).toThrow(/Unknown command/);
+	});
+
+	it("rejects an empty payload for every registered command", () => {
+		for (const type of COMMAND_TYPES) {
+			const parsed = requireCommand(type).parsePayload({});
+			expect(parsed.ok, `${type} accepted an empty payload`).toBe(false);
+		}
+	});
+
+	it("rejects a non-object payload for every registered command", () => {
+		for (const type of COMMAND_TYPES) {
+			for (const payload of [null, undefined, 7, "note", []]) {
+				const parsed = requireCommand(type).parsePayload(payload);
+				expect(
+					parsed.ok,
+					`${type} accepted ${JSON.stringify(payload) ?? "undefined"}`,
+				).toBe(false);
+			}
+		}
+	});
+
+	it("rejects unknown payload keys rather than ignoring them", () => {
+		const parsed = requireCommand("notes.clear").parsePayload({
+			clipId: ABSENT_IDS.clip,
+			sneaky: true,
+		});
+		expect(parsed.ok).toBe(false);
+	});
+});

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,0 +1,67 @@
+import { clipCommands } from "./definitions/clips";
+import { noteCommands } from "./definitions/notes";
+import { parameterCommands } from "./definitions/parameters";
+import { placementCommands } from "./definitions/placements";
+import { trackCommands } from "./definitions/tracks";
+import { transformCommands } from "./definitions/transforms";
+import type { RegisteredCommand } from "./types";
+
+/**
+ * The command registry (PRD section 9.6).
+ *
+ * One registry serves pointer UI, keyboard shortcuts, tests, and — once
+ * `AI-001` lands — assistant tool calls, so every mutation path shares the
+ * same validation, inverse, and summary. A command that is not registered here
+ * cannot change a project.
+ */
+
+/**
+ * Each module erases its own commands' payload types (see `eraseCommand`), so
+ * one heterogeneous registry needs no `any` and no cast here.
+ */
+const ALL_DEFINITIONS: readonly RegisteredCommand[] = [
+	...noteCommands,
+	...transformCommands,
+	...clipCommands,
+	...trackCommands,
+	...placementCommands,
+	...parameterCommands,
+];
+
+function buildRegistry(
+	definitions: readonly RegisteredCommand[],
+): ReadonlyMap<string, RegisteredCommand> {
+	const registry = new Map<string, RegisteredCommand>();
+	for (const definition of definitions) {
+		if (registry.has(definition.type)) {
+			throw new TypeError(`Command "${definition.type}" is already registered`);
+		}
+		registry.set(definition.type, definition);
+	}
+	return registry;
+}
+
+const REGISTRY = buildRegistry(ALL_DEFINITIONS);
+
+/** Every registered command type, in registration order. */
+export const COMMAND_TYPES: readonly string[] = [...REGISTRY.keys()];
+
+export function commandRegistry(): ReadonlyMap<string, RegisteredCommand> {
+	return REGISTRY;
+}
+
+export function findCommand(type: string): RegisteredCommand | undefined {
+	return REGISTRY.get(type);
+}
+
+export function requireCommand(type: string): RegisteredCommand {
+	const command = REGISTRY.get(type);
+	if (!command) {
+		throw new TypeError(`Unknown command "${type}"`);
+	}
+	return command;
+}
+
+export function isRegisteredCommand(type: string): boolean {
+	return REGISTRY.has(type);
+}

--- a/src/commands/structure.test.ts
+++ b/src/commands/structure.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	bars,
+	createNoteClip,
+	createPlacement,
+	createSamplerInstrument,
+	createTrack as createTrackEntity,
+	type Project,
+	TICKS_PER_BAR,
+	toTicks,
+} from "../domain";
+import {
+	addClip,
+	addPlacement,
+	addTrack,
+	removeClip,
+	removePlacement,
+	removeTrack,
+	reorderTrack,
+	setTrackFlag,
+	updateClip,
+	updatePlacement,
+	updateTrack,
+} from ".";
+import { executeCommand } from "./execute";
+import { findClip, findPlacement, findTrack } from "./projectEdits";
+import {
+	ABSENT_IDS,
+	type CommandTestProject,
+	createCommandTestProject,
+	createTestFactoryContext,
+} from "./testProjects";
+
+function apply(
+	project: Project,
+	command: Parameters<typeof executeCommand>[1],
+): Project {
+	const result = executeCommand(project, command);
+	if (!result.ok) {
+		throw new Error(`Expected success: ${result.issues[0].message}`);
+	}
+	return result.project;
+}
+
+function trackNames(project: Project): string[] {
+	return [...project.song.tracks]
+		.sort((a, b) => a.order - b.order)
+		.map((track) => track.name);
+}
+
+describe("structural commands", () => {
+	let fixture: CommandTestProject;
+	let context: ReturnType<typeof createTestFactoryContext>;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+		context = createTestFactoryContext("structure");
+	});
+
+	describe("track.create", () => {
+		it("appends a track and keeps orders contiguous", () => {
+			const track = createTrackEntity(context, {
+				name: "Lead",
+				order: 2,
+				instrument: createSamplerInstrument(null),
+			});
+			const next = apply(fixture.project, addTrack(track));
+			expect(trackNames(next)).toEqual(["Bass", "Drums", "Lead"]);
+		});
+
+		it("inserts in the middle and pushes later tracks down", () => {
+			const track = createTrackEntity(context, { name: "Lead", order: 0 });
+			const next = apply(fixture.project, addTrack(track));
+			expect(trackNames(next)).toEqual(["Lead", "Bass", "Drums"]);
+			expect(next.song.tracks.map((entry) => entry.order).sort()).toEqual([
+				0, 1, 2,
+			]);
+		});
+
+		it("rejects a position beyond the end of the track list", () => {
+			const track = createTrackEntity(context, { name: "Lead", order: 9 });
+			const result = executeCommand(fixture.project, addTrack(track));
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/Cannot insert a track/);
+		});
+
+		it("rejects a track ID that already exists", () => {
+			const existing = fixture.project.song.tracks[0];
+			const result = executeCommand(
+				fixture.project,
+				addTrack({ ...existing, order: 2 }),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/already exists/);
+		});
+	});
+
+	describe("track.delete", () => {
+		it("removes the track and everything that cannot outlive it", () => {
+			const next = apply(fixture.project, removeTrack(fixture.trackAId));
+
+			expect(findTrack(next, fixture.trackAId)).toBeUndefined();
+			expect(findClip(next, fixture.clipAId)).toBeUndefined();
+			expect(findPlacement(next, fixture.placementAId)).toBeUndefined();
+			expect(next.song.automation).toHaveLength(0);
+			// The surviving track is renumbered from 1 to 0.
+			expect(next.song.tracks.map((track) => track.order)).toEqual([0]);
+			expect(findClip(next, fixture.clipBId)).toBeDefined();
+		});
+
+		it("rejects a track that is not there", () => {
+			const result = executeCommand(
+				fixture.project,
+				removeTrack(ABSENT_IDS.track),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("rejected");
+		});
+	});
+
+	describe("track.update, reorder, and flags", () => {
+		it("renames a track", () => {
+			const next = apply(
+				fixture.project,
+				updateTrack(fixture.trackAId, { name: "Sub" }),
+			);
+			expect(findTrack(next, fixture.trackAId)?.name).toBe("Sub");
+		});
+
+		it("moves a track and renumbers the rest", () => {
+			const next = apply(fixture.project, reorderTrack(fixture.trackAId, 1));
+			expect(trackNames(next)).toEqual(["Drums", "Bass"]);
+		});
+
+		it("rejects a position outside the track list", () => {
+			const result = executeCommand(
+				fixture.project,
+				reorderTrack(fixture.trackAId, 5),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/Cannot move a track/);
+		});
+
+		it("mutes and solos a track", () => {
+			const muted = apply(
+				fixture.project,
+				setTrackFlag(fixture.trackAId, "muted", true),
+			);
+			expect(findTrack(muted, fixture.trackAId)?.mixer.muted).toBe(true);
+
+			const soloed = apply(
+				muted,
+				setTrackFlag(fixture.trackAId, "soloed", true),
+			);
+			expect(findTrack(soloed, fixture.trackAId)?.mixer.soloed).toBe(true);
+			expect(findTrack(soloed, fixture.trackAId)?.mixer.muted).toBe(true);
+		});
+	});
+
+	describe("clip commands", () => {
+		it("adds a clip to a track", () => {
+			const clip = createNoteClip(context, {
+				trackId: fixture.trackAId,
+				name: "Second",
+			});
+			const next = apply(fixture.project, addClip(clip));
+			expect(findClip(next, clip.id)?.name).toBe("Second");
+		});
+
+		it("rejects a clip whose owning track is missing", () => {
+			const clip = createNoteClip(context, {
+				trackId: ABSENT_IDS.track,
+				name: "Orphan",
+			});
+			const result = executeCommand(fixture.project, addClip(clip));
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("invalid_project");
+		});
+
+		it("deletes a clip together with its placements", () => {
+			const next = apply(fixture.project, removeClip(fixture.clipAId));
+			expect(findClip(next, fixture.clipAId)).toBeUndefined();
+			expect(findPlacement(next, fixture.placementAId)).toBeUndefined();
+			expect(next.song.placements).toHaveLength(1);
+		});
+
+		it("renames a clip", () => {
+			const next = apply(
+				fixture.project,
+				updateClip(fixture.clipAId, { name: "Groove" }),
+			);
+			expect(findClip(next, fixture.clipAId)?.name).toBe("Groove");
+		});
+
+		it("refuses to shrink a clip below its last note", () => {
+			const result = executeCommand(
+				fixture.project,
+				updateClip(fixture.clipAId, { lengthTicks: toTicks(100) }),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("invalid_project");
+			expect(result.issues[0].domainIssues?.[0].code).toBe(
+				"invalid_musical_time",
+			);
+		});
+	});
+
+	describe("placement commands", () => {
+		it("places a clip in the arrangement", () => {
+			const placement = createPlacement(context, {
+				clipId: fixture.clipAId,
+				trackId: fixture.trackAId,
+				startTicks: bars(2),
+				durationTicks: bars(1),
+			});
+			const next = apply(fixture.project, addPlacement(placement));
+			expect(findPlacement(next, placement.id)?.startTicks).toBe(bars(2));
+		});
+
+		it("rejects a placement whose clip does not exist", () => {
+			const placement = createPlacement(context, {
+				clipId: ABSENT_IDS.clip,
+				trackId: fixture.trackAId,
+				startTicks: 0,
+				durationTicks: bars(1),
+			});
+			const result = executeCommand(fixture.project, addPlacement(placement));
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].domainIssues?.[0].code).toBe(
+				"dangling_reference",
+			);
+		});
+
+		it("moves a placement along the timeline", () => {
+			const next = apply(
+				fixture.project,
+				updatePlacement(fixture.placementAId, {
+					startTicks: bars(4),
+				}),
+			);
+			expect(findPlacement(next, fixture.placementAId)?.startTicks).toBe(
+				TICKS_PER_BAR * 4,
+			);
+		});
+
+		it("refuses to move a placement onto a track that does not own its clip", () => {
+			const result = executeCommand(
+				fixture.project,
+				updatePlacement(fixture.placementAId, { trackId: fixture.trackBId }),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].domainIssues?.[0].code).toBe(
+				"cross_owner_reference",
+			);
+		});
+
+		it("removes a placement without touching its clip", () => {
+			const next = apply(
+				fixture.project,
+				removePlacement(fixture.placementAId),
+			);
+			expect(findPlacement(next, fixture.placementAId)).toBeUndefined();
+			expect(findClip(next, fixture.clipAId)).toBeDefined();
+		});
+	});
+});

--- a/src/commands/testProjects.ts
+++ b/src/commands/testProjects.ts
@@ -1,0 +1,225 @@
+// Test-only fixtures for the command suite.
+//
+// This lives beside the code it supports (the same pattern as
+// `src/audio/testAudioContext.ts`) because it is specific to command tests
+// rather than shared across suites. It is built from the real domain
+// factories and always seeded, so IDs and serialized output are identical on
+// every run.
+//
+// `src/domain/fixtures.ts`'s projects deliberately cover the schema's shape;
+// this one covers the surfaces commands touch that those fixtures leave empty:
+// a return bus and a send, an insert device with a parameter, an automation
+// lane, and two tracks so reorder and delete cascades have something to move.
+
+import {
+	assertProject,
+	bars,
+	type ClipId,
+	createAsset,
+	createDrumMachineInstrument,
+	createDrumPad,
+	createEmptySong,
+	createFactoryContext,
+	createNoteClip,
+	createNoteEvent,
+	createPlacement,
+	createProjectMetadata,
+	createReturnBus,
+	createSamplerInstrument,
+	createSeededIdFactory,
+	createSend,
+	createTrack,
+	type Device,
+	type DeviceId,
+	type EventId,
+	type PadId,
+	type PlacementId,
+	type Project,
+	type ReturnId,
+	serializeProject,
+	TICKS_PER_BAR,
+	TICKS_PER_SIXTEENTH,
+	TRACK_VOLUME,
+	type TrackId,
+	toTicks,
+} from "../domain";
+
+/** Device type used by the fixture's insert device. */
+export const TEST_DEVICE_TYPE = "testDelay";
+
+/** Parameter ID on that device, registered by tests that set it. */
+export const TEST_DEVICE_PARAMETER = "time";
+
+export interface CommandTestProject {
+	project: Project;
+	trackAId: TrackId;
+	trackBId: TrackId;
+	clipAId: ClipId;
+	clipBId: ClipId;
+	deviceId: DeviceId;
+	returnId: ReturnId;
+	placementAId: PlacementId;
+	padIds: PadId[];
+	/** Event IDs of `clipA`, in the order the fixture created them. */
+	eventIds: EventId[];
+}
+
+export function createCommandTestProject(
+	seed = "commands",
+): CommandTestProject {
+	const context = createFactoryContext({
+		ids: createSeededIdFactory(seed),
+		now: 1_700_000_000_000,
+	});
+
+	const asset = createAsset(context, {
+		name: "909 Bass Drum",
+		storageRef: "samples/house/drums/bd/909-bd.wav",
+	});
+
+	const device: Device = {
+		id: context.ids("device"),
+		type: TEST_DEVICE_TYPE,
+		order: 0,
+		bypassed: false,
+		parameters: { [TEST_DEVICE_PARAMETER]: 0.25 },
+		preset: null,
+	};
+
+	const returnBus = createReturnBus(context, { name: "Reverb", order: 0 });
+
+	const trackA = createTrack(context, {
+		name: "Bass",
+		order: 0,
+		instrument: createSamplerInstrument(asset.id),
+		devices: [device],
+		sendConfig: [createSend(returnBus.id, 0.25)],
+	});
+
+	const kick = createDrumPad(context, { name: "BD" });
+	const clap = createDrumPad(context, { name: "CP" });
+	const trackB = createTrack(context, {
+		name: "Drums",
+		order: 1,
+		instrument: createDrumMachineInstrument([kick, clap]),
+	});
+
+	const clipA = createNoteClip(context, {
+		trackId: trackA.id,
+		name: "Bassline",
+		lengthTicks: TICKS_PER_BAR,
+		events: [0, 4, 8, 12].map((sixteenth) =>
+			createNoteEvent(context, {
+				startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+				durationTicks: TICKS_PER_SIXTEENTH,
+				pitch: 36 + sixteenth,
+				velocity: 0.5,
+			}),
+		),
+	});
+
+	const clipB = createNoteClip(context, {
+		trackId: trackB.id,
+		name: "Beat",
+		lengthTicks: TICKS_PER_BAR,
+		events: [0, 8].map((sixteenth) =>
+			createNoteEvent(context, {
+				startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+				durationTicks: TICKS_PER_SIXTEENTH,
+				padId: kick.id,
+			}),
+		),
+	});
+
+	const placementA = createPlacement(context, {
+		clipId: clipA.id,
+		trackId: trackA.id,
+		startTicks: 0,
+		durationTicks: bars(1),
+	});
+	const placementB = createPlacement(context, {
+		clipId: clipB.id,
+		trackId: trackB.id,
+		startTicks: 0,
+		durationTicks: bars(1),
+	});
+
+	const project = assertProject({
+		metadata: createProjectMetadata(context, {
+			ownerId: "user_commands",
+			name: "Command fixture",
+		}),
+		song: {
+			...createEmptySong(120),
+			assets: [asset],
+			tracks: [trackA, trackB],
+			returns: [returnBus],
+			placements: [placementA, placementB],
+			automation: [
+				{
+					id: context.ids("automation"),
+					target: {
+						scope: "track",
+						trackId: trackA.id,
+						parameterId: TRACK_VOLUME.id,
+					},
+					interpolation: "linear",
+					points: [
+						{ tick: toTicks(0), value: 0 },
+						{ tick: toTicks(TICKS_PER_BAR), value: -6 },
+					],
+				},
+			],
+		},
+		clips: [clipA, clipB],
+	});
+
+	return {
+		project,
+		trackAId: trackA.id,
+		trackBId: trackB.id,
+		clipAId: clipA.id,
+		clipBId: clipB.id,
+		deviceId: device.id,
+		returnId: returnBus.id,
+		placementAId: placementA.id,
+		padIds: [kick.id, clap.id],
+		eventIds:
+			clipA.content.kind === "notes"
+				? clipA.content.events.map((event) => event.id)
+				: [],
+	};
+}
+
+/**
+ * Well-formed IDs that no fixture uses, for "the payload is valid but the
+ * entity is gone" tests. They have to pass the ID schema, or a test would
+ * assert on a payload rejection when it means to assert on a precondition.
+ */
+const ABSENT_SUFFIX = "A".repeat(21);
+export const ABSENT_IDS = {
+	track: `trk_${ABSENT_SUFFIX}` as TrackId,
+	clip: `clp_${ABSENT_SUFFIX}` as ClipId,
+	event: `evt_${ABSENT_SUFFIX}` as EventId,
+	placement: `plc_${ABSENT_SUFFIX}` as PlacementId,
+	device: `dev_${ABSENT_SUFFIX}` as DeviceId,
+	return: `ret_${ABSENT_SUFFIX}` as ReturnId,
+} as const;
+
+/** A seeded factory context for building entities inside a test. */
+export function createTestFactoryContext(seed = "test-entities") {
+	return createFactoryContext({
+		ids: createSeededIdFactory(seed),
+		now: 1_700_000_000_000,
+	});
+}
+
+/**
+ * Everything about a project except its metadata, serialized deterministically.
+ * Undo restores musical content exactly; it does not rewind the revision
+ * counter or `modifiedAt`, so those are excluded from the comparison.
+ */
+export function contentSignature(project: Project): string {
+	const { metadata: _metadata, ...content } = serializeProject(project);
+	return JSON.stringify(content);
+}

--- a/src/commands/transforms.test.ts
+++ b/src/commands/transforms.test.ts
@@ -1,0 +1,340 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	createIdFactory,
+	createSeededIdFactory,
+	type NoteEvent,
+	type Project,
+	TICKS_PER_BAR,
+	TICKS_PER_SIXTEENTH,
+	toTicks,
+} from "../domain";
+import {
+	clearNotes,
+	duplicateNotes,
+	quantizeNotes,
+	scaleNoteVelocity,
+	transposeNotes,
+	updateNote,
+	varyNotes,
+} from ".";
+import { executeCommand } from "./execute";
+import { findClip, noteEventsOf } from "./projectEdits";
+import {
+	type CommandTestProject,
+	createCommandTestProject,
+} from "./testProjects";
+
+function eventsOf(
+	project: Project,
+	clipId: CommandTestProject["clipAId"],
+): readonly NoteEvent[] {
+	const clip = findClip(project, clipId);
+	return clip ? (noteEventsOf(clip) ?? []) : [];
+}
+
+function pitchesOf(
+	project: Project,
+	clipId: CommandTestProject["clipAId"],
+): number[] {
+	return eventsOf(project, clipId).map((event) =>
+		event.trigger.kind === "pitch" ? event.trigger.pitch : -1,
+	);
+}
+
+/** Applies a command and unwraps the new project, failing loudly otherwise. */
+function apply(
+	project: Project,
+	command: Parameters<typeof executeCommand>[1],
+): Project {
+	const result = executeCommand(project, command);
+	if (!result.ok) {
+		throw new Error(
+			`Expected the command to apply: ${result.issues[0].message}`,
+		);
+	}
+	return result.project;
+}
+
+describe("musical transformations (CLP-04)", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	describe("notes.transpose", () => {
+		it("shifts every selected pitch", () => {
+			const next = apply(
+				fixture.project,
+				transposeNotes(fixture.clipAId, null, 12),
+			);
+			expect(pitchesOf(next, fixture.clipAId)).toEqual([48, 52, 56, 60]);
+		});
+
+		it("shifts only the selected notes", () => {
+			const next = apply(
+				fixture.project,
+				transposeNotes(fixture.clipAId, [fixture.eventIds[0]], -2),
+			);
+			expect(pitchesOf(next, fixture.clipAId)).toEqual([34, 40, 44, 48]);
+		});
+
+		it("leaves drum-pad triggers alone", () => {
+			const next = apply(
+				fixture.project,
+				transposeNotes(fixture.clipBId, null, 5),
+			);
+			const triggers = eventsOf(next, fixture.clipBId).map(
+				(event) => event.trigger.kind,
+			);
+			expect(triggers).toEqual(["pad", "pad"]);
+		});
+
+		it("refuses to clamp a note out of the MIDI range", () => {
+			const result = executeCommand(
+				fixture.project,
+				transposeNotes(fixture.clipAId, null, 100),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/pitch range/);
+		});
+
+		it("rejects a transformation with nothing selected", () => {
+			const empty = apply(fixture.project, clearNotes(fixture.clipAId));
+			const result = executeCommand(
+				empty,
+				transposeNotes(fixture.clipAId, null, 1),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/no notes to transform/);
+		});
+	});
+
+	describe("notes.scaleVelocity", () => {
+		it("scales the selected velocities", () => {
+			const next = apply(
+				fixture.project,
+				scaleNoteVelocity(fixture.clipAId, null, 1.5),
+			);
+			expect(eventsOf(next, fixture.clipAId).map((e) => e.velocity)).toEqual([
+				0.75, 0.75, 0.75, 0.75,
+			]);
+		});
+
+		it("clamps at the shared velocity range instead of overflowing", () => {
+			const next = apply(
+				fixture.project,
+				scaleNoteVelocity(fixture.clipAId, null, 10),
+			);
+			expect(eventsOf(next, fixture.clipAId).map((e) => e.velocity)).toEqual([
+				1, 1, 1, 1,
+			]);
+		});
+
+		it("rejects a non-positive factor at the schema", () => {
+			const result = executeCommand(
+				fixture.project,
+				scaleNoteVelocity(fixture.clipAId, null, 0),
+			);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("invalid_payload");
+		});
+	});
+
+	describe("notes.quantize", () => {
+		it("snaps fully onto the grid at full strength", () => {
+			const offGrid = apply(
+				fixture.project,
+				updateNote(fixture.clipAId, fixture.eventIds[1], {
+					startTicks: toTicks(200),
+				}),
+			);
+			const next = apply(
+				offGrid,
+				quantizeNotes(fixture.clipAId, [fixture.eventIds[1]], 192, 1),
+			);
+			expect(eventsOf(next, fixture.clipAId)[1].startTicks).toBe(192);
+		});
+
+		it("moves part of the way at partial strength", () => {
+			const offGrid = apply(
+				fixture.project,
+				updateNote(fixture.clipAId, fixture.eventIds[1], {
+					startTicks: toTicks(200),
+				}),
+			);
+			const next = apply(
+				offGrid,
+				quantizeNotes(fixture.clipAId, [fixture.eventIds[1]], 192, 0.5),
+			);
+			expect(eventsOf(next, fixture.clipAId)[1].startTicks).toBe(196);
+		});
+
+		it("never snaps a note past the end of its clip", () => {
+			const nearEnd = apply(
+				fixture.project,
+				updateNote(fixture.clipAId, fixture.eventIds[3], {
+					startTicks: toTicks(TICKS_PER_BAR - 8),
+				}),
+			);
+			const next = apply(
+				nearEnd,
+				quantizeNotes(fixture.clipAId, [fixture.eventIds[3]], TICKS_PER_BAR, 1),
+			);
+			const start = eventsOf(next, fixture.clipAId)[3].startTicks;
+			expect(start).toBe(0);
+			expect(start).toBeLessThan(TICKS_PER_BAR);
+		});
+	});
+
+	describe("notes.duplicate", () => {
+		it("copies the selection at the given offset with caller-minted ids", () => {
+			const ids = createSeededIdFactory("duplicate");
+			const command = duplicateNotes(ids, fixture.project, {
+				clipId: fixture.clipAId,
+				eventIds: [fixture.eventIds[0]],
+				offsetTicks: TICKS_PER_SIXTEENTH,
+			});
+			const next = apply(fixture.project, command);
+
+			const events = eventsOf(next, fixture.clipAId);
+			expect(events).toHaveLength(5);
+			const copy = events[4];
+			expect(copy.startTicks).toBe(TICKS_PER_SIXTEENTH);
+			expect(copy.id).toBe(command.payload.newIds[0]);
+			expect(copy.velocity).toBe(events[0].velocity);
+		});
+
+		it("duplicates the whole clip a bar later when it fits", () => {
+			const wider = apply(
+				fixture.project,
+				// Room for the copies before duplicating them.
+				{
+					type: "clip.update",
+					payload: {
+						clipId: fixture.clipAId,
+						changes: { lengthTicks: TICKS_PER_BAR * 2 },
+					},
+				},
+			);
+			const command = duplicateNotes(createIdFactory(), wider, {
+				clipId: fixture.clipAId,
+				offsetTicks: TICKS_PER_BAR,
+			});
+			const next = apply(wider, command);
+			expect(eventsOf(next, fixture.clipAId)).toHaveLength(8);
+		});
+
+		it("refuses to push a copy past the end of the clip", () => {
+			const command = duplicateNotes(createIdFactory(), fixture.project, {
+				clipId: fixture.clipAId,
+				offsetTicks: TICKS_PER_BAR,
+			});
+			const result = executeCommand(fixture.project, command);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/past the end/);
+		});
+
+		it("refuses a payload whose new id count does not match the selection", () => {
+			const result = executeCommand(fixture.project, {
+				type: "notes.duplicate",
+				payload: {
+					clipId: fixture.clipAId,
+					eventIds: null,
+					offsetTicks: TICKS_PER_SIXTEENTH,
+					newIds: [],
+				},
+			});
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/needs 4 new ids/);
+		});
+	});
+
+	describe("notes.clear", () => {
+		it("empties the clip", () => {
+			const next = apply(fixture.project, clearNotes(fixture.clipAId));
+			expect(eventsOf(next, fixture.clipAId)).toHaveLength(0);
+			// Clearing one clip leaves the other alone.
+			expect(eventsOf(next, fixture.clipBId)).toHaveLength(2);
+		});
+
+		it("rejects an already empty clip", () => {
+			const empty = apply(fixture.project, clearNotes(fixture.clipAId));
+			const result = executeCommand(empty, clearNotes(fixture.clipAId));
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].message).toMatch(/no notes to transform/);
+		});
+	});
+
+	describe("notes.vary", () => {
+		const options = { seed: "swing-1", amount: 1, gridTicks: 24 };
+
+		it("produces the same variation for the same seed", () => {
+			const first = apply(
+				fixture.project,
+				varyNotes(fixture.clipAId, null, options),
+			);
+			const second = apply(
+				fixture.project,
+				varyNotes(fixture.clipAId, null, options),
+			);
+			expect(eventsOf(first, fixture.clipAId)).toEqual(
+				eventsOf(second, fixture.clipAId),
+			);
+		});
+
+		it("actually varies the notes", () => {
+			const next = apply(
+				fixture.project,
+				varyNotes(fixture.clipAId, null, options),
+			);
+			expect(eventsOf(next, fixture.clipAId)).not.toEqual(
+				eventsOf(fixture.project, fixture.clipAId),
+			);
+		});
+
+		it("produces a different variation for a different seed", () => {
+			const first = apply(
+				fixture.project,
+				varyNotes(fixture.clipAId, null, options),
+			);
+			const other = apply(
+				fixture.project,
+				varyNotes(fixture.clipAId, null, { ...options, seed: "swing-2" }),
+			);
+			expect(eventsOf(first, fixture.clipAId)).not.toEqual(
+				eventsOf(other, fixture.clipAId),
+			);
+		});
+
+		it("changes nothing when the amount is zero", () => {
+			const next = apply(
+				fixture.project,
+				varyNotes(fixture.clipAId, null, { ...options, amount: 0 }),
+			);
+			expect(eventsOf(next, fixture.clipAId)).toEqual(
+				eventsOf(fixture.project, fixture.clipAId),
+			);
+		});
+
+		it("keeps every note inside its clip", () => {
+			const next = apply(
+				fixture.project,
+				varyNotes(fixture.clipAId, null, {
+					...options,
+					gridTicks: TICKS_PER_BAR,
+				}),
+			);
+			for (const event of eventsOf(next, fixture.clipAId)) {
+				expect(event.startTicks).toBeGreaterThanOrEqual(0);
+				expect(event.startTicks).toBeLessThan(TICKS_PER_BAR);
+			}
+		});
+	});
+});

--- a/src/commands/transforms.test.ts
+++ b/src/commands/transforms.test.ts
@@ -41,6 +41,12 @@ function pitchesOf(
 	);
 }
 
+/** Four fresh event ids, one per note in the test clip. */
+function createFourIds(): string[] {
+	const ids = createIdFactory();
+	return Array.from({ length: 4 }, () => ids("event"));
+}
+
 /** Applies a command and unwraps the new project, failing loudly otherwise. */
 function apply(
 	project: Project,
@@ -237,6 +243,28 @@ describe("musical transformations (CLP-04)", () => {
 			expect(result.ok).toBe(false);
 			if (result.ok) return;
 			expect(result.issues[0].message).toMatch(/past the end/);
+		});
+
+		it("rejects an out-of-range offset instead of throwing", () => {
+			const run = () =>
+				executeCommand(fixture.project, {
+					type: "notes.duplicate",
+					payload: {
+						clipId: fixture.clipAId,
+						eventIds: null,
+						// Passes the payload schema, but the copy's position would
+						// leave the safe-integer range that ticks live in.
+						offsetTicks: Number.MAX_SAFE_INTEGER,
+						newIds: createFourIds(),
+					},
+				});
+
+			expect(run).not.toThrow();
+			const result = run();
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.issues[0].code).toBe("rejected");
+			expect(result.project).toBe(fixture.project);
 		});
 
 		it("refuses a payload whose new id count does not match the selection", () => {

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,185 @@
+import type { ZodType } from "zod";
+import type { Project } from "../domain/entities";
+import type { DomainIssue } from "../domain/parse";
+
+/**
+ * The shared command layer's vocabulary (PRD section 9.6).
+ *
+ * Every project mutation — pointer gesture, keyboard shortcut, or assistant
+ * action — is a command. A command carries a versioned type and a validated
+ * payload, an actor and correlation ID, a deterministic pure transition, a
+ * generated inverse, a human-readable summary, and the base revision it was
+ * built against. Nothing here imports Firebase, Tone, or Solid: the kernel is
+ * a pure function of domain state so the editor, the assistant, history, and
+ * persistence all integrate through the same tested boundary.
+ */
+
+/** Who asked for the change. Assistant and system edits are still commands. */
+export type CommandActor = "user" | "assistant" | "system";
+
+/**
+ * A command before validation: a registered type plus an unvalidated payload.
+ * `version` is optional for locally built commands — it only matters when a
+ * command arrives from storage or another client and might predate this build.
+ */
+export interface RawCommandInput {
+	readonly type: string;
+	readonly payload: unknown;
+	readonly version?: number;
+}
+
+/** A command with its payload type known at the call site. */
+export interface CommandInput<Payload> {
+	readonly type: string;
+	readonly payload: Payload;
+	readonly version?: number;
+}
+
+/**
+ * A validated command as it was executed: what ran, who asked for it, which
+ * request it belongs to, and which project revision it was built against.
+ * Envelopes are what a history entry, an audit log, or a delayed remote
+ * application replays.
+ */
+export interface CommandEnvelope {
+	readonly type: string;
+	readonly version: number;
+	readonly payload: unknown;
+	readonly actor: CommandActor;
+	readonly correlationId: string;
+	readonly baseRevision: number;
+}
+
+export type CommandIssueCode =
+	/** No command is registered under this type. */
+	| "unknown_command"
+	/** The caller asked for a command version this build does not implement. */
+	| "unsupported_command_version"
+	/** The payload failed the command's schema. */
+	| "invalid_payload"
+	/** The project moved on since the command was built. */
+	| "revision_conflict"
+	/** The payload is well-formed but the project cannot satisfy it. */
+	| "rejected"
+	/** The transition would have left the project invalid. */
+	| "invalid_project";
+
+export interface CommandIssue {
+	readonly code: CommandIssueCode;
+	readonly commandType: string;
+	/** Position of the offending command inside its transaction. */
+	readonly commandIndex: number;
+	readonly message: string;
+	/** Domain invariant failures, when the transition produced invalid state. */
+	readonly domainIssues?: readonly DomainIssue[];
+}
+
+export function formatCommandIssue(issue: CommandIssue): string {
+	return `[${issue.code}] ${issue.commandType}#${issue.commandIndex}: ${issue.message}`;
+}
+
+export class CommandError extends Error {
+	readonly issues: readonly CommandIssue[];
+
+	constructor(message: string, issues: readonly CommandIssue[]) {
+		super(`${message}: ${issues.map(formatCommandIssue).join("; ")}`);
+		this.name = "CommandError";
+		this.issues = issues;
+	}
+}
+
+/**
+ * The outcome of one command's transition. A command either produces the next
+ * project or rejects with a reason; it never mutates its input and never
+ * returns a half-applied project.
+ */
+export type CommandApplyResult =
+	| { readonly ok: true; readonly project: Project }
+	| { readonly ok: false; readonly message: string };
+
+export function applied(project: Project): CommandApplyResult {
+	return { ok: true, project };
+}
+
+export function rejected(message: string): CommandApplyResult {
+	return { ok: false, message };
+}
+
+export interface CommandDefinition<Payload> {
+	/** Stable, namespaced command type, e.g. `note.add`. */
+	readonly type: string;
+	/** Payload version. A payload shape change is a new version, not an edit. */
+	readonly version: number;
+	readonly schema: ZodType<Payload>;
+	/** One line, suitable for a history entry or an AI proposal diff. */
+	summarize(payload: Payload, project: Project): string;
+	/** Pure, deterministic transition. */
+	apply(project: Project, payload: Payload): CommandApplyResult;
+	/**
+	 * Commands that turn `after` back into `before`. Inverses are generated
+	 * from the state the command actually changed, so undo restores exact
+	 * previous values rather than re-deriving them.
+	 */
+	invert(
+		payload: Payload,
+		before: Project,
+		after: Project,
+	): readonly RawCommandInput[];
+}
+
+/**
+ * A registered command with its payload type erased, so one registry can hold
+ * every command. The casts live here and nowhere else: `parsePayload` is the
+ * only way a raw payload becomes the typed payload the definition sees.
+ */
+export interface RegisteredCommand {
+	readonly type: string;
+	readonly version: number;
+	parsePayload(input: unknown): PayloadParseResult;
+	summarize(payload: unknown, project: Project): string;
+	apply(project: Project, payload: unknown): CommandApplyResult;
+	invert(
+		payload: unknown,
+		before: Project,
+		after: Project,
+	): readonly RawCommandInput[];
+}
+
+export type PayloadParseResult =
+	| { readonly ok: true; readonly payload: unknown }
+	| { readonly ok: false; readonly message: string };
+
+/** Identity function that pins a definition's payload type at declaration. */
+export function defineCommand<Payload>(
+	definition: CommandDefinition<Payload>,
+): CommandDefinition<Payload> {
+	return definition;
+}
+
+export function eraseCommand<Payload>(
+	definition: CommandDefinition<Payload>,
+): RegisteredCommand {
+	return {
+		type: definition.type,
+		version: definition.version,
+		parsePayload(input) {
+			const result = definition.schema.safeParse(input);
+			if (result.success) {
+				return { ok: true, payload: result.data };
+			}
+			const detail = result.error.issues
+				.map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+				.join("; ");
+			return { ok: false, message: detail };
+		},
+		summarize(payload, project) {
+			return definition.summarize(payload as Payload, project);
+		},
+		apply(project, payload) {
+			return definition.apply(project, payload as Payload);
+		},
+		invert(payload, before, after) {
+			return definition.invert(payload as Payload, before, after);
+		},
+	};
+}


### PR DESCRIPTION
## Summary

Implements the shared command layer (PRD section 9.6) that the editor, keyboard shortcuts, assistant, history, and persistence all integrate through, under `src/commands/`.

- **`src/commands/types.ts`** defines a command: a versioned type, a Zod payload schema, a pure `apply`, a generated `invert`, and a one-line `summarize`. `eraseCommand` is the single place a payload is cast, so one heterogeneous registry needs no `any`.
- **`src/commands/execute.ts`** is the atomic transaction unit. Commands apply to a working copy; the result is checked against every domain invariant with `checkProjectIntegrity`; any failure returns the original project object untouched. Envelopes carry actor, correlation ID, version, and base revision, and an explicit `baseRevision` refuses a command built against a project that has moved on. One committed transaction produces exactly one revision. A follow-up commit (`0e22f68`) made execution total: `runCommand` now converts a thrown error into a `rejected` CommandIssue instead of letting it escape `executeTransaction`, so a caller that correctly handles `result.ok === false` can no longer crash.
- **`src/commands/history.ts`** is session-local, bounded undo/redo. Entries hold commands and inverses rather than project snapshots, so undo replays an inverse and redo replays the original commands. Gestures apply live but commit as one entry and one revision. Only an explicit `replaceProject` clears history — never a save acknowledgement or a remote echo.
- **`src/commands/projectEdits.ts`** keeps edits immutable with structural sharing, so a note edit leaves every untouched track referentially identical and does not read as a topology change downstream.
- **Commands (21, all version 1)**: note add/remove/update for the FND-009 slice; the CLP-04 transformations transpose, scaleVelocity, quantize, duplicate, clear, and a seeded deterministic vary; clip, track, and placement lifecycle with their cascades; and one generic `parameter.set` that reads range, default, and clamping policy from the shared parameter definitions instead of repeating them.

Determinism is a design constraint, not an accident: payloads carry explicit IDs for anything they create and `notes.vary` takes its seed in the payload, so redo, an assistant preview, and a peer all reproduce the same project.

## PRD requirements

- [`CLP-04` - Clip transformations](docs/prd.md)
- [PRD section 8 - Undo and redo](docs/prd.md)
- [PRD section 9.6 - Command kernel](docs/prd.md)

## Acceptance checkboxes met (backlog FND-003)

- [x] Initial commands cover the `FND-009` note slice plus generic entity/parameter operations needed by Phase 1. (`src/commands/definitions/notes.ts`, `parameters.ts`, `clips.ts`, `tracks.ts`, `placements.ts`, `transforms.ts`)
- [x] Command execution either yields a valid new revision or makes no change; inverse and redo behavior are deterministic. (`src/commands/execute.ts`, `src/commands/execute.test.ts`, `src/commands/inverse.test.ts`)
- [x] Gesture and multi-command transactions create one history entry with a human-readable summary. (`src/commands/history.ts`, `src/commands/history.test.ts`)
- [x] Undo/redo is local, bounded, reset deliberately on project replacement, and does not depend on Firestore snapshots. (`src/commands/history.ts`, `src/commands/history.test.ts`)
- [x] Every registered command, invalid payload, inverse, transaction rollback, and history edge has unit tests. (156 tests across `src/commands/*.test.ts`, including a registry-driven case-list check so a new command cannot land without an inverse test)

## Review

This branch went through an Opus review round in the implementation workflow; the round's blocking finding (a command that threw instead of rejecting could escape `executeTransaction`) was addressed in the follow-up commit `0e22f68` and is covered by dedicated regression tests, before this branch was sent for a further review pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SFkibHg472eihebmBAut5r


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkibHg472eihebmBAut5r)_