### PR TITLE
Fix duplicate setupFiles key in vitest.config.ts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,14 +43,5 @@ export default defineConfig({
 			"perf/**",
 			".claude/**",
 		],
-		// Explicit rather than left to vite-plugin-solid's auto-detected bare
-		// specifier (`@testing-library/jest-dom/vitest`, resolved directly
-		// against `test.setupFiles` outside Vite's own module graph): running
-		// from a git-worktree checkout nested under the main checkout (see the
-		// `exclude` note above) can make that raw specifier resolve against the
-		// main checkout's `node_modules` instead of the worktree's own, which
-		// then fails to load. A real relative setup file resolves through
-		// Vite's normal import graph like every other project module instead.
-		setupFiles: ["./src/testing/jest-dom-setup.ts"],
 	},
 });


### PR DESCRIPTION
## Problem

CI on `main` is red at the **typecheck** step:

```
vitest.config.ts(54,3): error TS1117: An object literal cannot have multiple properties with the same name.
```

The `test` object had two `setupFiles` keys:
- line 32 — `[jestDomSetupPath]`, added by FND-008 (#14), resolved absolutely via `import.meta.resolve("@testing-library/jest-dom/vitest")`.
- line 54 — `["./src/testing/jest-dom-setup.ts"]`, appended later by FND-005 (#17).

This is a botched merge of two competing fixes for the same worktree module-resolution problem. TypeScript rejects the duplicate key, so `bun run typecheck` (the CI gate) fails before a single test runs. The duplicate's target, `src/testing/jest-dom-setup.ts`, was also never committed — it doesn't exist.

## Change

Keep the working `jestDomSetupPath` entry (its target `@testing-library/jest-dom/vitest` is a real installed package) and delete the duplicate line plus its orphaned comment.

## Verification

- `bun run typecheck` — clean (was the failure)
- `bun run check:ci` (Biome) — clean, 220 files
- `bun run test` — 695/696 pass; jest-dom matchers load correctly across the suite

The one failure is a **pre-existing, unrelated flaky test** — `scripts/starter-library/manifest.test.mjs > buildAsset > is deterministic: the same entry renders byte-identical audio` — which passes 3/3 in isolation and only flakes under the full parallel run (audio-render nondeterminism, same family as the previously-removed filter tests). It is not touched by this config change and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)