### PR TITLE
FND-005 - Selection and consumer projections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,15 @@ src/
 │   ├── types.ts             # Prototype types (removed by the FND-009 slice)
 │   ├── project.ts           # Project store and update functions
 │   └── dataService.ts       # Firestore data access layer
+├── selection/          # Selection/focus state (UI-only, never persisted)
+│   ├── types.ts             # SelectionScope union and SelectionState
+│   └── selection.ts         # Pure selection ops + project-driven reconciliation
+├── projection/         # Read-only consumer projections built from a Project
+│   ├── fingerprint.ts       # Deterministic content fingerprint for change detection
+│   ├── audioProjection.ts        # Audio engine's song projection (PRD 9.7)
+│   ├── arrangementProjection.ts  # Arrangement renderer's projection (PRD 9.3)
+│   ├── projectSummaryProjection.ts # Dashboard/persistence summary (PRD 9.9)
+│   └── assistantContextProjection.ts # Compact assistant context (PRD 9.8)
 ├── routes/             # File-based routing
 │   ├── index.tsx            # Home/landing page
 │   ├── dashboard.tsx        # User dashboard

--- a/src/projection/arrangementProjection.test.ts
+++ b/src/projection/arrangementProjection.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+import type { Project } from "../domain/entities";
+import {
+	createReferenceProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { TICKS_PER_BAR } from "../domain/time";
+import {
+	buildArrangementProjection,
+	findRowAtOffset,
+	queryPlacementsInRange,
+} from "./arrangementProjection";
+
+describe("buildArrangementProjection", () => {
+	it("projects rows, clips, placements, and sections from the slice fixture", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project);
+
+		expect(projection.revision).toBe(project.metadata.revision);
+		expect(projection.rows).toHaveLength(1);
+		expect(projection.rows[0].id).toBe(project.song.tracks[0].id);
+		expect(projection.rows[0].rowTop).toBe(0);
+		expect(projection.clips).toHaveLength(1);
+		expect(projection.placements).toHaveLength(1);
+		expect(projection.totalTicks).toBe(TICKS_PER_BAR);
+	});
+
+	it("summarizes a notes clip's preview without walking every event by hand", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildArrangementProjection(project);
+		const clip = projection.clips[0];
+		expect(clip.preview).toEqual({
+			kind: "notes",
+			noteCount: 4,
+			minPitch: 36,
+			maxPitch: 36,
+			density: 4,
+		});
+	});
+
+	it("does not mutate the source project", () => {
+		const project = createSliceFixtureProject();
+		const before = JSON.parse(JSON.stringify(project));
+		buildArrangementProjection(project);
+		expect(JSON.parse(JSON.stringify(project))).toEqual(before);
+	});
+
+	describe("row prefix sums", () => {
+		it("computes cumulative row offsets in track order", () => {
+			const project = createReferenceProject({
+				trackCount: 4,
+				placementCount: 8,
+			});
+			const projection = buildArrangementProjection(project, undefined, {
+				rowHeight: () => 50,
+			});
+			expect(projection.rows.map((row) => row.rowTop)).toEqual([
+				0, 50, 100, 150,
+			]);
+			expect(projection.totalRowHeight).toBe(200);
+		});
+
+		it("finds the row at a given pixel offset via binary search", () => {
+			const project = createReferenceProject({
+				trackCount: 4,
+				placementCount: 8,
+			});
+			const projection = buildArrangementProjection(project, undefined, {
+				rowHeight: () => 50,
+			});
+			expect(findRowAtOffset(projection, 0)?.id).toBe(projection.rows[0].id);
+			expect(findRowAtOffset(projection, 49)?.id).toBe(projection.rows[0].id);
+			expect(findRowAtOffset(projection, 50)?.id).toBe(projection.rows[1].id);
+			expect(findRowAtOffset(projection, 199)?.id).toBe(projection.rows[3].id);
+		});
+
+		it("returns null outside the row range", () => {
+			const project = createReferenceProject({
+				trackCount: 2,
+				placementCount: 4,
+			});
+			const projection = buildArrangementProjection(project, undefined, {
+				rowHeight: () => 50,
+			});
+			expect(findRowAtOffset(projection, -1)).toBeNull();
+			expect(findRowAtOffset(projection, 100)).toBeNull();
+		});
+
+		it("supports variable row heights (e.g. an expanded track)", () => {
+			const project = createReferenceProject({
+				trackCount: 3,
+				placementCount: 6,
+			});
+			const expandedTrackId = project.song.tracks[1].id;
+			const projection = buildArrangementProjection(project, undefined, {
+				rowHeight: (track) => (track.id === expandedTrackId ? 200 : 50),
+			});
+			expect(projection.rows.map((row) => row.rowTop)).toEqual([0, 50, 250]);
+			expect(findRowAtOffset(projection, 150)?.id).toBe(expandedTrackId);
+			expect(findRowAtOffset(projection, 260)?.id).toBe(projection.rows[2].id);
+		});
+	});
+
+	describe("placement range queries", () => {
+		it("returns only placements overlapping the requested tick range", () => {
+			const project = createReferenceProject({
+				trackCount: 2,
+				placementCount: 20,
+			});
+			const trackId = project.song.tracks[0].id;
+			const projection = buildArrangementProjection(project);
+
+			const all = queryPlacementsInRange(
+				projection,
+				trackId,
+				0,
+				Number.MAX_SAFE_INTEGER,
+			);
+			const windowed = queryPlacementsInRange(
+				projection,
+				trackId,
+				TICKS_PER_BAR * 4,
+				TICKS_PER_BAR * 8,
+			);
+
+			expect(windowed.length).toBeLessThanOrEqual(all.length);
+			for (const placement of windowed) {
+				expect(placement.trackId).toBe(trackId);
+				expect(placement.startTicks).toBeLessThan(TICKS_PER_BAR * 8);
+				expect(placement.endTicks).toBeGreaterThan(TICKS_PER_BAR * 4);
+			}
+			// Nothing outside the window should have been included.
+			const excluded = all.filter((p) => !windowed.includes(p));
+			for (const placement of excluded) {
+				const overlaps =
+					placement.startTicks < TICKS_PER_BAR * 8 &&
+					placement.endTicks > TICKS_PER_BAR * 4;
+				expect(overlaps).toBe(false);
+			}
+		});
+
+		it("returns an empty array for a track with no placements", () => {
+			const project = createSliceFixtureProject();
+			const projection = buildArrangementProjection(project);
+			expect(
+				queryPlacementsInRange(
+					projection,
+					"trk_does_not_exist" as never,
+					0,
+					100,
+				),
+			).toEqual([]);
+		});
+	});
+
+	describe("referential stability for unchanged entities", () => {
+		it("reuses every row, clip, and placement when nothing changed", () => {
+			const project = createReferenceProject({
+				trackCount: 8,
+				placementCount: 16,
+			});
+			const before = buildArrangementProjection(project);
+			const after = buildArrangementProjection(project, before);
+
+			expect(after.rows.every((row, i) => row === before.rows[i])).toBe(true);
+			expect(after.clips.every((clip, i) => clip === before.clips[i])).toBe(
+				true,
+			);
+			expect(after.placements.every((p, i) => p === before.placements[i])).toBe(
+				true,
+			);
+		});
+
+		it("reuses unrelated rows when only one track is renamed", () => {
+			const project = createReferenceProject({
+				trackCount: 6,
+				placementCount: 12,
+			});
+			const before = buildArrangementProjection(project);
+			const [renamedTrack, ...untouched] = project.song.tracks;
+
+			const edited: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track) =>
+						track.id === renamedTrack.id
+							? { ...track, name: "Renamed" }
+							: track,
+					),
+				},
+			};
+			const after = buildArrangementProjection(edited, before);
+
+			// The renamed row's own display fields changed, so it rebuilds...
+			expect(after.rowsById.get(renamedTrack.id)).not.toBe(
+				before.rowsById.get(renamedTrack.id),
+			);
+			expect(after.rowsById.get(renamedTrack.id)?.name).toBe("Renamed");
+			// ...but every other row is untouched, including its position.
+			for (const track of untouched) {
+				expect(after.rowsById.get(track.id)).toBe(
+					before.rowsById.get(track.id),
+				);
+			}
+		});
+
+		it("keeps unaffected rows stable across a two-track reorder", () => {
+			const project = createReferenceProject({
+				trackCount: 4,
+				placementCount: 8,
+			});
+			const [first, second, third] = project.song.tracks;
+			const before = buildArrangementProjection(project);
+
+			const reordered: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track) => {
+						if (track.id === first.id) return { ...track, order: 1 };
+						if (track.id === second.id) return { ...track, order: 0 };
+						return track;
+					}),
+				},
+			};
+			const after = buildArrangementProjection(reordered, before);
+
+			expect(after.rowsById.get(first.id)).not.toBe(
+				before.rowsById.get(first.id),
+			);
+			expect(after.rowsById.get(second.id)).not.toBe(
+				before.rowsById.get(second.id),
+			);
+			// The third track's own order/name/color did not change, and (since the
+			// swapped rows share the default row height) its rowTop is unaffected.
+			expect(after.rowsById.get(third.id)).toBe(before.rowsById.get(third.id));
+		});
+	});
+
+	describe("empty state", () => {
+		it("projects an empty project without error", () => {
+			const project = createSliceFixtureProject();
+			const emptied: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: [],
+					placements: [],
+					sections: [],
+					automation: [],
+				},
+				clips: [],
+			};
+			const projection = buildArrangementProjection(emptied);
+
+			expect(projection.rows).toEqual([]);
+			expect(projection.clips).toEqual([]);
+			expect(projection.placements).toEqual([]);
+			expect(projection.sections).toEqual([]);
+			expect(projection.totalRowHeight).toBe(0);
+			expect(projection.totalTicks).toBe(0);
+			expect(findRowAtOffset(projection, 0)).toBeNull();
+		});
+	});
+
+	describe("large fixtures", () => {
+		it("builds the full 50-track reference project", () => {
+			const project = createReferenceProject();
+			const projection = buildArrangementProjection(project);
+
+			expect(projection.rows).toHaveLength(50);
+			expect(projection.placements).toHaveLength(
+				project.song.placements.length,
+			);
+			expect(projection.automation).toHaveLength(100);
+			expect(projection.totalRowHeight).toBe(50 * 64);
+			// Every row's own track has placements queryable through the index.
+			for (const row of projection.rows) {
+				const forTrack = projection.placementsByTrack.get(row.id) ?? [];
+				for (let i = 1; i < forTrack.length; i += 1) {
+					expect(forTrack[i].startTicks).toBeGreaterThanOrEqual(
+						forTrack[i - 1].startTicks,
+					);
+				}
+			}
+		});
+	});
+});

--- a/src/projection/arrangementProjection.ts
+++ b/src/projection/arrangementProjection.ts
@@ -1,0 +1,477 @@
+import type {
+	AutomationLane,
+	AutomationTarget,
+	Project,
+	Track,
+} from "../domain/entities";
+import type {
+	AssetId,
+	AutomationId,
+	ClipId,
+	PlacementId,
+	SectionId,
+	TrackId,
+} from "../domain/ids";
+import { TICKS_PER_BAR, type Ticks, toTicks } from "../domain/time";
+import { fingerprintOf } from "./fingerprint";
+
+/**
+ * The arrangement renderer's read-only projection (PRD section 9.3).
+ *
+ * This is the "domain selector" the section describes: stable IDs, integer
+ * musical bounds, track order, colors, labels, compact clip/automation
+ * preview data, and revision counters "so unrelated edits do not invalidate
+ * all cached geometry." It does not do any of the *drawing* work section 9.3
+ * assigns to the Phase 2 renderer (`ARR-005`) or its Phase 0 spike
+ * (`FND-008`): no canvas layers, no viewport/zoom transform, no waveform
+ * peak pyramids, no LRU visual cache. What it gives that renderer is the data
+ * to draw from, plus the two lookups 9.3 calls out by name — a track row at a
+ * given pixel offset, and the placements/automation a track has in a tick
+ * range — so the renderer can do its own culling without walking the whole
+ * project on every frame.
+ *
+ * Row height is a placeholder the renderer overrides via `rowHeight` (default
+ * a fixed constant): actual row sizing, and whether a track is expanded, are
+ * viewport/UI concerns this projection does not model.
+ */
+
+const DEFAULT_ROW_HEIGHT = 64;
+
+export type ArrangementClipPreview =
+	| {
+			readonly kind: "notes";
+			readonly noteCount: number;
+			readonly minPitch: number | null;
+			readonly maxPitch: number | null;
+			/** Notes per bar, for a density sketch when zoomed too far to draw individual notes. */
+			readonly density: number;
+	  }
+	| {
+			readonly kind: "audioLoop";
+			readonly assetId: AssetId;
+			readonly sourceTempo: number;
+	  };
+
+export interface ArrangementClip {
+	readonly id: ClipId;
+	readonly trackId: TrackId;
+	readonly name: string;
+	readonly color: string;
+	readonly lengthTicks: Ticks;
+	readonly preview: ArrangementClipPreview;
+	readonly fingerprint: string;
+}
+
+export interface ArrangementPlacement {
+	readonly id: PlacementId;
+	readonly clipId: ClipId;
+	readonly trackId: TrackId;
+	readonly startTicks: Ticks;
+	readonly durationTicks: Ticks;
+	readonly endTicks: Ticks;
+	readonly clipOffsetTicks: Ticks;
+	readonly looped: boolean;
+	readonly fingerprint: string;
+}
+
+export interface ArrangementTrackRow {
+	readonly id: TrackId;
+	readonly name: string;
+	readonly color: string;
+	readonly order: number;
+	readonly type: Track["type"];
+	/** Index into `ArrangementProjection.rows`, i.e. visible position top-to-bottom. */
+	readonly rowIndex: number;
+	/** Pixel offset of this row's top edge — the "prefix sum" section 9.3 asks for. */
+	readonly rowTop: number;
+	readonly rowHeight: number;
+	readonly fingerprint: string;
+}
+
+export interface ArrangementSection {
+	readonly id: SectionId;
+	readonly name: string;
+	readonly color: string;
+	readonly startTicks: Ticks;
+	readonly durationTicks: Ticks;
+	readonly endTicks: Ticks;
+	readonly fingerprint: string;
+}
+
+export interface ArrangementAutomationLane {
+	readonly id: AutomationId;
+	readonly target: AutomationTarget;
+	readonly interpolation: AutomationLane["interpolation"];
+	readonly points: readonly AutomationLane["points"][number][];
+	readonly minValue: number;
+	readonly maxValue: number;
+	readonly fingerprint: string;
+}
+
+export interface ArrangementProjection {
+	readonly revision: number;
+	readonly tempo: number;
+	/** The end of the arrangement: the furthest placement or section end. */
+	readonly totalTicks: Ticks;
+	readonly totalRowHeight: number;
+	readonly rows: readonly ArrangementTrackRow[];
+	readonly rowsById: ReadonlyMap<TrackId, ArrangementTrackRow>;
+	readonly clips: readonly ArrangementClip[];
+	readonly clipsById: ReadonlyMap<ClipId, ArrangementClip>;
+	readonly placements: readonly ArrangementPlacement[];
+	readonly placementsById: ReadonlyMap<PlacementId, ArrangementPlacement>;
+	/** Every track's placements, sorted by `startTicks`, for range queries. */
+	readonly placementsByTrack: ReadonlyMap<
+		TrackId,
+		readonly ArrangementPlacement[]
+	>;
+	readonly sections: readonly ArrangementSection[];
+	readonly automation: readonly ArrangementAutomationLane[];
+	readonly automationByTrack: ReadonlyMap<
+		TrackId,
+		readonly ArrangementAutomationLane[]
+	>;
+}
+
+export interface BuildArrangementProjectionOptions {
+	/** Pixel height for one track's row. Defaults to a fixed constant. */
+	rowHeight?: (track: Track) => number;
+}
+
+function compareStrings(a: string, b: string): number {
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function clipPreviewShape(
+	clip: Project["clips"][number],
+): ArrangementClipPreview {
+	if (clip.content.kind === "audioLoop") {
+		return {
+			kind: "audioLoop",
+			assetId: clip.content.assetId,
+			sourceTempo: clip.content.sourceTempo,
+		};
+	}
+	const pitches = clip.content.events
+		.filter((event) => event.trigger.kind === "pitch")
+		.map((event) => (event.trigger as { kind: "pitch"; pitch: number }).pitch);
+	const bars = Math.max(1, clip.lengthTicks / TICKS_PER_BAR);
+	return {
+		kind: "notes",
+		noteCount: clip.content.events.length,
+		minPitch: pitches.length > 0 ? Math.min(...pitches) : null,
+		maxPitch: pitches.length > 0 ? Math.max(...pitches) : null,
+		density: clip.content.events.length / bars,
+	};
+}
+
+function buildClip(
+	clip: Project["clips"][number],
+	previous: ArrangementClip | undefined,
+): ArrangementClip {
+	const preview = clipPreviewShape(clip);
+	const shape = {
+		trackId: clip.trackId,
+		name: clip.name,
+		color: clip.color,
+		lengthTicks: clip.lengthTicks,
+		preview,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return {
+		id: clip.id,
+		trackId: clip.trackId,
+		name: clip.name,
+		color: clip.color,
+		lengthTicks: clip.lengthTicks,
+		preview,
+		fingerprint,
+	};
+}
+
+function buildPlacement(
+	placement: Project["song"]["placements"][number],
+	previous: ArrangementPlacement | undefined,
+): ArrangementPlacement {
+	const endTicks = toTicks(placement.startTicks + placement.durationTicks);
+	const shape = {
+		clipId: placement.clipId,
+		trackId: placement.trackId,
+		startTicks: placement.startTicks,
+		durationTicks: placement.durationTicks,
+		clipOffsetTicks: placement.clipOffsetTicks,
+		looped: placement.looped,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return {
+		id: placement.id,
+		clipId: placement.clipId,
+		trackId: placement.trackId,
+		startTicks: placement.startTicks,
+		durationTicks: placement.durationTicks,
+		endTicks,
+		clipOffsetTicks: placement.clipOffsetTicks,
+		looped: placement.looped,
+		fingerprint,
+	};
+}
+
+function buildSection(
+	section: Project["song"]["sections"][number],
+	previous: ArrangementSection | undefined,
+): ArrangementSection {
+	const endTicks = toTicks(section.startTicks + section.durationTicks);
+	const shape = {
+		name: section.name,
+		color: section.color,
+		startTicks: section.startTicks,
+		durationTicks: section.durationTicks,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return {
+		id: section.id,
+		name: section.name,
+		color: section.color,
+		startTicks: section.startTicks,
+		durationTicks: section.durationTicks,
+		endTicks,
+		fingerprint,
+	};
+}
+
+function buildAutomationLane(
+	lane: AutomationLane,
+	previous: ArrangementAutomationLane | undefined,
+): ArrangementAutomationLane {
+	const points = [...lane.points].sort((a, b) => a.tick - b.tick);
+	const values = points.map((point) => point.value);
+	const minValue = values.length > 0 ? Math.min(...values) : 0;
+	const maxValue = values.length > 0 ? Math.max(...values) : 0;
+	const shape = {
+		target: lane.target,
+		interpolation: lane.interpolation,
+		points,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return {
+		id: lane.id,
+		target: lane.target,
+		interpolation: lane.interpolation,
+		points,
+		minValue,
+		maxValue,
+		fingerprint,
+	};
+}
+
+function buildRow(
+	track: Track,
+	rowIndex: number,
+	rowTop: number,
+	rowHeight: number,
+	previous: ArrangementTrackRow | undefined,
+): ArrangementTrackRow {
+	const shape = {
+		name: track.name,
+		color: track.color,
+		order: track.order,
+		type: track.type,
+		rowIndex,
+		rowTop,
+		rowHeight,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return {
+		id: track.id,
+		name: track.name,
+		color: track.color,
+		order: track.order,
+		type: track.type,
+		rowIndex,
+		rowTop,
+		rowHeight,
+		fingerprint,
+	};
+}
+
+/**
+ * Builds (or incrementally rebuilds) the arrangement renderer's projection.
+ * Passing the previous projection as `previous` reuses every row, clip,
+ * placement, section, and automation-lane entry whose relevant fields have
+ * not changed, so a redraw driven by object identity does not repaint
+ * geometry for anything the edit did not touch.
+ */
+export function buildArrangementProjection(
+	project: Project,
+	previous?: ArrangementProjection,
+	options: BuildArrangementProjectionOptions = {},
+): ArrangementProjection {
+	const rowHeightOf = options.rowHeight ?? (() => DEFAULT_ROW_HEIGHT);
+
+	const orderedTracks = [...project.song.tracks].sort(
+		(a, b) => a.order - b.order || compareStrings(a.id, b.id),
+	);
+	let rowTop = 0;
+	const rows: ArrangementTrackRow[] = [];
+	for (const [rowIndex, track] of orderedTracks.entries()) {
+		const rowHeight = rowHeightOf(track);
+		rows.push(
+			buildRow(
+				track,
+				rowIndex,
+				rowTop,
+				rowHeight,
+				previous?.rowsById.get(track.id),
+			),
+		);
+		rowTop += rowHeight;
+	}
+	const totalRowHeight = rowTop;
+
+	const clips = [...project.clips]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((clip) => buildClip(clip, previous?.clipsById.get(clip.id)));
+
+	const previousPlacements = previous
+		? new Map(previous.placements.map((p) => [p.id, p]))
+		: undefined;
+	const placementsByTrack = new Map<TrackId, ArrangementPlacement[]>();
+	const placements = [...project.song.placements]
+		.sort((a, b) => a.startTicks - b.startTicks || compareStrings(a.id, b.id))
+		.map((placement) => {
+			const built = buildPlacement(
+				placement,
+				previousPlacements?.get(placement.id),
+			);
+			const forTrack = placementsByTrack.get(built.trackId) ?? [];
+			forTrack.push(built);
+			placementsByTrack.set(built.trackId, forTrack);
+			return built;
+		});
+
+	const previousSections = previous
+		? new Map(previous.sections.map((s) => [s.id, s]))
+		: undefined;
+	const sections = [...project.song.sections]
+		.sort((a, b) => a.startTicks - b.startTicks || compareStrings(a.id, b.id))
+		.map((section) => buildSection(section, previousSections?.get(section.id)));
+
+	const previousAutomation = previous
+		? new Map(previous.automation.map((lane) => [lane.id, lane]))
+		: undefined;
+	const automationByTrack = new Map<TrackId, ArrangementAutomationLane[]>();
+	const automation = [...project.song.automation]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((lane) => {
+			const built = buildAutomationLane(lane, previousAutomation?.get(lane.id));
+			if ("trackId" in lane.target) {
+				const forTrack = automationByTrack.get(lane.target.trackId) ?? [];
+				forTrack.push(built);
+				automationByTrack.set(lane.target.trackId, forTrack);
+			}
+			return built;
+		});
+
+	const totalTicks = toTicks(
+		Math.max(
+			0,
+			...placements.map((p) => p.endTicks),
+			...sections.map((s) => s.endTicks),
+		),
+	);
+
+	return {
+		revision: project.metadata.revision,
+		tempo: project.song.tempo,
+		totalTicks,
+		totalRowHeight,
+		rows,
+		rowsById: new Map(rows.map((row) => [row.id, row])),
+		clips,
+		clipsById: new Map(clips.map((clip) => [clip.id, clip])),
+		placements,
+		placementsById: new Map(placements.map((p) => [p.id, p])),
+		placementsByTrack,
+		sections,
+		automation,
+		automationByTrack,
+	};
+}
+
+/**
+ * Binary search for the row whose `[rowTop, rowTop + rowHeight)` span
+ * contains `offset` (e.g. a pointer Y coordinate translated into arrangement
+ * space). Returns `null` above the first row or at/below the last row's
+ * bottom edge. Works with variable row heights (e.g. an expanded track),
+ * since it searches the rows' actual prefix sums rather than assuming a
+ * uniform height.
+ */
+export function findRowAtOffset(
+	projection: ArrangementProjection,
+	offset: number,
+): ArrangementTrackRow | null {
+	const { rows } = projection;
+	if (offset < 0 || rows.length === 0 || offset >= projection.totalRowHeight) {
+		return null;
+	}
+	let low = 0;
+	let high = rows.length - 1;
+	while (low <= high) {
+		const mid = (low + high) >> 1;
+		const row = rows[mid];
+		if (offset < row.rowTop) {
+			high = mid - 1;
+		} else if (offset >= row.rowTop + row.rowHeight) {
+			low = mid + 1;
+		} else {
+			return row;
+		}
+	}
+	return null;
+}
+
+/**
+ * Placements on `trackId` whose span overlaps `[startTicks, endTicks)`. Uses
+ * the track's `startTicks`-sorted array (an upper-bound binary search cuts
+ * the scan to placements starting before the range ends, then a linear
+ * filter keeps only those that also end after the range starts) rather than
+ * scanning the whole project on every viewport change.
+ */
+export function queryPlacementsInRange(
+	projection: ArrangementProjection,
+	trackId: TrackId,
+	startTicks: number,
+	endTicks: number,
+): readonly ArrangementPlacement[] {
+	const forTrack = projection.placementsByTrack.get(trackId);
+	if (!forTrack || forTrack.length === 0) {
+		return [];
+	}
+	let low = 0;
+	let high = forTrack.length;
+	while (low < high) {
+		const mid = (low + high) >> 1;
+		if (forTrack[mid].startTicks < endTicks) {
+			low = mid + 1;
+		} else {
+			high = mid;
+		}
+	}
+	const candidates = forTrack.slice(0, low);
+	return candidates.filter((placement) => placement.endTicks > startTicks);
+}

--- a/src/projection/assistantContextProjection.test.ts
+++ b/src/projection/assistantContextProjection.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+	createReferenceProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import {
+	addToSelection,
+	emptySelection,
+	selectOnly,
+} from "../selection/selection";
+import {
+	buildAssistantContext,
+	summarizeSelection,
+} from "./assistantContextProjection";
+
+describe("buildAssistantContext", () => {
+	it("summarizes tracks, sections, and tempo compactly", () => {
+		const project = createSliceFixtureProject();
+		const context = buildAssistantContext(project);
+
+		expect(context.projectId).toBe(project.metadata.id);
+		expect(context.tempo).toBe(project.song.tempo);
+		expect(context.tracks).toHaveLength(1);
+		expect(context.tracks[0].name).toBe(project.song.tracks[0].name);
+		expect(context.tracks[0].clipCount).toBe(1);
+		expect(context.tracks[0].placementCount).toBe(1);
+		expect(context.selection).toBeNull();
+	});
+
+	it("never includes full per-note event data", () => {
+		const project = createSliceFixtureProject();
+		const context = buildAssistantContext(project);
+		const serialized = JSON.stringify(context);
+		// The fixture's note events use pitch 36; assert the context is compact
+		// enough that it does not embed a full per-event array (only counts).
+		expect(context.tracks[0]).not.toHaveProperty("clips");
+		expect(serialized.length).toBeLessThan(2000);
+	});
+
+	it("does not mutate the source project", () => {
+		const project = createSliceFixtureProject();
+		const before = JSON.parse(JSON.stringify(project));
+		buildAssistantContext(project);
+		expect(JSON.parse(JSON.stringify(project))).toEqual(before);
+	});
+
+	describe("selection summary", () => {
+		it("is null for an empty selection", () => {
+			const project = createSliceFixtureProject();
+			const context = buildAssistantContext(project, emptySelection());
+			expect(context.selection).toBeNull();
+		});
+
+		it("describes a single-track selection in words, not raw scopes", () => {
+			const project = createSliceFixtureProject();
+			const selection = selectOnly({
+				kind: "track",
+				id: project.song.tracks[0].id,
+			});
+			const context = buildAssistantContext(project, selection);
+			expect(context.selection?.description).toBe("1 track selected");
+			expect(context.selection?.countByKind).toEqual({ track: 1 });
+		});
+
+		it("describes a mixed multi-selection", () => {
+			const project = createSliceFixtureProject();
+			let selection = selectOnly({
+				kind: "track",
+				id: project.song.tracks[0].id,
+			});
+			selection = addToSelection(selection, {
+				kind: "placement",
+				id: project.song.placements[0].id,
+			});
+			selection = addToSelection(selection, {
+				kind: "clip",
+				id: project.clips[0].id,
+			});
+
+			const summary = summarizeSelection(selection);
+			expect(summary?.countByKind).toEqual({ track: 1, placement: 1, clip: 1 });
+			expect(summary?.description).toContain("1 track");
+			expect(summary?.description).toContain("1 clip");
+			expect(summary?.description).toContain("1 placement");
+		});
+
+		it("pluralizes counts greater than one", () => {
+			const project = createReferenceProject({
+				trackCount: 4,
+				placementCount: 8,
+			});
+			let selection = selectOnly({
+				kind: "track",
+				id: project.song.tracks[0].id,
+			});
+			selection = addToSelection(selection, {
+				kind: "track",
+				id: project.song.tracks[1].id,
+			});
+			const summary = summarizeSelection(selection);
+			expect(summary?.description).toBe("2 tracks selected");
+		});
+	});
+
+	describe("empty state", () => {
+		it("summarizes a project with no tracks or sections", () => {
+			const project = createSliceFixtureProject();
+			const emptied = {
+				...project,
+				song: { ...project.song, tracks: [], placements: [], sections: [] },
+				clips: [],
+			};
+			const context = buildAssistantContext(emptied);
+			expect(context.tracks).toEqual([]);
+			expect(context.sections).toEqual([]);
+			expect(context.totalTicks).toBe(0);
+		});
+	});
+
+	describe("large fixtures", () => {
+		it("summarizes the 50-track reference project", () => {
+			const project = createReferenceProject();
+			const context = buildAssistantContext(project);
+			expect(context.tracks).toHaveLength(50);
+			expect(context.sections).toHaveLength(4);
+		});
+	});
+});

--- a/src/projection/assistantContextProjection.ts
+++ b/src/projection/assistantContextProjection.ts
@@ -1,0 +1,159 @@
+import type { Instrument, Project, Track } from "../domain/entities";
+import type { SelectionScope, SelectionState } from "../selection/types";
+import { fingerprintOf } from "./fingerprint";
+
+/**
+ * The assistant's project context (PRD section 9.8).
+ *
+ * "Project analysis produces a compact, serializable context rather than
+ * sending the full persistence document by default." This is that compact
+ * context: track/section summaries and counts, never a full note-by-note
+ * clip dump, a Firestore document, or provider-specific objects. The current
+ * selection is folded in as a short human-readable description (never as the
+ * `SelectionScope` values verbatim), because a conversation turn or a
+ * selection change is, per the same PRD section, something the assistant
+ * reads about the user's intent, not a project mutation of its own.
+ */
+
+export interface AssistantTrackSummary {
+	readonly id: string;
+	readonly name: string;
+	readonly type: Track["type"];
+	readonly instrumentKind: Instrument["kind"] | null;
+	readonly deviceCount: number;
+	readonly muted: boolean;
+	readonly soloed: boolean;
+	readonly clipCount: number;
+	readonly placementCount: number;
+}
+
+export interface AssistantSectionSummary {
+	readonly id: string;
+	readonly name: string;
+	readonly startTicks: number;
+	readonly durationTicks: number;
+}
+
+export interface AssistantSelectionSummary {
+	/** A short human-readable description, e.g. "2 tracks and 1 placement selected". */
+	readonly description: string;
+	readonly countByKind: Readonly<
+		Partial<Record<SelectionScope["kind"], number>>
+	>;
+}
+
+export interface AssistantContext {
+	readonly projectId: string;
+	readonly projectName: string;
+	readonly tempo: number;
+	readonly timeSignature: Readonly<{ numerator: number; denominator: number }>;
+	readonly totalTicks: number;
+	readonly tracks: readonly AssistantTrackSummary[];
+	readonly sections: readonly AssistantSectionSummary[];
+	readonly selection: AssistantSelectionSummary | null;
+	readonly fingerprint: string;
+}
+
+function summarizeTrack(track: Track, project: Project): AssistantTrackSummary {
+	return {
+		id: track.id,
+		name: track.name,
+		type: track.type,
+		instrumentKind: track.instrument?.kind ?? null,
+		deviceCount: track.devices.length,
+		muted: track.mixer.muted,
+		soloed: track.mixer.soloed,
+		clipCount: project.clips.filter((clip) => clip.trackId === track.id).length,
+		placementCount: project.song.placements.filter(
+			(placement) => placement.trackId === track.id,
+		).length,
+	};
+}
+
+const SCOPE_KIND_LABELS: Record<
+	SelectionScope["kind"],
+	{ one: string; many: string }
+> = {
+	project: { one: "project", many: "projects" },
+	track: { one: "track", many: "tracks" },
+	clip: { one: "clip", many: "clips" },
+	placement: { one: "placement", many: "placements" },
+	event: { one: "note", many: "notes" },
+	section: { one: "section", many: "sections" },
+	device: { one: "device", many: "devices" },
+	automationPoint: { one: "automation point", many: "automation points" },
+	barRange: { one: "bar range", many: "bar ranges" },
+};
+
+/** A compact, human-readable summary of a selection: never the raw scopes. */
+export function summarizeSelection(
+	selection: SelectionState,
+): AssistantSelectionSummary | null {
+	if (selection.scopes.length === 0) {
+		return null;
+	}
+	const countByKind: Partial<Record<SelectionScope["kind"], number>> = {};
+	for (const scope of selection.scopes) {
+		countByKind[scope.kind] = (countByKind[scope.kind] ?? 0) + 1;
+	}
+	const parts = (
+		Object.entries(countByKind) as [SelectionScope["kind"], number][]
+	)
+		.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+		.map(([kind, count]) => {
+			const label = SCOPE_KIND_LABELS[kind];
+			return `${count} ${count === 1 ? label.one : label.many}`;
+		});
+	const description = `${parts.join(", ")} selected`;
+	return { description, countByKind };
+}
+
+/**
+ * Builds the assistant's project context. Pass the current `SelectionState`
+ * to fold in a compact description of what the user has selected.
+ */
+export function buildAssistantContext(
+	project: Project,
+	selection?: SelectionState,
+): AssistantContext {
+	const orderedTracks = [...project.song.tracks].sort(
+		(a, b) => a.order - b.order,
+	);
+	const tracks = orderedTracks.map((track) => summarizeTrack(track, project));
+	const sections = [...project.song.sections]
+		.sort((a, b) => a.startTicks - b.startTicks)
+		.map((section) => ({
+			id: section.id,
+			name: section.name,
+			startTicks: section.startTicks,
+			durationTicks: section.durationTicks,
+		}));
+	const totalTicks = Math.max(
+		0,
+		...project.song.placements.map((p) => p.startTicks + p.durationTicks),
+		...project.song.sections.map((s) => s.startTicks + s.durationTicks),
+	);
+	const selectionSummary = selection ? summarizeSelection(selection) : null;
+
+	const shape = {
+		projectName: project.metadata.name,
+		tempo: project.song.tempo,
+		timeSignature: project.song.timeSignature,
+		totalTicks,
+		tracks,
+		sections,
+		selection: selectionSummary,
+	};
+
+	return {
+		projectId: project.metadata.id,
+		projectName: project.metadata.name,
+		tempo: project.song.tempo,
+		timeSignature: project.song.timeSignature,
+		totalTicks,
+		tracks,
+		sections,
+		selection: selectionSummary,
+		fingerprint: fingerprintOf(shape),
+	};
+}

--- a/src/projection/audioProjection.test.ts
+++ b/src/projection/audioProjection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Project } from "../domain/entities";
+import { createFactoryContext, createReturnBus } from "../domain/factories";
 import {
 	createDrumMachineFixtureProject,
 	createReferenceProject,
@@ -13,6 +14,13 @@ function requireDefined<T>(value: T | undefined, message: string): T {
 		throw new Error(message);
 	}
 	return value;
+}
+
+/** A project with one return bus, so return-bus projection has something to test. */
+function withReturnBus(project: Project, seed: string): Project {
+	const context = createFactoryContext({ ids: createSeededIdFactory(seed) });
+	const bus = createReturnBus(context, { name: "Reverb", order: 0 });
+	return { ...project, song: { ...project.song, returns: [bus] } };
 }
 
 describe("buildAudioProjection", () => {
@@ -36,6 +44,25 @@ describe("buildAudioProjection", () => {
 		const projection = buildAudioProjection(project);
 		expect(projection.tracks[0]).not.toHaveProperty("name");
 		expect(projection.tracks[0]).not.toHaveProperty("color");
+	});
+
+	it("projects return buses with a fingerprint and no name, alongside the master bus", () => {
+		const project = withReturnBus(
+			createSliceFixtureProject(),
+			"audio-projection-returns",
+		);
+		const projection = buildAudioProjection(project);
+
+		expect(projection.returns).toHaveLength(1);
+		const returnBus = projection.returns[0];
+		expect(returnBus.id).toBe(project.song.returns[0].id);
+		expect(returnBus).not.toHaveProperty("name");
+		expect(typeof returnBus.fingerprint).toBe("string");
+		expect(typeof returnBus.topologyFingerprint).toBe("string");
+		expect(projection.returnsById.get(returnBus.id)).toBe(returnBus);
+
+		expect(typeof projection.master.fingerprint).toBe("string");
+		expect(typeof projection.master.topologyFingerprint).toBe("string");
 	});
 
 	it("does not mutate the source project", () => {
@@ -81,6 +108,33 @@ describe("buildAudioProjection", () => {
 			const after = buildAudioProjection(renamed, before);
 
 			expect(after.clips[0]).toBe(before.clips[0]);
+		});
+
+		it("keeps the same fingerprint, topologyFingerprint, and reference after a return bus rename", () => {
+			const project = withReturnBus(
+				createSliceFixtureProject(),
+				"audio-projection-return-rename",
+			);
+			const before = buildAudioProjection(project);
+
+			const renamed: Project = {
+				...project,
+				song: {
+					...project.song,
+					returns: project.song.returns.map((bus) => ({
+						...bus,
+						name: "Room",
+					})),
+				},
+			};
+			const after = buildAudioProjection(renamed, before);
+
+			expect(after.returns[0].fingerprint).toBe(before.returns[0].fingerprint);
+			expect(after.returns[0].topologyFingerprint).toBe(
+				before.returns[0].topologyFingerprint,
+			);
+			// Nothing audio-relevant changed, so the previous object is reused.
+			expect(after.returns[0]).toBe(before.returns[0]);
 		});
 	});
 
@@ -191,6 +245,70 @@ describe("buildAudioProjection", () => {
 			expect(afterTrack.topologyFingerprint).not.toBe(
 				beforeTrack.topologyFingerprint,
 			);
+		});
+
+		it("changes a return bus's topologyFingerprint when its device chain changes", () => {
+			const project = withReturnBus(
+				createSliceFixtureProject(),
+				"audio-projection-return-device",
+			);
+			const before = buildAudioProjection(project);
+
+			const deviceId = createSeededIdFactory("audio-projection-return-device")(
+				"device",
+			);
+			const edited: Project = {
+				...project,
+				song: {
+					...project.song,
+					returns: project.song.returns.map((bus) => ({
+						...bus,
+						devices: [
+							{
+								id: deviceId,
+								type: "filter",
+								order: 0,
+								bypassed: false,
+								parameters: {},
+								preset: null,
+							},
+						],
+					})),
+				},
+			};
+			const after = buildAudioProjection(edited, before);
+
+			expect(after.returns[0].topologyFingerprint).not.toBe(
+				before.returns[0].topologyFingerprint,
+			);
+		});
+
+		it("changes a return bus's fingerprint but not topologyFingerprint for a mixer volume edit", () => {
+			const project = withReturnBus(
+				createSliceFixtureProject(),
+				"audio-projection-return-mixer",
+			);
+			const before = buildAudioProjection(project);
+
+			const edited: Project = {
+				...project,
+				song: {
+					...project.song,
+					returns: project.song.returns.map((bus) => ({
+						...bus,
+						mixer: { ...bus.mixer, volume: -6 },
+					})),
+				},
+			};
+			const after = buildAudioProjection(edited, before);
+
+			expect(after.returns[0].topologyFingerprint).toBe(
+				before.returns[0].topologyFingerprint,
+			);
+			expect(after.returns[0].fingerprint).not.toBe(
+				before.returns[0].fingerprint,
+			);
+			expect(after.returns[0]).not.toBe(before.returns[0]);
 		});
 	});
 

--- a/src/projection/audioProjection.test.ts
+++ b/src/projection/audioProjection.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import type { Project } from "../domain/entities";
+import {
+	createDrumMachineFixtureProject,
+	createReferenceProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { createSeededIdFactory } from "../domain/ids";
+import { buildAudioProjection } from "./audioProjection";
+
+function requireDefined<T>(value: T | undefined, message: string): T {
+	if (value === undefined) {
+		throw new Error(message);
+	}
+	return value;
+}
+
+describe("buildAudioProjection", () => {
+	it("projects tempo, tracks, clips, and placements from the slice fixture", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildAudioProjection(project);
+
+		expect(projection.revision).toBe(project.metadata.revision);
+		expect(projection.tempo).toBe(project.song.tempo);
+		expect(projection.tracks).toHaveLength(1);
+		expect(projection.tracks[0].id).toBe(project.song.tracks[0].id);
+		expect(projection.tracksById.get(project.song.tracks[0].id)).toBe(
+			projection.tracks[0],
+		);
+		expect(projection.clips).toHaveLength(1);
+		expect(projection.placements).toHaveLength(1);
+	});
+
+	it("never carries a track name or color", () => {
+		const project = createSliceFixtureProject();
+		const projection = buildAudioProjection(project);
+		expect(projection.tracks[0]).not.toHaveProperty("name");
+		expect(projection.tracks[0]).not.toHaveProperty("color");
+	});
+
+	it("does not mutate the source project", () => {
+		const project = createSliceFixtureProject();
+		const before = JSON.parse(JSON.stringify(project));
+		buildAudioProjection(project);
+		expect(JSON.parse(JSON.stringify(project))).toEqual(before);
+	});
+
+	describe("renaming does not appear as an audio change", () => {
+		it("keeps the same fingerprint and topologyFingerprint after a track rename", () => {
+			const project = createSliceFixtureProject();
+			const before = buildAudioProjection(project);
+
+			const renamed: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track) => ({
+						...track,
+						name: "Renamed track",
+					})),
+				},
+			};
+			const after = buildAudioProjection(renamed, before);
+
+			expect(after.tracks[0].fingerprint).toBe(before.tracks[0].fingerprint);
+			expect(after.tracks[0].topologyFingerprint).toBe(
+				before.tracks[0].topologyFingerprint,
+			);
+			// Nothing audio-relevant changed, so the previous object is reused.
+			expect(after.tracks[0]).toBe(before.tracks[0]);
+		});
+
+		it("keeps the same fingerprint after a clip rename", () => {
+			const project = createSliceFixtureProject();
+			const before = buildAudioProjection(project);
+
+			const renamed: Project = {
+				...project,
+				clips: project.clips.map((clip) => ({ ...clip, name: "Renamed clip" })),
+			};
+			const after = buildAudioProjection(renamed, before);
+
+			expect(after.clips[0]).toBe(before.clips[0]);
+		});
+	});
+
+	describe("topology vs. parameter changes", () => {
+		it("changes fingerprint but not topologyFingerprint for a mixer volume edit", () => {
+			const project = createSliceFixtureProject();
+			const before = buildAudioProjection(project);
+
+			const edited: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track) => ({
+						...track,
+						mixer: { ...track.mixer, volume: -12 },
+					})),
+				},
+			};
+			const after = buildAudioProjection(edited, before);
+
+			expect(after.tracks[0].topologyFingerprint).toBe(
+				before.tracks[0].topologyFingerprint,
+			);
+			expect(after.tracks[0].fingerprint).not.toBe(
+				before.tracks[0].fingerprint,
+			);
+			expect(after.tracks[0]).not.toBe(before.tracks[0]);
+		});
+
+		it("changes topologyFingerprint when a device is added to the chain", () => {
+			const project = createSliceFixtureProject();
+			const before = buildAudioProjection(project);
+
+			const deviceId = createSeededIdFactory("audio-projection-device")(
+				"device",
+			);
+			const edited: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track) => ({
+						...track,
+						devices: [
+							{
+								id: deviceId,
+								type: "filter",
+								order: 0,
+								bypassed: false,
+								parameters: {},
+								preset: null,
+							},
+						],
+					})),
+				},
+			};
+			const after = buildAudioProjection(edited, before);
+
+			expect(after.tracks[0].topologyFingerprint).not.toBe(
+				before.tracks[0].topologyFingerprint,
+			);
+		});
+
+		it("changes topologyFingerprint when a sampler's asset is swapped", () => {
+			const drumMachineProject = createDrumMachineFixtureProject();
+			const before = buildAudioProjection(drumMachineProject);
+			const samplerTrack = requireDefined(
+				drumMachineProject.song.tracks.find(
+					(track) => track.instrument?.kind === "drumMachine",
+				),
+				"expected the drum-machine fixture to have a drumMachine track",
+			);
+
+			const edited: Project = {
+				...drumMachineProject,
+				song: {
+					...drumMachineProject.song,
+					tracks: drumMachineProject.song.tracks.map((track) =>
+						track.id === samplerTrack.id &&
+						track.instrument?.kind === "drumMachine"
+							? {
+									...track,
+									instrument: {
+										...track.instrument,
+										pads: track.instrument.pads.map((pad, index) =>
+											index === 0
+												? {
+														...pad,
+														assetId: drumMachineProject.song.assets[1].id,
+													}
+												: pad,
+										),
+									},
+								}
+							: track,
+					),
+				},
+			};
+
+			const after = buildAudioProjection(edited, before);
+			const beforeTrack = requireDefined(
+				before.tracksById.get(samplerTrack.id),
+				"expected the sampler track to be projected",
+			);
+			const afterTrack = requireDefined(
+				after.tracksById.get(samplerTrack.id),
+				"expected the sampler track to be projected",
+			);
+			expect(afterTrack.topologyFingerprint).not.toBe(
+				beforeTrack.topologyFingerprint,
+			);
+		});
+	});
+
+	describe("referential stability for unchanged entities", () => {
+		it("reuses every track projection when nothing changed", () => {
+			const project = createReferenceProject({
+				trackCount: 8,
+				placementCount: 16,
+			});
+			const before = buildAudioProjection(project);
+			const after = buildAudioProjection(project, before);
+
+			expect(after.tracks).toHaveLength(before.tracks.length);
+			for (let index = 0; index < before.tracks.length; index += 1) {
+				expect(after.tracks[index]).toBe(before.tracks[index]);
+			}
+			expect(after.clips.every((clip, i) => clip === before.clips[i])).toBe(
+				true,
+			);
+			expect(after.placements.every((p, i) => p === before.placements[i])).toBe(
+				true,
+			);
+			expect(
+				after.automation.every((lane, i) => lane === before.automation[i]),
+			).toBe(true);
+		});
+
+		it("reuses unrelated track projections when only one track changes", () => {
+			const project = createReferenceProject({
+				trackCount: 6,
+				placementCount: 12,
+			});
+			const before = buildAudioProjection(project);
+			const [changedTrack, ...untouched] = project.song.tracks;
+
+			const edited: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track) =>
+						track.id === changedTrack.id
+							? { ...track, mixer: { ...track.mixer, volume: -20 } }
+							: track,
+					),
+				},
+			};
+			const after = buildAudioProjection(edited, before);
+
+			expect(after.tracksById.get(changedTrack.id)).not.toBe(
+				before.tracksById.get(changedTrack.id),
+			);
+			for (const track of untouched) {
+				expect(after.tracksById.get(track.id)).toBe(
+					before.tracksById.get(track.id),
+				);
+			}
+		});
+	});
+
+	describe("empty state", () => {
+		it("projects an empty tempo-only project without error", () => {
+			const project = createSliceFixtureProject();
+			const emptied: Project = {
+				...project,
+				song: { ...project.song, tracks: [], placements: [], automation: [] },
+				clips: [],
+			};
+			const projection = buildAudioProjection(emptied);
+			expect(projection.tracks).toEqual([]);
+			expect(projection.clips).toEqual([]);
+			expect(projection.placements).toEqual([]);
+			expect(projection.tracksById.size).toBe(0);
+		});
+	});
+
+	describe("large fixtures", () => {
+		it("builds the full 50-track reference project", () => {
+			const project = createReferenceProject();
+			const projection = buildAudioProjection(project);
+			expect(projection.tracks).toHaveLength(50);
+			expect(projection.placements).toHaveLength(
+				project.song.placements.length,
+			);
+			expect(projection.automation).toHaveLength(100);
+		});
+	});
+});

--- a/src/projection/audioProjection.ts
+++ b/src/projection/audioProjection.ts
@@ -18,6 +18,7 @@ import type {
 	AutomationId,
 	ClipId,
 	PlacementId,
+	ReturnId,
 	TrackId,
 } from "../domain/ids";
 import type { Ticks } from "../domain/time";
@@ -39,10 +40,11 @@ import { fingerprintOf } from "./fingerprint";
  * exact same entry object — a track whose `fingerprint` has not changed comes
  * back as the identical reference, so a consumer that keys its own resources
  * off object identity (or does a `===` check before doing any work) never
- * sees a track it did not actually change. Renaming a track or clip changes
- * neither `fingerprint` nor `topologyFingerprint` on this projection, because
- * `name`/`color` never appear in it at all — by construction, a rename
- * cannot look like an audio change, topology or otherwise.
+ * sees a track it did not actually change. Renaming a track, clip, or return
+ * bus changes neither `fingerprint` nor `topologyFingerprint` on this
+ * projection, because `name`/`color` never appear in it at all — by
+ * construction, a rename cannot look like an audio change, topology or
+ * otherwise.
  */
 
 export interface AudioTrackProjection {
@@ -62,6 +64,23 @@ export interface AudioTrackProjection {
 	 * pre- or post-fader. Continuous values (mixer volume/pan, device
 	 * parameters, send levels, device bypass) are excluded, since those update
 	 * an existing node rather than reshape the graph.
+	 */
+	readonly topologyFingerprint: string;
+}
+
+export interface AudioReturnProjection {
+	readonly id: ReturnId;
+	readonly order: number;
+	/** Ordered by chain position (the `order` field), not array insertion order. */
+	readonly devices: readonly Device[];
+	readonly mixer: ReturnBus["mixer"];
+	/** Changes for any audio-relevant edit to this return bus. */
+	readonly fingerprint: string;
+	/**
+	 * Changes only when the return bus's node graph *shape* would need to
+	 * change: device chain composition and order. Continuous values (mixer
+	 * volume/pan/muted, device parameters, device bypass) are excluded, since
+	 * those update an existing node rather than reshape the graph.
 	 */
 	readonly topologyFingerprint: string;
 }
@@ -104,13 +123,24 @@ export interface AudioAssetProjection {
 	readonly fingerprint: string;
 }
 
+export interface AudioMasterProjection {
+	readonly volume: MasterSettings["volume"];
+	/** Ordered by chain position (the `order` field), not array insertion order. */
+	readonly devices: readonly Device[];
+	/** Changes for any audio-relevant edit to the master bus. */
+	readonly fingerprint: string;
+	/** Changes only when the master device chain's composition or order changes. */
+	readonly topologyFingerprint: string;
+}
+
 export interface AudioSongProjection {
 	/** The project's own revision counter — the real, stored "song" granularity. */
 	readonly revision: number;
 	readonly tempo: number;
 	readonly timeSignature: Readonly<{ numerator: number; denominator: number }>;
-	readonly master: MasterSettings;
-	readonly returns: readonly ReturnBus[];
+	readonly master: AudioMasterProjection;
+	readonly returns: readonly AudioReturnProjection[];
+	readonly returnsById: ReadonlyMap<ReturnId, AudioReturnProjection>;
 	readonly tracks: readonly AudioTrackProjection[];
 	readonly tracksById: ReadonlyMap<TrackId, AudioTrackProjection>;
 	readonly clips: readonly AudioClipProjection[];
@@ -220,6 +250,84 @@ function buildAudioTrack(
 	};
 }
 
+function returnTopologyShape(devices: readonly Device[]): unknown {
+	return {
+		devices: devices.map((device) => ({ id: device.id, type: device.type })),
+	};
+}
+
+function returnFullShape(
+	order: number,
+	devices: readonly Device[],
+	mixer: ReturnBus["mixer"],
+): unknown {
+	return {
+		order,
+		topology: returnTopologyShape(devices),
+		devices: devices.map((device) => ({
+			id: device.id,
+			bypassed: device.bypassed,
+			parameters: device.parameters,
+		})),
+		mixer,
+	};
+}
+
+function buildAudioReturn(
+	bus: ReturnBus,
+	previous: AudioReturnProjection | undefined,
+): AudioReturnProjection {
+	const devices = sortDevices(bus.devices);
+	const topologyFingerprint = fingerprintOf(returnTopologyShape(devices));
+	const fingerprint = fingerprintOf(
+		returnFullShape(bus.order, devices, bus.mixer),
+	);
+	if (
+		previous &&
+		previous.fingerprint === fingerprint &&
+		previous.topologyFingerprint === topologyFingerprint
+	) {
+		return previous;
+	}
+	return {
+		id: bus.id,
+		order: bus.order,
+		devices,
+		mixer: bus.mixer,
+		fingerprint,
+		topologyFingerprint,
+	};
+}
+
+function buildAudioMaster(
+	master: MasterSettings,
+	previous: AudioMasterProjection | undefined,
+): AudioMasterProjection {
+	const devices = sortDevices(master.devices);
+	const topologyFingerprint = fingerprintOf(returnTopologyShape(devices));
+	const fingerprint = fingerprintOf({
+		volume: master.volume,
+		devices: devices.map((device) => ({
+			id: device.id,
+			bypassed: device.bypassed,
+			parameters: device.parameters,
+		})),
+	});
+	if (
+		previous &&
+		previous.fingerprint === fingerprint &&
+		previous.topologyFingerprint === topologyFingerprint
+	) {
+		return previous;
+	}
+	return {
+		volume: master.volume,
+		devices,
+		fingerprint,
+		topologyFingerprint,
+	};
+}
+
 function buildAudioClip(
 	clip: Project["clips"][number],
 	previous: AudioClipProjection | undefined,
@@ -317,6 +425,12 @@ export function buildAudioProjection(
 		.sort((a, b) => compareStrings(a.id, b.id))
 		.map((track) => buildAudioTrack(track, previous?.tracksById.get(track.id)));
 
+	const returns = [...project.song.returns]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((bus) => buildAudioReturn(bus, previous?.returnsById.get(bus.id)));
+
+	const master = buildAudioMaster(project.song.master, previous?.master);
+
 	const clips = [...project.clips]
 		.sort((a, b) => compareStrings(a.id, b.id))
 		.map((clip) => buildAudioClip(clip, previous?.clipsById.get(clip.id)));
@@ -350,8 +464,9 @@ export function buildAudioProjection(
 		revision: project.metadata.revision,
 		tempo: project.song.tempo,
 		timeSignature: project.song.timeSignature,
-		master: project.song.master,
-		returns: project.song.returns,
+		master,
+		returns,
+		returnsById: new Map(returns.map((bus) => [bus.id, bus])),
 		tracks,
 		tracksById: new Map(tracks.map((track) => [track.id, track])),
 		clips,

--- a/src/projection/audioProjection.ts
+++ b/src/projection/audioProjection.ts
@@ -1,0 +1,363 @@
+import type {
+	AutomationLane,
+	AutomationPoint,
+	AutomationTarget,
+	ClipContent,
+	Device,
+	Instrument,
+	MasterSettings,
+	Placement,
+	Project,
+	ReturnBus,
+	Send,
+	Track,
+	TrackMixer,
+} from "../domain/entities";
+import type {
+	AssetId,
+	AutomationId,
+	ClipId,
+	PlacementId,
+	TrackId,
+} from "../domain/ids";
+import type { Ticks } from "../domain/time";
+import { fingerprintOf } from "./fingerprint";
+
+/**
+ * The audio engine's read-only song projection (PRD section 9.7).
+ *
+ * `buildAudioProjection` never mutates the `Project` it reads, and its output
+ * carries only what a `ProjectAudioGraph` needs to build or reconcile Tone
+ * nodes: no `name`, `color`, UI selection, viewport, or assistant state can
+ * reach it, because those fields simply are not part of this shape (`FND-006`
+ * and `FND-007` build the runtime that consumes this; this task owns the
+ * projection they will read).
+ *
+ * Every entry carries a `fingerprint`: a deterministic digest of exactly the
+ * fields this projection exposes for that entity (see `fingerprint.ts`).
+ * Passing the previous build as `previous` lets unrelated edits reuse the
+ * exact same entry object — a track whose `fingerprint` has not changed comes
+ * back as the identical reference, so a consumer that keys its own resources
+ * off object identity (or does a `===` check before doing any work) never
+ * sees a track it did not actually change. Renaming a track or clip changes
+ * neither `fingerprint` nor `topologyFingerprint` on this projection, because
+ * `name`/`color` never appear in it at all — by construction, a rename
+ * cannot look like an audio change, topology or otherwise.
+ */
+
+export interface AudioTrackProjection {
+	readonly id: TrackId;
+	readonly type: Track["type"];
+	readonly instrument: Instrument | null;
+	/** Ordered by chain position (the `order` field), not array insertion order. */
+	readonly devices: readonly Device[];
+	readonly sendConfig: readonly Send[];
+	readonly mixer: TrackMixer;
+	/** Changes for any audio-relevant edit to this track. */
+	readonly fingerprint: string;
+	/**
+	 * Changes only when the node graph's *shape* would need to change: track
+	 * type, instrument kind/asset, drum pad identity, device chain composition
+	 * and order, or which return buses a send targets and whether it taps
+	 * pre- or post-fader. Continuous values (mixer volume/pan, device
+	 * parameters, send levels, device bypass) are excluded, since those update
+	 * an existing node rather than reshape the graph.
+	 */
+	readonly topologyFingerprint: string;
+}
+
+export interface AudioClipProjection {
+	readonly id: ClipId;
+	readonly trackId: TrackId;
+	readonly lengthTicks: Ticks;
+	readonly content: ClipContent;
+	readonly fingerprint: string;
+}
+
+export interface AudioPlacementProjection {
+	readonly id: PlacementId;
+	readonly clipId: ClipId;
+	readonly trackId: TrackId;
+	readonly startTicks: Ticks;
+	readonly durationTicks: Ticks;
+	readonly clipOffsetTicks: Ticks;
+	readonly looped: boolean;
+	readonly fingerprint: string;
+}
+
+export interface AudioAutomationProjection {
+	readonly id: AutomationId;
+	readonly target: AutomationTarget;
+	readonly interpolation: AutomationLane["interpolation"];
+	readonly points: readonly AutomationPoint[];
+	readonly fingerprint: string;
+}
+
+export interface AudioAssetProjection {
+	readonly id: AssetId;
+	readonly kind: string;
+	readonly storageRef: string;
+	readonly url: string | null;
+	readonly durationSeconds: number | null;
+	readonly sampleRate: number | null;
+	readonly channelCount: number | null;
+	readonly fingerprint: string;
+}
+
+export interface AudioSongProjection {
+	/** The project's own revision counter — the real, stored "song" granularity. */
+	readonly revision: number;
+	readonly tempo: number;
+	readonly timeSignature: Readonly<{ numerator: number; denominator: number }>;
+	readonly master: MasterSettings;
+	readonly returns: readonly ReturnBus[];
+	readonly tracks: readonly AudioTrackProjection[];
+	readonly tracksById: ReadonlyMap<TrackId, AudioTrackProjection>;
+	readonly clips: readonly AudioClipProjection[];
+	readonly clipsById: ReadonlyMap<ClipId, AudioClipProjection>;
+	readonly placements: readonly AudioPlacementProjection[];
+	readonly automation: readonly AudioAutomationProjection[];
+	readonly assets: readonly AudioAssetProjection[];
+}
+
+function compareStrings(a: string, b: string): number {
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function sortDevices(devices: readonly Device[]): Device[] {
+	return [...devices].sort(
+		(a, b) => a.order - b.order || compareStrings(a.id, b.id),
+	);
+}
+
+function sortSends(sendConfig: readonly Send[]): Send[] {
+	return [...sendConfig].sort((a, b) => compareStrings(a.returnId, b.returnId));
+}
+
+function instrumentTopologyShape(instrument: Instrument | null): unknown {
+	if (!instrument) return null;
+	switch (instrument.kind) {
+		case "sampler":
+			return { kind: instrument.kind, assetId: instrument.assetId };
+		case "synth":
+			return { kind: instrument.kind };
+		case "drumMachine":
+			return {
+				kind: instrument.kind,
+				pads: [...instrument.pads]
+					.map((pad) => ({ id: pad.id, assetId: pad.assetId }))
+					.sort((a, b) => compareStrings(a.id, b.id)),
+			};
+	}
+}
+
+function trackTopologyShape(track: Track, devices: readonly Device[]): unknown {
+	return {
+		type: track.type,
+		instrument: instrumentTopologyShape(track.instrument),
+		devices: devices.map((device) => ({ id: device.id, type: device.type })),
+		sends: sortSends(track.sendConfig).map((send) => ({
+			returnId: send.returnId,
+			preFader: send.preFader,
+		})),
+	};
+}
+
+function trackFullShape(track: Track, devices: readonly Device[]): unknown {
+	return {
+		topology: trackTopologyShape(track, devices),
+		devices: devices.map((device) => ({
+			id: device.id,
+			bypassed: device.bypassed,
+			parameters: device.parameters,
+		})),
+		sends: sortSends(track.sendConfig).map((send) => ({
+			returnId: send.returnId,
+			level: send.level,
+			preFader: send.preFader,
+		})),
+		instrumentParameters:
+			track.instrument?.kind === "drumMachine"
+				? {
+						parameters: track.instrument.parameters,
+						pads: [...track.instrument.pads]
+							.map((pad) => ({
+								id: pad.id,
+								chokeGroup: pad.chokeGroup,
+								parameters: pad.parameters,
+								mixer: pad.mixer,
+							}))
+							.sort((a, b) => compareStrings(a.id, b.id)),
+					}
+				: (track.instrument?.parameters ?? null),
+		mixer: track.mixer,
+	};
+}
+
+function buildAudioTrack(
+	track: Track,
+	previous: AudioTrackProjection | undefined,
+): AudioTrackProjection {
+	const devices = sortDevices(track.devices);
+	const topologyFingerprint = fingerprintOf(trackTopologyShape(track, devices));
+	const fingerprint = fingerprintOf(trackFullShape(track, devices));
+	if (
+		previous &&
+		previous.fingerprint === fingerprint &&
+		previous.topologyFingerprint === topologyFingerprint
+	) {
+		return previous;
+	}
+	return {
+		id: track.id,
+		type: track.type,
+		instrument: track.instrument,
+		devices,
+		sendConfig: sortSends(track.sendConfig),
+		mixer: track.mixer,
+		fingerprint,
+		topologyFingerprint,
+	};
+}
+
+function buildAudioClip(
+	clip: Project["clips"][number],
+	previous: AudioClipProjection | undefined,
+): AudioClipProjection {
+	const shape = {
+		trackId: clip.trackId,
+		lengthTicks: clip.lengthTicks,
+		content: clip.content,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return {
+		id: clip.id,
+		trackId: clip.trackId,
+		lengthTicks: clip.lengthTicks,
+		content: clip.content,
+		fingerprint,
+	};
+}
+
+function buildAudioPlacement(
+	placement: Placement,
+	previous: AudioPlacementProjection | undefined,
+): AudioPlacementProjection {
+	const shape = {
+		clipId: placement.clipId,
+		trackId: placement.trackId,
+		startTicks: placement.startTicks,
+		durationTicks: placement.durationTicks,
+		clipOffsetTicks: placement.clipOffsetTicks,
+		looped: placement.looped,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return { id: placement.id, ...shape, fingerprint };
+}
+
+function buildAudioAutomation(
+	lane: AutomationLane,
+	previous: AudioAutomationProjection | undefined,
+): AudioAutomationProjection {
+	const points = [...lane.points].sort((a, b) => a.tick - b.tick);
+	const shape = {
+		target: lane.target,
+		interpolation: lane.interpolation,
+		points,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return {
+		id: lane.id,
+		target: lane.target,
+		interpolation: lane.interpolation,
+		points,
+		fingerprint,
+	};
+}
+
+function buildAudioAsset(
+	asset: Project["song"]["assets"][number],
+	previous: AudioAssetProjection | undefined,
+): AudioAssetProjection {
+	const shape = {
+		kind: asset.kind,
+		storageRef: asset.storageRef,
+		url: asset.url,
+		durationSeconds: asset.durationSeconds,
+		sampleRate: asset.sampleRate,
+		channelCount: asset.channelCount,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (previous && previous.fingerprint === fingerprint) {
+		return previous;
+	}
+	return { id: asset.id, ...shape, fingerprint };
+}
+
+/**
+ * Builds (or incrementally rebuilds) the audio engine's song projection.
+ * Passing the previous projection as `previous` reuses every entry whose
+ * relevant fields have not changed, so unrelated edits do not appear as an
+ * audio change to anything downstream that compares object identity.
+ */
+export function buildAudioProjection(
+	project: Project,
+	previous?: AudioSongProjection,
+): AudioSongProjection {
+	const tracks = [...project.song.tracks]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((track) => buildAudioTrack(track, previous?.tracksById.get(track.id)));
+
+	const clips = [...project.clips]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((clip) => buildAudioClip(clip, previous?.clipsById.get(clip.id)));
+
+	const previousPlacements = previous
+		? new Map(previous.placements.map((p) => [p.id, p]))
+		: undefined;
+	const placements = [...project.song.placements]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((placement) =>
+			buildAudioPlacement(placement, previousPlacements?.get(placement.id)),
+		);
+
+	const previousAutomation = previous
+		? new Map(previous.automation.map((lane) => [lane.id, lane]))
+		: undefined;
+	const automation = [...project.song.automation]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((lane) =>
+			buildAudioAutomation(lane, previousAutomation?.get(lane.id)),
+		);
+
+	const previousAssets = previous
+		? new Map(previous.assets.map((asset) => [asset.id, asset]))
+		: undefined;
+	const assets = [...project.song.assets]
+		.sort((a, b) => compareStrings(a.id, b.id))
+		.map((asset) => buildAudioAsset(asset, previousAssets?.get(asset.id)));
+
+	return {
+		revision: project.metadata.revision,
+		tempo: project.song.tempo,
+		timeSignature: project.song.timeSignature,
+		master: project.song.master,
+		returns: project.song.returns,
+		tracks,
+		tracksById: new Map(tracks.map((track) => [track.id, track])),
+		clips,
+		clipsById: new Map(clips.map((clip) => [clip.id, clip])),
+		placements,
+		automation,
+		assets,
+	};
+}

--- a/src/projection/boundaries.test.ts
+++ b/src/projection/boundaries.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every projection is a pure function of a `Project` (PRD sections 9.2,
+ * 9.7-9.8): the audio engine, the arrangement renderer, a dashboard list, and
+ * the assistant each read one of these instead of Firebase, Tone.js, or
+ * SolidJS state directly. None of these modules needs any of those imports.
+ */
+
+const projectionDirectory = join(process.cwd(), "src", "projection");
+
+const FORBIDDEN_IMPORTS = [
+	"firebase",
+	"solid-js",
+	"@solidjs/",
+	"tone",
+	"vitest",
+];
+
+function sourceFiles(): string[] {
+	return readdirSync(projectionDirectory).filter(
+		(file) => file.endsWith(".ts") && !file.endsWith(".test.ts"),
+	);
+}
+
+describe("projection boundaries", () => {
+	it("has source files to check", () => {
+		expect(sourceFiles().length).toBeGreaterThan(3);
+	});
+
+	it("imports no Firebase, Tone, Solid, or test-framework module", () => {
+		for (const file of sourceFiles()) {
+			const source = readFileSync(join(projectionDirectory, file), "utf8");
+			const imports = [...source.matchAll(/from\s+"([^"]+)"/g)].map(
+				(match) => match[1],
+			);
+			for (const specifier of imports) {
+				for (const forbidden of FORBIDDEN_IMPORTS) {
+					expect(
+						specifier.startsWith(forbidden),
+						`${file} imports "${specifier}"`,
+					).toBe(false);
+				}
+			}
+		}
+	});
+});

--- a/src/projection/fingerprint.test.ts
+++ b/src/projection/fingerprint.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { fingerprintOf, stableStringify } from "./fingerprint";
+
+describe("stableStringify", () => {
+	it("is independent of object key order", () => {
+		expect(stableStringify({ a: 1, b: 2 })).toBe(
+			stableStringify({ b: 2, a: 1 }),
+		);
+	});
+
+	it("sorts keys at every nesting depth", () => {
+		expect(stableStringify({ z: { b: 1, a: 2 }, a: 1 })).toBe(
+			'{"a":1,"z":{"a":2,"b":1}}',
+		);
+	});
+
+	it("preserves array order", () => {
+		expect(stableStringify([3, 1, 2])).toBe("[3,1,2]");
+		expect(stableStringify([1, 2, 3])).not.toBe(stableStringify([3, 2, 1]));
+	});
+});
+
+describe("fingerprintOf", () => {
+	it("is deterministic for equal input", () => {
+		const a = { name: "Lead", volume: -6, devices: [1, 2] };
+		const b = { volume: -6, name: "Lead", devices: [1, 2] };
+		expect(fingerprintOf(a)).toBe(fingerprintOf(b));
+	});
+
+	it("changes when a relevant field changes", () => {
+		const a = fingerprintOf({ volume: -6 });
+		const b = fingerprintOf({ volume: -3 });
+		expect(a).not.toBe(b);
+	});
+});

--- a/src/projection/fingerprint.ts
+++ b/src/projection/fingerprint.ts
@@ -1,0 +1,57 @@
+/**
+ * Content fingerprints for change detection (PRD section 9.3: "The projection
+ * exposes revision counters at song, track, clip, asset, and automation
+ * granularity so unrelated edits do not invalidate all cached geometry").
+ *
+ * Schema-v1 (`src/domain`) has one project-wide revision counter
+ * (`metadata.revision`) and deliberately no per-track/per-clip counters —
+ * adding those would be a domain-schema change, which is FND-002's contract,
+ * not incidental work for this task. A deterministic content fingerprint
+ * gives every projection the same guarantee (unrelated edits produce the same
+ * fingerprint; any relevant edit produces a different one) without touching
+ * the stored schema: two calls fingerprinting the same relevant fields always
+ * agree, so a projection builder can compare a fingerprint against the
+ * previous build and reuse the previous object when they match.
+ */
+
+/**
+ * Stable JSON text for a plain value: object keys are written in sorted
+ * order at every nesting depth regardless of insertion order, so two
+ * structurally-equal values always produce byte-identical text. Arrays are
+ * written in the given order — a caller with an order-insensitive collection
+ * (e.g. a device chain that should be compared by an `order` field rather
+ * than array position) must sort it before calling this.
+ */
+export function stableStringify(value: unknown): string {
+	return JSON.stringify(value, sortObjectKeys);
+}
+
+function sortObjectKeys(_key: string, value: unknown): unknown {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return value;
+	}
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+		sorted[key] = (value as Record<string, unknown>)[key];
+	}
+	return sorted;
+}
+
+/** FNV-1a, 32-bit. Not cryptographic — only used to shorten a fingerprint key. */
+function fnv1a(text: string): number {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < text.length; index += 1) {
+		hash ^= text.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return hash >>> 0;
+}
+
+/**
+ * A short, deterministic fingerprint for `value`. Equal relevant fields
+ * always produce an equal fingerprint; this is the "revision/change
+ * information" every projection in this module exposes.
+ */
+export function fingerprintOf(value: unknown): string {
+	return fnv1a(stableStringify(value)).toString(36);
+}

--- a/src/projection/index.ts
+++ b/src/projection/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Read-only consumer projections (PRD sections 9.2-9.3, 9.7-9.8).
+ *
+ * Every projection here is a pure function of a `Project` (and, for the
+ * assistant context, the current `SelectionState`): none of them can mutate
+ * canonical state, and none of them read Firebase, Tone.js, or SolidJS types.
+ * Passing a projection's own previous build back in lets it reuse entries
+ * whose relevant fields have not changed, so an edit to one entity does not
+ * look like a change to every other entity a consumer is holding onto.
+ */
+
+export * from "./arrangementProjection";
+export * from "./assistantContextProjection";
+export * from "./audioProjection";
+export * from "./fingerprint";
+export * from "./projectSummaryProjection";

--- a/src/projection/projectSummaryProjection.test.ts
+++ b/src/projection/projectSummaryProjection.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { Project } from "../domain/entities";
+import {
+	createReferenceProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { buildProjectSummaryProjection } from "./projectSummaryProjection";
+
+describe("buildProjectSummaryProjection", () => {
+	it("summarizes metadata and counts without needing clip content", () => {
+		const project = createSliceFixtureProject();
+		const summary = buildProjectSummaryProjection(project);
+
+		expect(summary.id).toBe(project.metadata.id);
+		expect(summary.name).toBe(project.metadata.name);
+		expect(summary.ownerId).toBe(project.metadata.ownerId);
+		expect(summary.trackCount).toBe(1);
+		expect(summary.clipCount).toBe(1);
+		expect(summary.placementCount).toBe(1);
+	});
+
+	it("does not mutate the source project", () => {
+		const project = createSliceFixtureProject();
+		const before = JSON.parse(JSON.stringify(project));
+		buildProjectSummaryProjection(project);
+		expect(JSON.parse(JSON.stringify(project))).toEqual(before);
+	});
+
+	describe("referential stability", () => {
+		it("reuses the previous summary when nothing summarized changed", () => {
+			const project = createSliceFixtureProject();
+			const before = buildProjectSummaryProjection(project);
+			const after = buildProjectSummaryProjection(project, before);
+			expect(after).toBe(before);
+		});
+
+		it("rebuilds when the project name changes", () => {
+			const project = createSliceFixtureProject();
+			const before = buildProjectSummaryProjection(project);
+
+			const renamed: Project = {
+				...project,
+				metadata: { ...project.metadata, name: "New name" },
+			};
+			const after = buildProjectSummaryProjection(renamed, before);
+
+			expect(after).not.toBe(before);
+			expect(after.name).toBe("New name");
+		});
+
+		it("does not rebuild for an unrelated song edit that changes no summarized field", () => {
+			const project = createSliceFixtureProject();
+			const before = buildProjectSummaryProjection(project);
+
+			const edited: Project = {
+				...project,
+				song: {
+					...project.song,
+					tracks: project.song.tracks.map((track) => ({
+						...track,
+						mixer: { ...track.mixer, volume: -6 },
+					})),
+				},
+			};
+			const after = buildProjectSummaryProjection(edited, before);
+
+			expect(after).toBe(before);
+		});
+	});
+
+	describe("empty state", () => {
+		it("summarizes a project with no tracks, clips, or placements", () => {
+			const project = createSliceFixtureProject();
+			const emptied: Project = {
+				...project,
+				song: { ...project.song, tracks: [], placements: [], sections: [] },
+				clips: [],
+			};
+			const summary = buildProjectSummaryProjection(emptied);
+			expect(summary.trackCount).toBe(0);
+			expect(summary.clipCount).toBe(0);
+			expect(summary.placementCount).toBe(0);
+			expect(summary.sectionCount).toBe(0);
+		});
+	});
+
+	describe("large fixtures", () => {
+		it("summarizes the 50-track reference project", () => {
+			const project = createReferenceProject();
+			const summary = buildProjectSummaryProjection(project);
+			expect(summary.trackCount).toBe(50);
+			expect(summary.clipCount).toBe(project.clips.length);
+			expect(summary.placementCount).toBe(project.song.placements.length);
+		});
+	});
+});

--- a/src/projection/projectSummaryProjection.ts
+++ b/src/projection/projectSummaryProjection.ts
@@ -1,0 +1,63 @@
+import type { Project } from "../domain/entities";
+import { fingerprintOf } from "./fingerprint";
+
+/**
+ * The persistence/dashboard summary projection (PRD section 9.9).
+ *
+ * Section 9.9's `projects/{projectId}` metadata tier is "queryable for the
+ * dashboard without loading song state or clip content." This projection is
+ * that same shape as a read-only view over an already-loaded `Project`: it
+ * carries only what a project list needs (name, owner, timestamps, revision)
+ * plus a few counts derived from the song for display, never the song or
+ * clip documents themselves. `FND-004` owns the actual Firestore document
+ * mapping for this tier; this is the projection any dashboard-style consumer
+ * (or, per section 9.8, a compact assistant context) reads instead of poking
+ * at `project.song`/`project.clips` directly.
+ */
+export interface ProjectSummaryProjection {
+	readonly id: string;
+	readonly name: string;
+	readonly ownerId: string;
+	readonly collaboratorIds: readonly string[];
+	readonly createdAt: number;
+	readonly modifiedAt: number;
+	readonly template: string | null;
+	readonly genre: string | null;
+	readonly revision: number;
+	readonly trackCount: number;
+	readonly clipCount: number;
+	readonly placementCount: number;
+	readonly sectionCount: number;
+	/** Changes whenever any summarized field changes. */
+	readonly fingerprint: string;
+}
+
+export function buildProjectSummaryProjection(
+	project: Project,
+	previous?: ProjectSummaryProjection,
+): ProjectSummaryProjection {
+	const { metadata } = project;
+	const shape = {
+		name: metadata.name,
+		ownerId: metadata.ownerId,
+		collaboratorIds: [...metadata.collaboratorIds].sort(),
+		createdAt: metadata.createdAt,
+		modifiedAt: metadata.modifiedAt,
+		template: metadata.template,
+		genre: metadata.genre,
+		revision: metadata.revision,
+		trackCount: project.song.tracks.length,
+		clipCount: project.clips.length,
+		placementCount: project.song.placements.length,
+		sectionCount: project.song.sections.length,
+	};
+	const fingerprint = fingerprintOf(shape);
+	if (
+		previous &&
+		previous.id === metadata.id &&
+		previous.fingerprint === fingerprint
+	) {
+		return previous;
+	}
+	return { id: metadata.id, ...shape, fingerprint };
+}

--- a/src/selection/boundaries.test.ts
+++ b/src/selection/boundaries.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The selection model is UI-only state, but it is not itself a UI framework
+ * binding (PRD section 9.2): it names canonical entities by stable ID and
+ * reads a `Project` to reconcile itself, nothing more. A Firestore
+ * `Timestamp`, a Tone node, or a Solid signal never needs to reach it.
+ */
+
+const selectionDirectory = join(process.cwd(), "src", "selection");
+
+const FORBIDDEN_IMPORTS = [
+	"firebase",
+	"solid-js",
+	"@solidjs/",
+	"tone",
+	"vitest",
+];
+
+function sourceFiles(): string[] {
+	return readdirSync(selectionDirectory).filter(
+		(file) => file.endsWith(".ts") && !file.endsWith(".test.ts"),
+	);
+}
+
+describe("selection boundaries", () => {
+	it("has source files to check", () => {
+		expect(sourceFiles().length).toBeGreaterThan(0);
+	});
+
+	it("imports no Firebase, Tone, Solid, or test-framework module", () => {
+		for (const file of sourceFiles()) {
+			const source = readFileSync(join(selectionDirectory, file), "utf8");
+			const imports = [...source.matchAll(/from\s+"([^"]+)"/g)].map(
+				(match) => match[1],
+			);
+			for (const specifier of imports) {
+				for (const forbidden of FORBIDDEN_IMPORTS) {
+					expect(
+						specifier.startsWith(forbidden),
+						`${file} imports "${specifier}"`,
+					).toBe(false);
+				}
+			}
+		}
+	});
+});

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -1,0 +1,9 @@
+/**
+ * The selection/focus model (PRD sections 9.2-9.3).
+ *
+ * UI-only state that names canonical entities by stable ID. It never enters
+ * `Song` or `Project`, and building or reconciling it never mutates them.
+ */
+
+export * from "./selection";
+export * from "./types";

--- a/src/selection/selection.test.ts
+++ b/src/selection/selection.test.ts
@@ -1,0 +1,626 @@
+import { describe, expect, it } from "vitest";
+import type { Project } from "../domain/entities";
+import {
+	createFactoryContext,
+	createNoteClip,
+	createNoteEvent,
+	createPlacement,
+	createProjectMetadata,
+	createSection,
+	createTrack,
+} from "../domain/factories";
+import {
+	createDrumMachineFixtureProject,
+	createReferenceProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import type { AutomationId, DeviceId } from "../domain/ids";
+import { createSeededIdFactory } from "../domain/ids";
+import { assertProject } from "../domain/parse";
+import { TICKS_PER_BAR, toTicks } from "../domain/time";
+import {
+	addToSelection,
+	buildSelectionEntityIndex,
+	clearSelection,
+	emptySelection,
+	isEmptySelection,
+	reconcileSelection,
+	removeFromSelection,
+	scopeKey,
+	scopesEqual,
+	selectOnly,
+	setFocus,
+	toggleInSelection,
+} from "./selection";
+import type { SelectionScope } from "./types";
+
+function requireDefined<T>(value: T | undefined, message: string): T {
+	if (value === undefined) {
+		throw new Error(message);
+	}
+	return value;
+}
+
+/**
+ * A project with one device (on its one track) and one automation lane (with
+ * two points), so device and automationPoint scopes have something concrete
+ * to reference. Neither the slice nor drum-machine fixtures create devices,
+ * since the FND-009 slice needs none.
+ */
+function buildProjectWithDeviceAndAutomation(seed: string): {
+	project: Project;
+	trackId: Project["song"]["tracks"][number]["id"];
+	deviceId: DeviceId;
+	laneId: AutomationId;
+} {
+	const context = createFactoryContext({ ids: createSeededIdFactory(seed) });
+	const deviceId = context.ids("device");
+	const track = createTrack(context, {
+		name: "Lead",
+		order: 0,
+		devices: [
+			{
+				id: deviceId,
+				type: "filter",
+				order: 0,
+				bypassed: false,
+				parameters: {},
+				preset: null,
+			},
+		],
+	});
+	const clip = createNoteClip(context, {
+		trackId: track.id,
+		name: "Clip",
+		events: [
+			createNoteEvent(context, { startTicks: 0, durationTicks: 48, pitch: 60 }),
+		],
+	});
+	const placement = createPlacement(context, {
+		clipId: clip.id,
+		trackId: track.id,
+		startTicks: 0,
+		durationTicks: TICKS_PER_BAR,
+	});
+	const laneId = context.ids("automation");
+	const section = createSection(context, {
+		name: "Verse",
+		startTicks: 0,
+		durationTicks: TICKS_PER_BAR,
+	});
+
+	const project = assertProject({
+		metadata: createProjectMetadata(context, {
+			ownerId: "user_fixture",
+			name: "Device fixture",
+		}),
+		song: {
+			tempo: 120,
+			timeSignature: { numerator: 4, denominator: 4 },
+			tracks: [track],
+			returns: [],
+			master: { volume: 0, devices: [] },
+			sections: [section],
+			placements: [placement],
+			automation: [
+				{
+					id: laneId,
+					target: {
+						scope: "track",
+						trackId: track.id,
+						parameterId: "track.volume",
+					},
+					interpolation: "linear",
+					points: [
+						{ tick: toTicks(0), value: 0 },
+						{ tick: toTicks(96), value: 3 },
+					],
+				},
+			],
+			assets: [],
+		},
+		clips: [clip],
+	});
+
+	return { project, trackId: track.id, deviceId, laneId };
+}
+
+describe("emptySelection / isEmptySelection", () => {
+	it("is a stable, reusable empty reference", () => {
+		expect(emptySelection()).toBe(emptySelection());
+		expect(isEmptySelection(emptySelection())).toBe(true);
+	});
+
+	it("clearSelection returns the same reference as emptySelection", () => {
+		expect(clearSelection()).toBe(emptySelection());
+	});
+});
+
+describe("scopeKey / scopesEqual", () => {
+	it("gives entity-kind scopes a key derived only from kind and id", () => {
+		const a: SelectionScope = { kind: "track", id: "trk_a" as never };
+		const b: SelectionScope = { kind: "track", id: "trk_a" as never };
+		const c: SelectionScope = { kind: "clip", id: "trk_a" as never };
+		expect(scopesEqual(a, b)).toBe(true);
+		expect(scopesEqual(a, c)).toBe(false);
+	});
+
+	it("keys an automation point by lane and tick", () => {
+		const a: SelectionScope = {
+			kind: "automationPoint",
+			laneId: "aut_a" as never,
+			tick: toTicks(96),
+		};
+		const b: SelectionScope = {
+			kind: "automationPoint",
+			laneId: "aut_a" as never,
+			tick: toTicks(96),
+		};
+		const c: SelectionScope = {
+			kind: "automationPoint",
+			laneId: "aut_a" as never,
+			tick: toTicks(192),
+		};
+		expect(scopesEqual(a, b)).toBe(true);
+		expect(scopesEqual(a, c)).toBe(false);
+	});
+
+	it("keys a bar range independent of track ID order", () => {
+		const a: SelectionScope = {
+			kind: "barRange",
+			startTicks: toTicks(0),
+			endTicks: toTicks(TICKS_PER_BAR),
+			trackIds: ["trk_a", "trk_b"] as never,
+		};
+		const b: SelectionScope = {
+			kind: "barRange",
+			startTicks: toTicks(0),
+			endTicks: toTicks(TICKS_PER_BAR),
+			trackIds: ["trk_b", "trk_a"] as never,
+		};
+		expect(scopeKey(a)).toBe(scopeKey(b));
+	});
+});
+
+describe("selection mutators", () => {
+	const trackScope = (id: string): SelectionScope => ({
+		kind: "track",
+		id: id as never,
+	});
+
+	it("selectOnly replaces the whole selection and focuses the new scope", () => {
+		const state = selectOnly(trackScope("trk_a"));
+		expect(state.scopes).toEqual([trackScope("trk_a")]);
+		expect(state.focus).toEqual(trackScope("trk_a"));
+	});
+
+	it("addToSelection appends and focuses without duplicating", () => {
+		let state = selectOnly(trackScope("trk_a"));
+		state = addToSelection(state, trackScope("trk_b"));
+		expect(state.scopes).toEqual([trackScope("trk_a"), trackScope("trk_b")]);
+		expect(state.focus).toEqual(trackScope("trk_b"));
+
+		const before = state;
+		state = addToSelection(state, trackScope("trk_b"));
+		expect(state).toBe(before);
+	});
+
+	it("addToSelection re-focuses an already-selected scope without duplicating it", () => {
+		let state = selectOnly(trackScope("trk_a"));
+		state = addToSelection(state, trackScope("trk_b"));
+		state = addToSelection(state, trackScope("trk_a"));
+		expect(state.scopes).toEqual([trackScope("trk_a"), trackScope("trk_b")]);
+		expect(state.focus).toEqual(trackScope("trk_a"));
+	});
+
+	it("removeFromSelection drops a scope and re-focuses the last remaining one", () => {
+		let state = selectOnly(trackScope("trk_a"));
+		state = addToSelection(state, trackScope("trk_b"));
+		state = removeFromSelection(state, trackScope("trk_b"));
+		expect(state.scopes).toEqual([trackScope("trk_a")]);
+		expect(state.focus).toEqual(trackScope("trk_a"));
+	});
+
+	it("removeFromSelection clears focus once the last scope is gone", () => {
+		let state = selectOnly(trackScope("trk_a"));
+		state = removeFromSelection(state, trackScope("trk_a"));
+		expect(state).toEqual(emptySelection());
+	});
+
+	it("removeFromSelection is a no-op for a scope that is not selected", () => {
+		const state = selectOnly(trackScope("trk_a"));
+		expect(removeFromSelection(state, trackScope("trk_z"))).toBe(state);
+	});
+
+	it("toggleInSelection adds when absent and removes when present", () => {
+		let state = emptySelection();
+		state = toggleInSelection(state, trackScope("trk_a"));
+		expect(state.scopes).toEqual([trackScope("trk_a")]);
+		state = toggleInSelection(state, trackScope("trk_a"));
+		expect(state).toEqual(emptySelection());
+	});
+
+	it("setFocus moves focus among already-selected scopes without changing the set", () => {
+		let state = selectOnly(trackScope("trk_a"));
+		state = addToSelection(state, trackScope("trk_b"));
+		const scopesBefore = state.scopes;
+		state = setFocus(state, trackScope("trk_a"));
+		expect(state.scopes).toBe(scopesBefore);
+		expect(state.focus).toEqual(trackScope("trk_a"));
+	});
+
+	it("setFocus adds a not-yet-selected scope", () => {
+		const state = setFocus(emptySelection(), trackScope("trk_a"));
+		expect(state.scopes).toEqual([trackScope("trk_a")]);
+		expect(state.focus).toEqual(trackScope("trk_a"));
+	});
+
+	it("setFocus is a no-op if the scope is already focused", () => {
+		const state = selectOnly(trackScope("trk_a"));
+		expect(setFocus(state, trackScope("trk_a"))).toBe(state);
+	});
+});
+
+describe("reconcileSelection: empty state", () => {
+	it("returns the same reference for an empty selection", () => {
+		const project = createSliceFixtureProject();
+		const state = emptySelection();
+		expect(reconcileSelection(state, project)).toBe(state);
+	});
+});
+
+describe("reconcileSelection: referential stability for unchanged entities", () => {
+	it("returns the identical selection reference when every scope is still live", () => {
+		const project = createSliceFixtureProject();
+		const track = project.song.tracks[0];
+		const clip = project.clips[0];
+		const placement = project.song.placements[0];
+		let state = selectOnly({ kind: "track", id: track.id });
+		state = addToSelection(state, { kind: "clip", id: clip.id });
+		state = addToSelection(state, { kind: "placement", id: placement.id });
+
+		const reconciled = reconcileSelection(state, project);
+		expect(reconciled).toBe(state);
+	});
+
+	it("keeps unrelated scope objects reference-equal after a partial deletion", () => {
+		const project = createReferenceProject({
+			trackCount: 6,
+			placementCount: 12,
+		});
+		const survivingTrack = project.song.tracks[0];
+		const deletedTrack = project.song.tracks[1];
+
+		let state = selectOnly({ kind: "track", id: survivingTrack.id });
+		const survivingScope = state.scopes[0];
+		state = addToSelection(state, { kind: "track", id: deletedTrack.id });
+
+		const prunedProject: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.filter((t) => t.id !== deletedTrack.id),
+			},
+		};
+
+		const reconciled = reconcileSelection(state, prunedProject);
+		expect(reconciled.scopes).toEqual([
+			{ kind: "track", id: survivingTrack.id },
+		]);
+		expect(reconciled.scopes[0]).toBe(survivingScope);
+	});
+});
+
+describe("reconcileSelection: deleted selections", () => {
+	function expectDropped(
+		project: Project,
+		scope: SelectionScope,
+		mutate: (project: Project) => Project,
+	) {
+		const state = selectOnly(scope);
+		const mutated = mutate(project);
+		const reconciled = reconcileSelection(state, mutated);
+		expect(isEmptySelection(reconciled)).toBe(true);
+	}
+
+	it("drops a track scope once the track is deleted", () => {
+		const project = createSliceFixtureProject();
+		const track = project.song.tracks[0];
+		expectDropped(project, { kind: "track", id: track.id }, (p) => ({
+			...p,
+			song: { ...p.song, tracks: [] },
+			clips: [],
+		}));
+	});
+
+	it("drops a clip scope once the clip is deleted", () => {
+		const project = createSliceFixtureProject();
+		const clip = project.clips[0];
+		expectDropped(project, { kind: "clip", id: clip.id }, (p) => ({
+			...p,
+			clips: [],
+			song: { ...p.song, placements: [] },
+		}));
+	});
+
+	it("drops a placement scope once the placement is deleted", () => {
+		const project = createSliceFixtureProject();
+		const placement = project.song.placements[0];
+		expectDropped(project, { kind: "placement", id: placement.id }, (p) => ({
+			...p,
+			song: { ...p.song, placements: [] },
+		}));
+	});
+
+	it("drops an event scope once the note event is deleted", () => {
+		const project = createDrumMachineFixtureProject();
+		const drumClip = requireDefined(
+			project.clips.find((c) => c.content.kind === "notes"),
+			"expected the drum-machine fixture to have a notes clip",
+		);
+		const event = requireDefined(
+			drumClip.content.kind === "notes"
+				? drumClip.content.events[0]
+				: undefined,
+			"expected the notes clip to have at least one event",
+		);
+		expectDropped(project, { kind: "event", id: event.id }, (p) => ({
+			...p,
+			clips: p.clips.map((c) =>
+				c.id === drumClip.id && c.content.kind === "notes"
+					? { ...c, content: { kind: "notes", events: [] } }
+					: c,
+			),
+		}));
+	});
+
+	it("drops a section scope once the section is deleted", () => {
+		const { project, laneId: _laneId } =
+			buildProjectWithDeviceAndAutomation("selection-section");
+		const section = project.song.sections[0];
+		expectDropped(project, { kind: "section", id: section.id }, (p) => ({
+			...p,
+			song: { ...p.song, sections: [] },
+		}));
+	});
+
+	it("drops a device scope once the device is deleted", () => {
+		const { project, trackId } =
+			buildProjectWithDeviceAndAutomation("selection-device");
+		const deviceId = project.song.tracks[0].devices[0].id;
+		expectDropped(project, { kind: "device", id: deviceId }, (p) => ({
+			...p,
+			song: {
+				...p.song,
+				tracks: p.song.tracks.map((t) =>
+					t.id === trackId ? { ...t, devices: [] } : t,
+				),
+			},
+		}));
+	});
+
+	it("drops an automationPoint scope once its point is removed", () => {
+		const { project, laneId } = buildProjectWithDeviceAndAutomation(
+			"selection-automation",
+		);
+		const point = project.song.automation[0].points[1];
+		expectDropped(
+			project,
+			{ kind: "automationPoint", laneId, tick: point.tick },
+			(p) => ({
+				...p,
+				song: {
+					...p.song,
+					automation: p.song.automation.map((lane) =>
+						lane.id === laneId ? { ...lane, points: [lane.points[0]] } : lane,
+					),
+				},
+			}),
+		);
+	});
+
+	it("drops an automationPoint scope once its whole lane is removed", () => {
+		const { project, laneId } = buildProjectWithDeviceAndAutomation(
+			"selection-automation-lane",
+		);
+		const point = project.song.automation[0].points[0];
+		expectDropped(
+			project,
+			{ kind: "automationPoint", laneId, tick: point.tick },
+			(p) => ({ ...p, song: { ...p.song, automation: [] } }),
+		);
+	});
+
+	it("re-focuses the last remaining scope when the focused scope is deleted", () => {
+		const project = createSliceFixtureProject();
+		const track = project.song.tracks[0];
+		const placement = project.song.placements[0];
+		let state = selectOnly({ kind: "placement", id: placement.id });
+		state = addToSelection(state, { kind: "track", id: track.id });
+		// Focus is now the track. Delete the track; the placement scope survives
+		// (it references a still-live placement) and becomes the new focus.
+		const prunedProject: Project = {
+			...project,
+			song: { ...project.song, tracks: [] },
+		};
+		const reconciled = reconcileSelection(state, prunedProject);
+		expect(reconciled.scopes).toEqual([
+			{ kind: "placement", id: placement.id },
+		]);
+		expect(reconciled.focus).toEqual({ kind: "placement", id: placement.id });
+	});
+});
+
+describe("reconcileSelection: bar-range scopes", () => {
+	it("narrows a track-scoped bar range when only some tracks survive", () => {
+		const project = createReferenceProject({
+			trackCount: 4,
+			placementCount: 8,
+		});
+		const [trackA, trackB] = project.song.tracks;
+		const state = selectOnly({
+			kind: "barRange",
+			startTicks: toTicks(0),
+			endTicks: toTicks(TICKS_PER_BAR * 4),
+			trackIds: [trackA.id, trackB.id],
+		});
+		const prunedProject: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.filter((t) => t.id !== trackB.id),
+			},
+		};
+		const reconciled = reconcileSelection(state, prunedProject);
+		expect(reconciled.scopes).toEqual([
+			{
+				kind: "barRange",
+				startTicks: toTicks(0),
+				endTicks: toTicks(TICKS_PER_BAR * 4),
+				trackIds: [trackA.id],
+			},
+		]);
+	});
+
+	it("drops a track-scoped bar range once every referenced track is gone", () => {
+		const project = createReferenceProject({
+			trackCount: 2,
+			placementCount: 4,
+		});
+		const [trackA, trackB] = project.song.tracks;
+		const state = selectOnly({
+			kind: "barRange",
+			startTicks: toTicks(0),
+			endTicks: toTicks(TICKS_PER_BAR),
+			trackIds: [trackA.id, trackB.id],
+		});
+		const prunedProject: Project = {
+			...project,
+			song: { ...project.song, tracks: [] },
+		};
+		expect(isEmptySelection(reconcileSelection(state, prunedProject))).toBe(
+			true,
+		);
+	});
+
+	it("leaves an all-tracks bar range (no track IDs) untouched by track deletion", () => {
+		const project = createReferenceProject({
+			trackCount: 3,
+			placementCount: 6,
+		});
+		const state = selectOnly({
+			kind: "barRange",
+			startTicks: toTicks(0),
+			endTicks: toTicks(TICKS_PER_BAR),
+			trackIds: [],
+		});
+		const prunedProject: Project = {
+			...project,
+			song: { ...project.song, tracks: [] },
+		};
+		expect(reconcileSelection(state, prunedProject)).toBe(state);
+	});
+});
+
+describe("reconcileSelection: reorder", () => {
+	it("keeps a track selection valid after reordering tracks", () => {
+		const project = createReferenceProject({
+			trackCount: 4,
+			placementCount: 8,
+		});
+		const [first, second] = project.song.tracks;
+		const state = selectOnly({ kind: "track", id: second.id });
+
+		const reordered: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.map((track) => {
+					if (track.id === first.id) return { ...track, order: 1 };
+					if (track.id === second.id) return { ...track, order: 0 };
+					return track;
+				}),
+			},
+		};
+
+		expect(reconcileSelection(state, reordered)).toBe(state);
+	});
+
+	it("keeps a section selection valid after reordering sections", () => {
+		const { project } =
+			buildProjectWithDeviceAndAutomation("selection-reorder");
+		const section = project.song.sections[0];
+		const state = selectOnly({ kind: "section", id: section.id });
+		const reordered: Project = {
+			...project,
+			song: {
+				...project.song,
+				sections: [{ ...section, startTicks: toTicks(TICKS_PER_BAR * 4) }],
+			},
+		};
+		expect(reconcileSelection(state, reordered)).toBe(state);
+	});
+});
+
+describe("reconcileSelection: large fixtures", () => {
+	it("reconciles a large multi-selection against the 50-track reference project", () => {
+		const project = createReferenceProject();
+		let state = emptySelection();
+		for (const track of project.song.tracks.slice(0, 10)) {
+			state = addToSelection(state, { kind: "track", id: track.id });
+		}
+		for (const placement of project.song.placements.slice(0, 25)) {
+			state = addToSelection(state, { kind: "placement", id: placement.id });
+		}
+		for (const lane of project.song.automation.slice(0, 5)) {
+			state = addToSelection(state, {
+				kind: "automationPoint",
+				laneId: lane.id,
+				tick: lane.points[0].tick,
+			});
+		}
+
+		expect(reconcileSelection(state, project)).toBe(state);
+		expect(state.scopes).toHaveLength(40);
+
+		const deletedTrackId = project.song.tracks[0].id;
+		const survivingPlacements = project.song.placements.filter(
+			(placement) => placement.trackId !== deletedTrackId,
+		);
+		const prunedProject: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.filter((t) => t.id !== deletedTrackId),
+				placements: survivingPlacements,
+			},
+		};
+		const reconciled = reconcileSelection(state, prunedProject);
+		expect(reconciled).not.toBe(state);
+		for (const scope of reconciled.scopes) {
+			if (scope.kind === "track" || scope.kind === "placement") {
+				expect(scope.id).not.toBe(deletedTrackId);
+			}
+		}
+	});
+});
+
+describe("buildSelectionEntityIndex", () => {
+	it("indexes every selectable entity kind", () => {
+		const { project } = buildProjectWithDeviceAndAutomation("selection-index");
+		const index = buildSelectionEntityIndex(project);
+		expect(index.projectId).toBe(project.metadata.id);
+		expect(index.trackIds.has(project.song.tracks[0].id)).toBe(true);
+		expect(index.clipIds.has(project.clips[0].id)).toBe(true);
+		expect(index.placementIds.has(project.song.placements[0].id)).toBe(true);
+		expect(index.sectionIds.has(project.song.sections[0].id)).toBe(true);
+		expect(index.deviceIds.has(project.song.tracks[0].devices[0].id)).toBe(
+			true,
+		);
+		expect(
+			index.automationPointTicks
+				.get(project.song.automation[0].id)
+				?.has(project.song.automation[0].points[0].tick),
+		).toBe(true);
+	});
+});

--- a/src/selection/selection.test.ts
+++ b/src/selection/selection.test.ts
@@ -520,6 +520,40 @@ describe("reconcileSelection: bar-range scopes", () => {
 		};
 		expect(reconcileSelection(state, prunedProject)).toBe(state);
 	});
+
+	it("dedupes two bar ranges that converge on the same track set after narrowing", () => {
+		const project = createReferenceProject({
+			trackCount: 3,
+			placementCount: 6,
+		});
+		const [trackA, trackB, trackC] = project.song.tracks;
+		const range = {
+			kind: "barRange" as const,
+			startTicks: toTicks(0),
+			endTicks: toTicks(TICKS_PER_BAR),
+		};
+		// Two distinct scopes: {A, B} and {A, C}. Deleting B and C narrows both
+		// down to the identical {A} scope.
+		const state = addToSelection(
+			selectOnly({ ...range, trackIds: [trackA.id, trackB.id] }),
+			{ ...range, trackIds: [trackA.id, trackC.id] },
+		);
+		expect(state.scopes).toHaveLength(2);
+
+		const prunedProject: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.filter((t) => t.id === trackA.id),
+			},
+		};
+		const reconciled = reconcileSelection(state, prunedProject);
+
+		expect(reconciled.scopes).toEqual([{ ...range, trackIds: [trackA.id] }]);
+		// Focus (originally the second scope) still resolves to the one
+		// surviving, deduped instance rather than falling through to a stale key.
+		expect(reconciled.focus).toBe(reconciled.scopes[0]);
+	});
 });
 
 describe("reconcileSelection: reorder", () => {

--- a/src/selection/selection.ts
+++ b/src/selection/selection.ts
@@ -1,0 +1,292 @@
+import type { Project } from "../domain/entities";
+import type { Ticks } from "../domain/time";
+import type { SelectionScope, SelectionState } from "./types";
+
+/**
+ * Pure selection/focus operations (PRD sections 9.2-9.3).
+ *
+ * Every function here is a pure `(state, ...) => state` transition: nothing
+ * touches a `Project`, except `reconcileSelection`, which only *reads* one to
+ * decide which scopes still name a live entity. None of these ever mutate
+ * their `Project` or `SelectionState` argument, and a call that would not
+ * change anything returns the exact same `SelectionState` reference it was
+ * given, so an unaffected consumer (e.g. a memoized Solid computation) can
+ * skip recomputing.
+ */
+
+const EMPTY_SELECTION: SelectionState = Object.freeze({
+	scopes: Object.freeze([]) as readonly SelectionScope[],
+	focus: null,
+});
+
+/** The canonical empty selection. Always the same reference. */
+export function emptySelection(): SelectionState {
+	return EMPTY_SELECTION;
+}
+
+export function isEmptySelection(state: SelectionState): boolean {
+	return state.scopes.length === 0;
+}
+
+/** A stable string key two scopes share if and only if they refer to the same thing. */
+export function scopeKey(scope: SelectionScope): string {
+	switch (scope.kind) {
+		case "project":
+		case "track":
+		case "clip":
+		case "placement":
+		case "event":
+		case "section":
+		case "device":
+			return `${scope.kind}:${scope.id}`;
+		case "automationPoint":
+			return `automationPoint:${scope.laneId}:${scope.tick}`;
+		case "barRange":
+			return `barRange:${scope.startTicks}:${scope.endTicks}:${[...scope.trackIds].sort().join(",")}`;
+	}
+}
+
+export function scopesEqual(a: SelectionScope, b: SelectionScope): boolean {
+	return scopeKey(a) === scopeKey(b);
+}
+
+function findByKey(
+	scopes: readonly SelectionScope[],
+	key: string,
+): SelectionScope | undefined {
+	return scopes.find((scope) => scopeKey(scope) === key);
+}
+
+/** Replaces the whole selection with a single scope, which becomes focus. */
+export function selectOnly(scope: SelectionScope): SelectionState {
+	return { scopes: [scope], focus: scope };
+}
+
+/** Clears the selection. Equivalent to {@link emptySelection}. */
+export function clearSelection(): SelectionState {
+	return EMPTY_SELECTION;
+}
+
+/**
+ * Adds `scope` to the selection and makes it the focus. A no-op (returning
+ * the same reference) if `scope` is already selected and already focused.
+ */
+export function addToSelection(
+	state: SelectionState,
+	scope: SelectionScope,
+): SelectionState {
+	const key = scopeKey(scope);
+	const existing = findByKey(state.scopes, key);
+	if (existing) {
+		if (state.focus && scopeKey(state.focus) === key) {
+			return state;
+		}
+		return { scopes: state.scopes, focus: existing };
+	}
+	return { scopes: [...state.scopes, scope], focus: scope };
+}
+
+/**
+ * Removes `scope` from the selection. A no-op if it was not selected. If the
+ * removed scope was the focus, the new focus becomes the last remaining
+ * scope, or `null` if none remain.
+ */
+export function removeFromSelection(
+	state: SelectionState,
+	scope: SelectionScope,
+): SelectionState {
+	const key = scopeKey(scope);
+	if (!findByKey(state.scopes, key)) {
+		return state;
+	}
+	const scopes = state.scopes.filter((entry) => scopeKey(entry) !== key);
+	const focus =
+		state.focus && scopeKey(state.focus) === key
+			? (scopes[scopes.length - 1] ?? null)
+			: state.focus;
+	return { scopes, focus };
+}
+
+/** Adds `scope` if absent, removes it if present. */
+export function toggleInSelection(
+	state: SelectionState,
+	scope: SelectionScope,
+): SelectionState {
+	return findByKey(state.scopes, scopeKey(scope))
+		? removeFromSelection(state, scope)
+		: addToSelection(state, scope);
+}
+
+/**
+ * Moves focus to `scope`, adding it to the selection first if it is not
+ * already selected. A no-op if `scope` is already both selected and focused.
+ */
+export function setFocus(
+	state: SelectionState,
+	scope: SelectionScope,
+): SelectionState {
+	const key = scopeKey(scope);
+	const existing = findByKey(state.scopes, key);
+	if (!existing) {
+		return addToSelection(state, scope);
+	}
+	if (state.focus && scopeKey(state.focus) === key) {
+		return state;
+	}
+	return { scopes: state.scopes, focus: existing };
+}
+
+/** Existence sets used to reconcile a selection against a live project. */
+export interface SelectionEntityIndex {
+	readonly projectId: string;
+	readonly trackIds: ReadonlySet<string>;
+	readonly clipIds: ReadonlySet<string>;
+	readonly placementIds: ReadonlySet<string>;
+	readonly eventIds: ReadonlySet<string>;
+	readonly sectionIds: ReadonlySet<string>;
+	readonly deviceIds: ReadonlySet<string>;
+	/** Ticks with a point, keyed by automation lane ID. */
+	readonly automationPointTicks: ReadonlyMap<string, ReadonlySet<Ticks>>;
+}
+
+/** Builds the existence index {@link reconcileSelection} checks scopes against. */
+export function buildSelectionEntityIndex(
+	project: Project,
+): SelectionEntityIndex {
+	const trackIds = new Set<string>();
+	const deviceIds = new Set<string>();
+	const eventIds = new Set<string>();
+
+	for (const track of project.song.tracks) {
+		trackIds.add(track.id);
+		for (const device of track.devices) {
+			deviceIds.add(device.id);
+		}
+	}
+	for (const bus of project.song.returns) {
+		for (const device of bus.devices) {
+			deviceIds.add(device.id);
+		}
+	}
+	for (const device of project.song.master.devices) {
+		deviceIds.add(device.id);
+	}
+	for (const clip of project.clips) {
+		if (clip.content.kind === "notes") {
+			for (const event of clip.content.events) {
+				eventIds.add(event.id);
+			}
+		}
+	}
+
+	const automationPointTicks = new Map<string, ReadonlySet<Ticks>>();
+	for (const lane of project.song.automation) {
+		automationPointTicks.set(
+			lane.id,
+			new Set(lane.points.map((point) => point.tick)),
+		);
+	}
+
+	return {
+		projectId: project.metadata.id,
+		trackIds,
+		clipIds: new Set(project.clips.map((clip) => clip.id)),
+		placementIds: new Set(project.song.placements.map((p) => p.id)),
+		eventIds,
+		sectionIds: new Set(project.song.sections.map((section) => section.id)),
+		deviceIds,
+		automationPointTicks,
+	};
+}
+
+function scopeIsLive(
+	scope: SelectionScope,
+	index: SelectionEntityIndex,
+): SelectionScope | null {
+	switch (scope.kind) {
+		case "project":
+			return scope.id === index.projectId ? scope : null;
+		case "track":
+			return index.trackIds.has(scope.id) ? scope : null;
+		case "clip":
+			return index.clipIds.has(scope.id) ? scope : null;
+		case "placement":
+			return index.placementIds.has(scope.id) ? scope : null;
+		case "event":
+			return index.eventIds.has(scope.id) ? scope : null;
+		case "section":
+			return index.sectionIds.has(scope.id) ? scope : null;
+		case "device":
+			return index.deviceIds.has(scope.id) ? scope : null;
+		case "automationPoint": {
+			const ticks = index.automationPointTicks.get(scope.laneId);
+			return ticks?.has(scope.tick) ? scope : null;
+		}
+		case "barRange": {
+			if (scope.trackIds.length === 0) {
+				// Applies across all tracks; no per-track existence to check.
+				return scope;
+			}
+			const survivingTrackIds = scope.trackIds.filter((id) =>
+				index.trackIds.has(id),
+			);
+			if (survivingTrackIds.length === 0) {
+				return null;
+			}
+			if (survivingTrackIds.length === scope.trackIds.length) {
+				return scope;
+			}
+			return { ...scope, trackIds: survivingTrackIds };
+		}
+	}
+}
+
+/**
+ * Drops any scope that no longer names a live entity in `project` (a deleted
+ * track, clip, placement, event, section, device, or automation point), and
+ * narrows a `barRange` whose track list has shrunk. Reordering an entity
+ * (track order, section order, automation point order) never invalidates a
+ * selection, because every scope names its entity by stable ID, never by
+ * position.
+ *
+ * Returns the exact same `state` reference when nothing needed to change, so
+ * callers can use reference equality to skip downstream work.
+ */
+export function reconcileSelection(
+	state: SelectionState,
+	project: Project,
+): SelectionState {
+	if (isEmptySelection(state)) {
+		return state;
+	}
+	const index = buildSelectionEntityIndex(project);
+	let changed = false;
+	const scopes: SelectionScope[] = [];
+	// A surviving `barRange` gets a new key when its track list is narrowed, so
+	// focus is tracked by the *original* key it was found under rather than by
+	// re-deriving a key from the (possibly now-different) survivor.
+	const survivorByOriginalKey = new Map<string, SelectionScope>();
+	for (const scope of state.scopes) {
+		const originalKey = scopeKey(scope);
+		const survivor = scopeIsLive(scope, index);
+		if (survivor === null) {
+			changed = true;
+			continue;
+		}
+		if (survivor !== scope) {
+			changed = true;
+		}
+		scopes.push(survivor);
+		survivorByOriginalKey.set(originalKey, survivor);
+	}
+	if (!changed) {
+		return state;
+	}
+	const focus =
+		state.focus === null
+			? null
+			: (survivorByOriginalKey.get(scopeKey(state.focus)) ??
+				scopes[scopes.length - 1] ??
+				null);
+	return { scopes, focus };
+}

--- a/src/selection/selection.ts
+++ b/src/selection/selection.ts
@@ -266,6 +266,12 @@ export function reconcileSelection(
 	// focus is tracked by the *original* key it was found under rather than by
 	// re-deriving a key from the (possibly now-different) survivor.
 	const survivorByOriginalKey = new Map<string, SelectionScope>();
+	// Narrowing a barRange's trackIds can make two originally-distinct scopes
+	// converge on the same key (two bar ranges losing different tracks down to
+	// the same surviving set). Track emitted keys so `scopes` stays the
+	// duplicate-free set SelectionState documents, dropping the second
+	// convergent survivor while still resolving focus to the one that's kept.
+	const scopesByKey = new Map<string, SelectionScope>();
 	for (const scope of state.scopes) {
 		const originalKey = scopeKey(scope);
 		const survivor = scopeIsLive(scope, index);
@@ -276,6 +282,14 @@ export function reconcileSelection(
 		if (survivor !== scope) {
 			changed = true;
 		}
+		const survivorKey = scopeKey(survivor);
+		const existingSurvivor = scopesByKey.get(survivorKey);
+		if (existingSurvivor) {
+			changed = true;
+			survivorByOriginalKey.set(originalKey, existingSurvivor);
+			continue;
+		}
+		scopesByKey.set(survivorKey, survivor);
 		scopes.push(survivor);
 		survivorByOriginalKey.set(originalKey, survivor);
 	}

--- a/src/selection/types.ts
+++ b/src/selection/types.ts
@@ -1,0 +1,65 @@
+import type {
+	AutomationId,
+	ClipId,
+	DeviceId,
+	EventId,
+	PlacementId,
+	ProjectId,
+	SectionId,
+	TrackId,
+} from "../domain/ids";
+import type { Ticks } from "../domain/time";
+
+/**
+ * Selection and focus state (PRD sections 9.2-9.3).
+ *
+ * Selection is UI-only state: it identifies canonical entities by their stable
+ * schema-v1 ID (never by array position), but it is never itself part of
+ * persisted song state, and building it never mutates the project it points
+ * into. Renaming, scrolling, zooming, and switching selection are all changes
+ * to this module's state, not to `Song` or `Project`.
+ *
+ * Every scope other than `barRange` names one canonical entity by ID. A
+ * `barRange` names a span of musical time (and, optionally, the tracks it
+ * spans) rather than a single entity, for marquee selection, loop-to-song
+ * (ARR-03), and arrangement loop ranges.
+ *
+ * An automation point has no ID of its own in the schema-v1 domain model
+ * (`automationPointSchema` is just `{ tick, value }`): points within one lane
+ * are ordered by strictly increasing tick (a `parse.ts` invariant), so a
+ * `(laneId, tick)` pair is already a stable, unique reference to one point.
+ */
+export type SelectionScope =
+	| { readonly kind: "project"; readonly id: ProjectId }
+	| { readonly kind: "track"; readonly id: TrackId }
+	| { readonly kind: "clip"; readonly id: ClipId }
+	| { readonly kind: "placement"; readonly id: PlacementId }
+	| { readonly kind: "event"; readonly id: EventId }
+	| { readonly kind: "section"; readonly id: SectionId }
+	| { readonly kind: "device"; readonly id: DeviceId }
+	| {
+			readonly kind: "automationPoint";
+			readonly laneId: AutomationId;
+			readonly tick: Ticks;
+	  }
+	| {
+			readonly kind: "barRange";
+			readonly startTicks: Ticks;
+			readonly endTicks: Ticks;
+			/** Empty means the range applies across all tracks (e.g. a loop range). */
+			readonly trackIds: readonly TrackId[];
+	  };
+
+export type SelectionScopeKind = SelectionScope["kind"];
+
+/**
+ * The full selection: an ordered, duplicate-free set of scopes plus the
+ * focused scope among them. Focus is the anchor used for shift-extend,
+ * keyboard navigation, and single-target property panels; it is always
+ * either `null` (nothing selected) or reference-equal to one entry in
+ * `scopes` produced by this module's own operations.
+ */
+export interface SelectionState {
+	readonly scopes: readonly SelectionScope[];
+	readonly focus: SelectionScope | null;
+}

--- a/src/testing/jest-dom-setup.ts
+++ b/src/testing/jest-dom-setup.ts
@@ -1,0 +1,15 @@
+// Explicit vitest setup: registers `@testing-library/jest-dom`'s matchers.
+//
+// `vite-plugin-solid` normally auto-injects this via a bare module specifier
+// (`@testing-library/jest-dom/vitest`) resolved directly against
+// `vitest.config.ts`'s `test.setupFiles`, outside Vite's own module graph.
+// Declaring the real import in a relative file that `vitest.config.ts` points
+// to instead lets it resolve exactly like every other project import — which
+// matters when running from a git-worktree checkout nested under the main
+// checkout (see `vitest.config.ts`'s `exclude` note), where that raw bare
+// specifier can resolve against the wrong `node_modules`.
+//
+// Keep "jest-dom" in this filename: `vite-plugin-solid` only skips its own
+// auto-injection when an existing `test.setupFiles` entry path matches
+// `/jest-dom/`, and would otherwise add its (broken, here) specifier too.
+import "@testing-library/jest-dom/vitest";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,5 +24,14 @@ export default defineConfig({
 			"tests/emulator/**",
 			".claude/**",
 		],
+		// Explicit rather than left to vite-plugin-solid's auto-detected bare
+		// specifier (`@testing-library/jest-dom/vitest`, resolved directly
+		// against `test.setupFiles` outside Vite's own module graph): running
+		// from a git-worktree checkout nested under the main checkout (see the
+		// `exclude` note above) can make that raw specifier resolve against the
+		// main checkout's `node_modules` instead of the worktree's own, which
+		// then fails to load. A real relative setup file resolves through
+		// Vite's normal import graph like every other project module instead.
+		setupFiles: ["./src/testing/jest-dom-setup.ts"],
 	},
 });


### PR DESCRIPTION
## Summary

Implements `FND-005 - Selection and consumer projections`: a UI-only selection/focus model and a set of read-only, pure projections that the editor, audio engine, arrangement renderer, persistence layer, and assistant consume instead of touching canonical `Project` state directly.

- **`src/selection`** — `SelectionState` (`scopes` + `focus`) over a `SelectionScope` union covering project, track, clip, placement, event, section, device, automation point (`(laneId, tick)`, since points have no ID of their own), and bar-range (musical span, optionally scoped to tracks) — all addressed by stable schema-v1 ID, never array position. Operations (`select`, `extend`, `toggle`, `clear`, `reconcileSelection`, …) keep `scopes` duplicate-free and keep `focus` reference-equal to an entry in `scopes` or `null`.
- **`src/projection`** — pure functions of a `Project` (plus `SelectionState` for the assistant context): `arrangementProjection` (renderer-facing, stable IDs/integer bounds/track order/labels/revision counters), `audioProjection` (topology vs. parameter change classification for tracks, return buses, and master, each with its own `fingerprint`/`topologyFingerprint`), `projectSummaryProjection` (dashboard/persistence-safe metadata without song/clip payloads), and `assistantContextProjection` (compact serializable context). A shared `fingerprint` helper lets each projection reuse a previous entry when nothing relevant to that consumer changed.
- None of this module touches Firebase, Tone.js, or SolidJS types, and none of it can mutate canonical state — consistent with `src/domain` owning the only writable contract.

### PRD requirements

- [PRD 9.2 — System boundaries](https://github.com/afternoon/solid-groove/blob/main/docs/prd.md#92-system-boundaries): selection model sits between UI and the command layer; audio engine and arrangement renderer consume separate read-only projections.
- [PRD 9.3 — Arrangement renderer decision](https://github.com/afternoon/solid-groove/blob/main/docs/prd.md#93-arrangement-renderer-decision): domain selectors build the renderer-specific `ArrangementProjection` (stable IDs, integer musical bounds, track order, revision counters) that Canvas code consumes instead of traversing Firestore-shaped data.
- [PRD 9.7 — Audio engine boundary](https://github.com/afternoon/solid-groove/blob/main/docs/prd.md#97-audio-engine-boundary): the engine consumes a read-only song projection and classifies changes (parameter vs. topology) rather than subscribing to the full mutable project.
- [PRD 9.8 — Assistant boundary](https://github.com/afternoon/solid-groove/blob/main/docs/prd.md#98-assistant-boundary): project analysis produces a compact, serializable context rather than the full persistence document.

### Acceptance checkboxes met (`docs/backlog.md`, FND-005)

- [x] Selection supports project, track, clip, placement, event, section, automation point, device, and bar-range scopes by stable ID.
- [x] Projections expose explicit revision/change information and cannot mutate canonical state.
- [x] Renaming, selection, scrolling, or assistant conversation does not appear as an audio topology change.
- [x] Selector tests cover deleted selections, reorder, empty state, large fixtures, and referential stability for unchanged entities.

## Review

This branch went through an Opus review round in the implementation workflow. The initial pass raised two blocking findings — return buses and master flowing into the audio projection without their own fingerprints (carrying the display-only `name` field), and `reconcileSelection` able to collapse two distinct bar-range scopes onto the same key without deduping. Both were fixed on this branch (commit `17924d0`) with tests added for return-bus rename/device-chain/mixer-edit fingerprint stability and bar-range convergence, and the branch passed the subsequent review round.

## Test plan

- [x] `bun run test` (unit/component suite, including `src/selection` and `src/projection`)
- [x] `bun run check:ci`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkibHg472eihebmBAut5r)_