### PR TITLE
FND-007 - Stable ID-keyed audio graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,19 @@ Solid Groove is a browser-based music production tool designed to make music cre
 ```
 src/
 ├── audio/              # Audio playback and synthesis
-│   ├── AudioProvider.tsx    # Context provider for SongPlayer
-│   └── SongPlayer.ts        # Tone.js integration and playback logic
+│   ├── AudioRuntime.ts      # Single application-scoped Tone/Web Audio context (PRD 9.7)
+│   ├── resourceRegistry.ts  # Owner/type tracked audio resource registry (PRD AUD-09)
+│   ├── ProjectAudioGraph.ts # Stable ID-keyed project graph reconciled from the audio projection (PRD AUD-08)
+│   ├── TrackAudioGraph.ts   # One track's instrument, device chain, sends, and channel strip
+│   ├── ReturnAudioGraph.ts  # One return bus's device chain and channel strip
+│   ├── MasterAudioGraph.ts  # The master bus's device chain and volume stage
+│   ├── DeviceChain.ts       # Ordered, ID-keyed insert-chain reconciliation shared by tracks/returns/master
+│   ├── InstrumentGraph.ts   # Sampler/synth/drum-machine instrument node factory and reconciliation
+│   ├── AudioBufferCache.ts  # Asset buffer cache keyed by ID/revision with stale-load cancellation
+│   ├── toneBufferLoader.ts  # The only Tone-touching asset decode path `AudioBufferCache` uses in production
+│   ├── scheduling.ts        # Placement/clip -> absolute-tick event expansion (musical time, not wall clock)
+│   ├── AudioProvider.tsx    # Context provider for SongPlayer (prototype path; superseded by `ProjectAudioGraph`)
+│   └── SongPlayer.ts        # Prototype Tone.js integration and playback logic, replaced by `FND-009`
 ├── auth/               # Authentication logic
 │   ├── AuthProvider.tsx     # Context provider for auth state
 │   └── authService.ts       # Firebase auth service wrapper
@@ -220,6 +231,16 @@ See [`docs/testing.md`](./docs/testing.md) for what each suite covers, how CI ga
 - Undo/redo is session-local, bounded, and replays inverse commands rather than project snapshots. Only an explicit `replaceProject` clears it — a save acknowledgement or remote echo must never touch it.
 - Like `src/domain`, this layer imports no Firebase, Tone, or Solid. Adding or changing a command is a contract change; see the registry test's pinned command list.
 
+### Audio engine (`src/audio`)
+- `AudioRuntime` is the single application-scoped owner of the real-time Tone/Web Audio context, transport, buffer cache, and resource registry (PRD AUD-07, AUD-09; section 9.7). It is the only place production code may create, install, resume, suspend, replace, or close that context — obtain it via `getAudioRuntime()`, never construct one directly.
+- `ProjectAudioGraph` reconciles a read-only `AudioSongProjection` (from `src/projection/audioProjection.ts`) into a stable graph keyed by track, instrument, device, return, and asset IDs (PRD AUD-03, AUD-08). Passing back the exact projection object the audio projection handed out previously is a complete no-op; an edit to one track, return, or placement only touches that entity's own subgraph.
+- `TrackAudioGraph`/`ReturnAudioGraph`/`MasterAudioGraph` each own one channel strip (`Tone.PanVol`/`Tone.Volume`) plus a `DeviceChain`. `DeviceChain` reconciles an ordered `Device[]` by id: only added/removed devices create or dispose a node, and reordering relinks connections without recreating anything. Schema v1 has no concrete processors yet (Phase 1 authors them); an unregistered `device.type` gets an inert passthrough node so topology is provable ahead of real DSP.
+- `InstrumentGraph.ts` builds the sampler/synth/drum-machine node for a track's `Instrument`. A track only replaces its instrument node when `kind` changes; an asset swap, a drum-pad added/removed, or a generic parameter edit calls the existing node's `update()` instead.
+- `AudioBufferCache` decodes and caches asset buffers keyed by asset ID and content fingerprint, with reference-counted eviction and generation-tracked cancellation so a stale decode can never reconnect or overwrite a newer one. It never imports Tone itself — `toneBufferLoader.ts` is the one production loader that does, which keeps the cache's generation/refcount bookkeeping testable without any Web Audio globals.
+- `scheduling.ts` expands a placement's clip content into absolute-tick events (looping and clip trimming included) as a pure function of the audio projection; `ProjectAudioGraph` schedules those against `Tone.Transport` (or an injected `AudioTransport` in tests) with an owner-tracked handle per event, never an anonymous global callback.
+- Every constructed Tone/Web Audio resource is registered with the owning `AudioProjectScope` (`AudioRuntime.openProjectScope`) so disposal is idempotent and instrumented (PRD AUD-09) — components and domain stores request graph operations but never receive mutable audio nodes.
+- `SongPlayer`/`ToneInstrument`/`AudioProvider.tsx` are the prototype playback path against `src/model/types`, superseded by `ProjectAudioGraph` once `FND-009` wires the domain-typed graph into the UI; do not extend the prototype path for new work.
+
 ### Service Layer
 - Create service modules for external integrations (authService, dataService)
 - Services handle all direct Firebase API calls
@@ -229,11 +250,6 @@ See [`docs/testing.md`](./docs/testing.md) for what each suite covers, how CI ga
 - Use Firestore's `onSnapshot` for real-time updates
 - Subscriptions are set up in `createEffect` with proper cleanup
 - Store updates use `produce` for immutable updates
-
-### Audio Playback
-- SongPlayer class manages Tone.js instances
-- AudioProvider makes SongPlayer available via context
-- Audio state is separate from UI state
 
 ### File-based Routing
 - Routes are defined by files in `src/routes/`

--- a/src/audio/AudioBufferCache.test.ts
+++ b/src/audio/AudioBufferCache.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AssetId } from "../domain/ids";
+import type { AudioAssetProjection } from "../projection/audioProjection";
+import {
+	type AssetBufferLoader,
+	AudioBufferCache,
+	type CachedBuffer,
+} from "./AudioBufferCache";
+
+/**
+ * `AudioBufferCache` never imports Tone (see the module comment); these tests
+ * exercise its generation/refcount bookkeeping with a trivial fake buffer and
+ * a manually-resolvable loader instead of any Web Audio globals.
+ */
+
+class FakeBuffer implements CachedBuffer {
+	disposed = false;
+	constructor(public readonly label: string) {}
+	dispose(): void {
+		this.disposed = true;
+	}
+}
+
+interface PendingLoad {
+	asset: AudioAssetProjection;
+	resolve: (buffer: FakeBuffer) => void;
+	reject: (error: unknown) => void;
+}
+
+/** A loader whose promises settle only when the test tells them to. */
+function createManualLoader(): {
+	loader: AssetBufferLoader<FakeBuffer>;
+	pending: PendingLoad[];
+} {
+	const pending: PendingLoad[] = [];
+	const loader: AssetBufferLoader<FakeBuffer> = {
+		load(asset) {
+			return new Promise((resolve, reject) => {
+				pending.push({ asset, resolve, reject });
+			});
+		},
+	};
+	return { loader, pending };
+}
+
+function asset(
+	id: string,
+	fingerprint: string,
+	overrides: Partial<AudioAssetProjection> = {},
+): AudioAssetProjection {
+	return {
+		id: id as AssetId,
+		kind: "sample",
+		storageRef: `samples/${id}.wav`,
+		url: `/samples/${id}.wav`,
+		durationSeconds: 1,
+		sampleRate: 44_100,
+		channelCount: 1,
+		fingerprint,
+		...overrides,
+	};
+}
+
+describe("AudioBufferCache", () => {
+	it("resolves the subscriber once the load settles", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const onBuffer = vi.fn();
+
+		cache.subscribe(asset("ast_a", "f1"), onBuffer);
+		expect(onBuffer).not.toHaveBeenCalled();
+
+		const buffer = new FakeBuffer("a@f1");
+		pending[0].resolve(buffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBuffer).toHaveBeenCalledExactlyOnceWith(buffer);
+	});
+
+	it("shares one decode across multiple subscribers to the same asset id", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const first = vi.fn();
+		const second = vi.fn();
+
+		cache.subscribe(asset("ast_a", "f1"), first);
+		cache.subscribe(asset("ast_a", "f1"), second);
+		expect(pending).toHaveLength(1);
+
+		const buffer = new FakeBuffer("a@f1");
+		pending[0].resolve(buffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(first).toHaveBeenCalledExactlyOnceWith(buffer);
+		expect(second).toHaveBeenCalledExactlyOnceWith(buffer);
+	});
+
+	it("calls a new subscriber synchronously once a buffer is already decoded", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		cache.subscribe(asset("ast_a", "f1"), () => {});
+		const buffer = new FakeBuffer("a@f1");
+		pending[0].resolve(buffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const late = vi.fn();
+		cache.subscribe(asset("ast_a", "f1"), late);
+		expect(late).toHaveBeenCalledExactlyOnceWith(buffer);
+	});
+
+	it("re-decodes when an asset's fingerprint changes and notifies existing subscribers with the new buffer", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const onBuffer = vi.fn();
+
+		cache.subscribe(asset("ast_a", "f1"), onBuffer);
+		const first = new FakeBuffer("a@f1");
+		pending[0].resolve(first);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		cache.refresh(asset("ast_a", "f2"));
+		expect(pending).toHaveLength(2);
+		expect(first.disposed).toBe(true);
+
+		const second = new FakeBuffer("a@f2");
+		pending[1].resolve(second);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBuffer).toHaveBeenLastCalledWith(second);
+	});
+
+	it("never installs or reports a stale-generation load, however late it resolves", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const onBuffer = vi.fn();
+
+		cache.subscribe(asset("ast_a", "f1"), onBuffer);
+		// Replace before the first load settles — this is the "replace a
+		// sample" race AUD-08 calls out.
+		cache.refresh(asset("ast_a", "f2"));
+		expect(pending).toHaveLength(2);
+
+		const staleBuffer = new FakeBuffer("stale a@f1");
+		const freshBuffer = new FakeBuffer("fresh a@f2");
+		// Resolve the *newer* generation first, then the stale one, so a late
+		// completion genuinely cannot reconnect or overwrite the newer result.
+		pending[1].resolve(freshBuffer);
+		await Promise.resolve();
+		await Promise.resolve();
+		pending[0].resolve(staleBuffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBuffer).toHaveBeenCalledTimes(1);
+		expect(onBuffer).toHaveBeenCalledWith(freshBuffer);
+		expect(staleBuffer.disposed).toBe(true);
+		expect(freshBuffer.disposed).toBe(false);
+	});
+
+	it("refresh() is a no-op for an unchanged fingerprint — no new load, no re-notification", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const onBuffer = vi.fn();
+		cache.subscribe(asset("ast_a", "f1"), onBuffer);
+		pending[0].resolve(new FakeBuffer("a@f1"));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		cache.refresh(asset("ast_a", "f1"));
+
+		expect(pending).toHaveLength(1);
+		expect(onBuffer).toHaveBeenCalledTimes(1);
+	});
+
+	it("refresh() is a no-op for an asset the cache has no subscriber for", () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		cache.refresh(asset("ast_untracked", "f1"));
+		expect(pending).toHaveLength(0);
+	});
+
+	it("disposes the buffer once every subscriber releases, and a later subscribe starts a fresh decode", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const first = vi.fn();
+		const second = vi.fn();
+
+		const subA = cache.subscribe(asset("ast_a", "f1"), first);
+		const subB = cache.subscribe(asset("ast_a", "f1"), second);
+		const buffer = new FakeBuffer("a@f1");
+		pending[0].resolve(buffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		subA.release();
+		expect(buffer.disposed).toBe(false); // subB still holds a reference
+
+		subB.release();
+		expect(buffer.disposed).toBe(true);
+		expect(cache.diagnostics().cachedAssets).toBe(0);
+
+		const third = vi.fn();
+		cache.subscribe(asset("ast_a", "f1"), third);
+		expect(pending).toHaveLength(2); // a fresh decode, not the disposed one
+	});
+
+	it("release() is idempotent", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const sub = cache.subscribe(asset("ast_a", "f1"), () => {});
+		const buffer = new FakeBuffer("a@f1");
+		pending[0].resolve(buffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		sub.release();
+		sub.release();
+		expect(buffer.disposed).toBe(true);
+	});
+
+	it("a load that settles after every subscriber already released is disposed and never installed", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const onBuffer = vi.fn();
+		const sub = cache.subscribe(asset("ast_a", "f1"), onBuffer);
+
+		sub.release();
+		const buffer = new FakeBuffer("a@f1");
+		pending[0].resolve(buffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBuffer).not.toHaveBeenCalled();
+		expect(buffer.disposed).toBe(true);
+		expect(cache.diagnostics().cachedAssets).toBe(0);
+	});
+
+	it("reports a failed decode as a null buffer and logs the error", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const onBuffer = vi.fn();
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		cache.subscribe(asset("ast_a", "f1"), onBuffer);
+		pending[0].reject(new Error("decode failed"));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBuffer).toHaveBeenCalledExactlyOnceWith(null);
+		expect(consoleError).toHaveBeenCalledOnce();
+		consoleError.mockRestore();
+	});
+
+	it("tracks pending-load and cached-asset diagnostics", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		cache.subscribe(asset("ast_a", "f1"), () => {});
+		cache.subscribe(asset("ast_b", "f1"), () => {});
+
+		expect(cache.diagnostics()).toEqual({ cachedAssets: 2, pendingLoads: 2 });
+
+		pending[0].resolve(new FakeBuffer("a"));
+		pending[1].resolve(new FakeBuffer("b"));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(cache.diagnostics()).toEqual({ cachedAssets: 2, pendingLoads: 0 });
+	});
+
+	it("dispose() releases every cached buffer and discards any in-flight decode", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const onBuffer = vi.fn();
+		cache.subscribe(asset("ast_a", "f1"), onBuffer);
+		const readyBuffer = new FakeBuffer("a@f1");
+		pending[0].resolve(readyBuffer);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		cache.subscribe(asset("ast_b", "f1"), () => {});
+
+		cache.dispose();
+		expect(readyBuffer.disposed).toBe(true);
+		expect(cache.diagnostics().cachedAssets).toBe(0);
+
+		const lateBuffer = new FakeBuffer("b@f1");
+		pending[1].resolve(lateBuffer);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(lateBuffer.disposed).toBe(true);
+		expect(onBuffer).toHaveBeenCalledTimes(1); // only its original decode, never re-notified after dispose
+	});
+});

--- a/src/audio/AudioBufferCache.test.ts
+++ b/src/audio/AudioBufferCache.test.ts
@@ -125,6 +125,9 @@ describe("AudioBufferCache", () => {
 		cache.refresh(asset("ast_a", "f2"));
 		expect(pending).toHaveLength(2);
 		expect(first.disposed).toBe(true);
+		// Subscribers must be told the buffer is gone (null) before the
+		// replacement decode settles, so nobody holds a disposed buffer.
+		expect(onBuffer).toHaveBeenNthCalledWith(2, null);
 
 		const second = new FakeBuffer("a@f2");
 		pending[1].resolve(second);
@@ -132,6 +135,25 @@ describe("AudioBufferCache", () => {
 		await Promise.resolve();
 
 		expect(onBuffer).toHaveBeenLastCalledWith(second);
+	});
+
+	it("notifies subscribers with null before disposing the superseded buffer, not after", async () => {
+		const { loader, pending } = createManualLoader();
+		const cache = new AudioBufferCache(loader);
+		const disposedAtNotifyTime: boolean[] = [];
+
+		const first = new FakeBuffer("a@f1");
+		cache.subscribe(asset("ast_a", "f1"), (buffer) => {
+			if (buffer === null) disposedAtNotifyTime.push(first.disposed);
+		});
+		pending[0].resolve(first);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		cache.refresh(asset("ast_a", "f2"));
+
+		expect(disposedAtNotifyTime).toEqual([false]);
+		expect(first.disposed).toBe(true);
 	});
 
 	it("never installs or reports a stale-generation load, however late it resolves", async () => {

--- a/src/audio/AudioBufferCache.ts
+++ b/src/audio/AudioBufferCache.ts
@@ -125,11 +125,22 @@ export class AudioBufferCache<B extends CachedBuffer = CachedBuffer> {
 	): void {
 		if (tracker.fingerprint === asset.fingerprint) return;
 
-		tracker.buffer?.dispose();
+		const previousBuffer = tracker.buffer;
 		tracker.buffer = null;
 		tracker.fingerprint = asset.fingerprint;
 		tracker.generation += 1;
 		const generation = tracker.generation;
+
+		if (previousBuffer) {
+			// Tell every subscriber the buffer is gone *before* disposing it, so
+			// a consumer never holds a reference to a disposed buffer while the
+			// replacement decode is in flight (PRD AUD-09: no use-after-dispose).
+			// Skipped when there was no buffer yet (e.g. a refresh() that lands
+			// while the first decode is still in flight) — there is nothing to
+			// invalidate and no spurious null notification to send.
+			for (const listener of tracker.listeners) listener(null);
+			previousBuffer.dispose();
+		}
 
 		this.pendingLoads += 1;
 		this.loader.load(asset).then(

--- a/src/audio/AudioBufferCache.ts
+++ b/src/audio/AudioBufferCache.ts
@@ -1,0 +1,177 @@
+import type { AssetId } from "../domain/ids";
+import type { AudioAssetProjection } from "../projection/audioProjection";
+
+/**
+ * Buffer cache keyed by asset ID and revision (PRD AUD-08, section 9.7:
+ * "Decoded buffers are cached by asset identity and source revision with
+ * reference-counted or otherwise deterministic eviction").
+ *
+ * Deliberately generic over the decoded buffer type rather than importing
+ * Tone directly: this module never touches Tone or Web Audio, so its
+ * generation/refcount bookkeeping — the part that has to be exactly right for
+ * "no stale-load reconnection" — is tested with a trivial fake loader and no
+ * Web Audio globals at all. `toneBufferLoader.ts` supplies the real loader
+ * used everywhere in production.
+ */
+export interface CachedBuffer {
+	dispose(): void;
+}
+
+export interface AssetBufferLoader<B extends CachedBuffer = CachedBuffer> {
+	load(asset: AudioAssetProjection): Promise<B>;
+}
+
+export interface BufferSubscription {
+	/** Stop receiving updates and release this consumer's reference. Idempotent. */
+	release(): void;
+}
+
+/** One asset's cache bookkeeping. Mutated in place rather than replaced, so a
+ * subscriber's `release()` — captured against this same object — always
+ * decrements the refcount that its `subscribe()` incremented, even across a
+ * fingerprint change in between. */
+interface AssetTracker<B extends CachedBuffer> {
+	refCount: number;
+	listeners: Set<(buffer: B | null) => void>;
+	fingerprint: string | null;
+	/** Bumped every time the tracked fingerprint changes or the tracker is
+	 * fully released. A load whose generation no longer matches when it
+	 * settles is stale and is discarded rather than installed or reported. */
+	generation: number;
+	buffer: B | null;
+}
+
+export interface AudioBufferCacheDiagnostics {
+	cachedAssets: number;
+	pendingLoads: number;
+}
+
+export class AudioBufferCache<B extends CachedBuffer = CachedBuffer> {
+	private readonly trackers = new Map<AssetId, AssetTracker<B>>();
+	private pendingLoads = 0;
+
+	constructor(private readonly loader: AssetBufferLoader<B>) {}
+
+	/**
+	 * Subscribe to the decoded buffer for `asset`. `onBuffer` runs synchronously
+	 * if a buffer is already decoded at this fingerprint; otherwise it runs
+	 * once decoding settles, and again any time this same asset id's content
+	 * changes underneath the subscription (e.g. a replaced sample). Multiple
+	 * subscribers to one asset id share a single decode and a single buffer.
+	 */
+	subscribe(
+		asset: AudioAssetProjection,
+		onBuffer: (buffer: B | null) => void,
+	): BufferSubscription {
+		const tracker = this.trackerFor(asset);
+		tracker.refCount += 1;
+		tracker.listeners.add(onBuffer);
+		if (tracker.buffer !== null) onBuffer(tracker.buffer);
+
+		let released = false;
+		return {
+			release: () => {
+				if (released) return;
+				released = true;
+				tracker.listeners.delete(onBuffer);
+				tracker.refCount = Math.max(0, tracker.refCount - 1);
+				if (tracker.refCount === 0) {
+					if (this.trackers.get(asset.id) === tracker) {
+						this.trackers.delete(asset.id);
+					}
+					// Bumping the generation here (not just on delete-from-map) means
+					// a load already in flight for this tracker is recognized as
+					// stale even if a *new* tracker for the same asset id gets
+					// created before that load settles.
+					tracker.generation += 1;
+					tracker.buffer?.dispose();
+					tracker.buffer = null;
+				}
+			},
+		};
+	}
+
+	/**
+	 * Re-checks `asset` against the cache and starts a reload if its
+	 * fingerprint has changed since it was last decoded. A no-op for an asset
+	 * this cache has no tracker for, or whose fingerprint is unchanged — so
+	 * calling this for every known asset on every project reconcile pass never
+	 * causes unrelated churn.
+	 */
+	refresh(asset: AudioAssetProjection): void {
+		const tracker = this.trackers.get(asset.id);
+		if (tracker) this.syncFingerprint(tracker, asset);
+	}
+
+	private trackerFor(asset: AudioAssetProjection): AssetTracker<B> {
+		let tracker = this.trackers.get(asset.id);
+		if (!tracker) {
+			tracker = {
+				refCount: 0,
+				listeners: new Set(),
+				fingerprint: null,
+				generation: 0,
+				buffer: null,
+			};
+			this.trackers.set(asset.id, tracker);
+		}
+		this.syncFingerprint(tracker, asset);
+		return tracker;
+	}
+
+	private syncFingerprint(
+		tracker: AssetTracker<B>,
+		asset: AudioAssetProjection,
+	): void {
+		if (tracker.fingerprint === asset.fingerprint) return;
+
+		tracker.buffer?.dispose();
+		tracker.buffer = null;
+		tracker.fingerprint = asset.fingerprint;
+		tracker.generation += 1;
+		const generation = tracker.generation;
+
+		this.pendingLoads += 1;
+		this.loader.load(asset).then(
+			(buffer) => {
+				this.pendingLoads -= 1;
+				if (tracker.generation !== generation) {
+					// Superseded by a replace or a full release before this decode
+					// settled — never install or report a stale-generation result.
+					buffer.dispose();
+					return;
+				}
+				tracker.buffer = buffer;
+				for (const listener of tracker.listeners) listener(buffer);
+			},
+			(error: unknown) => {
+				this.pendingLoads -= 1;
+				if (tracker.generation !== generation) return;
+				console.error(
+					`AudioBufferCache: failed to load asset "${asset.id}"`,
+					error,
+				);
+				for (const listener of tracker.listeners) listener(null);
+			},
+		);
+	}
+
+	/** Diagnostics (PRD AUD-09): cached asset count and in-flight decode count. */
+	diagnostics(): AudioBufferCacheDiagnostics {
+		return {
+			cachedAssets: this.trackers.size,
+			pendingLoads: this.pendingLoads,
+		};
+	}
+
+	/** Release every cached buffer and forget every asset. Idempotent. */
+	dispose(): void {
+		for (const tracker of this.trackers.values()) {
+			tracker.generation += 1;
+			tracker.buffer?.dispose();
+			tracker.buffer = null;
+			tracker.listeners.clear();
+		}
+		this.trackers.clear();
+	}
+}

--- a/src/audio/DeviceChain.test.ts
+++ b/src/audio/DeviceChain.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Device } from "../domain/entities";
+import { installWebAudioGlobals, rms } from "./testAudioContext";
+
+// Must run before Tone is imported — see AudioRuntime.test.ts for why.
+installWebAudioGlobals();
+
+let Tone: typeof import("tone");
+let AudioRuntimeModule: typeof import("./AudioRuntime");
+let DeviceChainModule: typeof import("./DeviceChain");
+
+beforeAll(async () => {
+	Tone = await import("tone");
+	AudioRuntimeModule = await import("./AudioRuntime");
+	DeviceChainModule = await import("./DeviceChain");
+});
+
+afterEach(async () => {
+	try {
+		await AudioRuntimeModule.getAudioRuntime().close();
+	} catch {
+		// already closed by the test itself
+	}
+	AudioRuntimeModule.__resetAudioRuntimeForTests();
+});
+
+function device(id: string, order: number, type = "generic"): Device {
+	return {
+		id: id as Device["id"],
+		type,
+		order,
+		bypassed: false,
+		parameters: {},
+		preset: null,
+	};
+}
+
+/** A fake device node factory that records create/update/dispose calls by id,
+ * so reconciliation churn can be asserted precisely without any acoustic
+ * introspection of the resulting Tone graph. */
+function fakeFactory(log: string[]): import("./DeviceChain").DeviceNodeFactory {
+	return (d) => {
+		log.push(`create:${d.id}`);
+		const node = new Tone.Gain(1);
+		return {
+			id: d.id,
+			type: d.type,
+			input: node,
+			output: node,
+			update(next) {
+				log.push(`update:${next.id}`);
+			},
+			dispose() {
+				log.push(`dispose:${d.id}`);
+				node.dispose();
+			},
+		};
+	};
+}
+
+describe("DeviceChain", () => {
+	it("creates one node per device and reuses it on a parameter-only reconcile", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const log: string[] = [];
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory(log));
+
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		expect(log).toEqual(["create:dev_a", "create:dev_b"]);
+
+		log.length = 0;
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		expect(log).toEqual(["update:dev_a", "update:dev_b"]);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("adding one device creates only that device's node", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const log: string[] = [];
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory(log));
+
+		chain.reconcile([device("dev_a", 0)]);
+		log.length = 0;
+
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		expect(log).toEqual(["update:dev_a", "create:dev_b"]);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("removing one device disposes only that device's node", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const log: string[] = [];
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory(log));
+
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		log.length = 0;
+
+		chain.reconcile([device("dev_a", 0)]);
+		expect(log).toEqual(["dispose:dev_b", "update:dev_a"]);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("reordering existing devices reuses every node — no create or dispose", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const log: string[] = [];
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory(log));
+
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		log.length = 0;
+
+		chain.reconcile([device("dev_b", 0), device("dev_a", 1)]);
+		expect(log.filter((entry) => entry.startsWith("create"))).toEqual([]);
+		expect(log.filter((entry) => entry.startsWith("dispose"))).toEqual([]);
+		expect(log).toEqual(["update:dev_b", "update:dev_a"]);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("an unrelated bypass/parameter edit does not touch other devices", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const log: string[] = [];
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory(log));
+
+		chain.reconcile([
+			device("dev_a", 0),
+			device("dev_b", 1),
+			device("dev_c", 2),
+		]);
+		log.length = 0;
+
+		chain.reconcile([
+			device("dev_a", 0),
+			{ ...device("dev_b", 1), bypassed: true },
+			device("dev_c", 2),
+		]);
+		// Every surviving device gets `update()` (bypass is applied there) but
+		// none is created or disposed.
+		expect(log.filter((entry) => entry.startsWith("create"))).toEqual([]);
+		expect(log.filter((entry) => entry.startsWith("dispose"))).toEqual([]);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("dispose() tears down every device node and the chain's own shell; idempotent", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const log: string[] = [];
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory(log));
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+
+		const baseline = runtime.diagnostics().resources.total;
+		expect(baseline).toBeGreaterThan(0);
+
+		chain.dispose();
+		chain.dispose(); // idempotent — no duplicate dispose, no throw
+
+		await Promise.resolve();
+		expect(runtime.diagnostics().resources.total).toBe(0);
+		expect(log.filter((e) => e.startsWith("dispose")).sort()).toEqual([
+			"dispose:dev_a",
+			"dispose:dev_b",
+		]);
+
+		await runtime.close();
+	});
+
+	it("the default passthrough device leaves a signal unchanged", async () => {
+		const rendered = await Tone.Offline(({ destination }) => {
+			const runtime = new AudioRuntimeModule.AudioRuntime();
+			const scope = runtime.openProjectScope("p");
+			const chain = new DeviceChainModule.DeviceChain(scope);
+			chain.output.connect(destination);
+			chain.reconcile([device("dev_a", 0)]);
+
+			const noise = new Tone.Noise("white").connect(chain.input).start(0);
+			noise.stop(0.05);
+		}, 0.05);
+
+		expect(rms(Float32Array.from(rendered.getChannelData(0)))).toBeGreaterThan(
+			0.01,
+		);
+	});
+});

--- a/src/audio/DeviceChain.ts
+++ b/src/audio/DeviceChain.ts
@@ -1,0 +1,140 @@
+import * as Tone from "tone";
+import type { Device } from "../domain/entities";
+import type { DeviceId } from "../domain/ids";
+import type { AudioProjectScope } from "./AudioRuntime";
+
+/**
+ * One node (or small internal subgraph) in an ordered insert chain, keyed by
+ * the device's stable id (PRD AUD-08, section 9.7). `update()` must apply
+ * bypass and parameter changes to the *existing* node — a device is only ever
+ * recreated when its `type` changes, which `DeviceChain` treats as "remove
+ * the old id, add the new one" since a device's `id` is stable across a type
+ * change only if a future command explicitly retypes it in place (schema v1
+ * has no such command yet).
+ */
+export interface DeviceNode {
+	readonly id: DeviceId;
+	readonly type: string;
+	readonly input: Tone.ToneAudioNode;
+	readonly output: Tone.ToneAudioNode;
+	update(device: Device): void;
+	dispose(): void;
+}
+
+export type DeviceNodeFactory = (device: Device) => DeviceNode;
+
+/**
+ * Schema v1 defines the generic `Device` shape (id, type, order, bypass,
+ * parameters) but no concrete processors — filter/EQ, overdrive, compression,
+ * delay, and reverb are authored with their devices in Phase 1 (PRD section
+ * 7.3). Until a factory is registered for a `device.type`, the chain gives it
+ * an inert passthrough node instead of refusing to build the graph, so
+ * topology — insertion, removal, and reordering — is fully provable ahead of
+ * any real DSP.
+ */
+export function createPassthroughDeviceNode(device: Device): DeviceNode {
+	const node = new Tone.Gain(1);
+	return {
+		id: device.id,
+		type: device.type,
+		input: node,
+		output: node,
+		update() {
+			// A passthrough has no parameters to apply or smooth.
+		},
+		dispose() {
+			node.dispose();
+		},
+	};
+}
+
+const defaultDeviceNodeFactory: DeviceNodeFactory = createPassthroughDeviceNode;
+
+interface TrackedDevice {
+	node: DeviceNode;
+	handle: ReturnType<AudioProjectScope["register"]>;
+}
+
+/**
+ * An ordered, ID-keyed insert chain shared by tracks, return buses, and the
+ * master bus. Reconciling against a new `Device[]` reuses every node whose id
+ * is still present — only devices actually added or removed create or
+ * dispose a node — and only relinks the signal path when composition or order
+ * changed, never on a bypass/parameter-only edit.
+ */
+export class DeviceChain {
+	readonly input: Tone.Gain;
+	readonly output: Tone.Gain;
+	private readonly nodes = new Map<DeviceId, TrackedDevice>();
+	private order: DeviceId[] = [];
+	private readonly chainHandle: ReturnType<AudioProjectScope["register"]>;
+
+	constructor(
+		private readonly scope: AudioProjectScope,
+		private readonly createNode: DeviceNodeFactory = defaultDeviceNodeFactory,
+	) {
+		this.input = new Tone.Gain(1);
+		this.output = new Tone.Gain(1);
+		this.input.connect(this.output);
+		this.chainHandle = this.scope.register("node", () => {
+			this.input.dispose();
+			this.output.dispose();
+		});
+	}
+
+	/** Reconciles this chain's devices, ordered by chain position (`order`). */
+	reconcile(devices: readonly Device[]): void {
+		const nextIds = devices.map((device) => device.id);
+		const nextIdSet = new Set(nextIds);
+
+		for (const [id, tracked] of this.nodes) {
+			if (!nextIdSet.has(id)) {
+				void this.scope.release(tracked.handle);
+				this.nodes.delete(id);
+			}
+		}
+
+		let compositionChanged = false;
+		for (const device of devices) {
+			const existing = this.nodes.get(device.id);
+			if (existing) {
+				existing.node.update(device);
+			} else {
+				const node = this.createNode(device);
+				const handle = this.scope.register("node", () => node.dispose());
+				this.nodes.set(device.id, { node, handle });
+				compositionChanged = true;
+			}
+		}
+
+		const orderChanged =
+			this.order.length !== nextIds.length ||
+			this.order.some((id, index) => id !== nextIds[index]);
+		this.order = nextIds;
+
+		if (compositionChanged || orderChanged) this.relink();
+	}
+
+	private relink(): void {
+		this.input.disconnect();
+		let previous: Tone.ToneAudioNode = this.input;
+		for (const id of this.order) {
+			const tracked = this.nodes.get(id);
+			if (!tracked) continue;
+			tracked.node.output.disconnect();
+			previous.connect(tracked.node.input);
+			previous = tracked.node.output;
+		}
+		previous.connect(this.output);
+	}
+
+	/** Tears down every device node and this chain's own shell. Idempotent. */
+	dispose(): void {
+		for (const [, tracked] of this.nodes) {
+			void this.scope.release(tracked.handle);
+		}
+		this.nodes.clear();
+		this.order = [];
+		void this.scope.release(this.chainHandle);
+	}
+}

--- a/src/audio/InstrumentGraph.test.ts
+++ b/src/audio/InstrumentGraph.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { DrumPad, Instrument } from "../domain/entities";
+import type { AssetId, PadId } from "../domain/ids";
+import { createSeededIdFactory } from "../domain/ids";
+import type { AudioAssetProjection } from "../projection/audioProjection";
+import { installWebAudioGlobals } from "./testAudioContext";
+
+installWebAudioGlobals();
+
+let AudioRuntimeModule: typeof import("./AudioRuntime");
+let AudioBufferCacheModule: typeof import("./AudioBufferCache");
+let InstrumentGraphModule: typeof import("./InstrumentGraph");
+
+beforeAll(async () => {
+	AudioRuntimeModule = await import("./AudioRuntime");
+	AudioBufferCacheModule = await import("./AudioBufferCache");
+	InstrumentGraphModule = await import("./InstrumentGraph");
+});
+
+afterEach(async () => {
+	try {
+		await AudioRuntimeModule.getAudioRuntime().close();
+	} catch {
+		// already closed
+	}
+	AudioRuntimeModule.__resetAudioRuntimeForTests();
+});
+
+const ids = createSeededIdFactory("instrument-graph-test");
+
+function asset(id: AssetId, fingerprint = "f1"): AudioAssetProjection {
+	return {
+		id,
+		kind: "sample",
+		storageRef: `samples/${id}.wav`,
+		url: `/samples/${id}.wav`,
+		durationSeconds: 1,
+		sampleRate: 44_100,
+		channelCount: 1,
+		fingerprint,
+	};
+}
+
+/** A loader that resolves immediately with a distinct fake buffer per call,
+ * so tests can assert which decode ended up installed. */
+function immediateLoader(): {
+	loader: import("./AudioBufferCache").AssetBufferLoader<{
+		label: string;
+		dispose(): void;
+	}>;
+	created: { label: string; dispose: () => void }[];
+} {
+	const created: { label: string; dispose: () => void }[] = [];
+	return {
+		loader: {
+			async load(a) {
+				const dispose = vi.fn();
+				const buffer = { label: `${a.id}@${a.fingerprint}`, dispose };
+				created.push(buffer);
+				return buffer;
+			},
+		},
+		created,
+	};
+}
+
+function makeContext(scope: import("./AudioRuntime").AudioProjectScope) {
+	const { loader } = immediateLoader();
+	const assetsById = new Map<AssetId, AudioAssetProjection>();
+	const bufferCache = new AudioBufferCacheModule.AudioBufferCache(
+		loader as unknown as import("./AudioBufferCache").AssetBufferLoader<
+			import("tone").ToneAudioBuffer
+		>,
+	);
+	return {
+		context: { scope, assetsById, bufferCache },
+		assetsById,
+		bufferCache,
+	};
+}
+
+describe("createInstrumentNode", () => {
+	it("sampler: triggers nothing until its asset buffer resolves", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const { context, assetsById } = makeContext(scope);
+		const assetId = ids("asset");
+		assetsById.set(assetId, asset(assetId));
+
+		const instrument: Instrument = {
+			kind: "sampler",
+			assetId,
+			parameters: {},
+		};
+		const node = InstrumentGraphModule.createInstrumentNode(
+			instrument,
+			context,
+		);
+		expect(node.kind).toBe("sampler");
+
+		// Buffer decode is async even with an immediate loader (a real
+		// `Promise` still needs a microtask to settle) — before that, a
+		// trigger must not throw or play a half-loaded buffer.
+		expect(() =>
+			node.trigger({ kind: "pitch", pitch: 60 }, 0, "8n", 0.8),
+		).not.toThrow();
+
+		node.dispose();
+		await runtime.close();
+	});
+
+	it("sampler: swapping the asset releases the old buffer subscription and attaches the new one", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const { context, assetsById } = makeContext(scope);
+		const assetA = ids("asset");
+		const assetB = ids("asset");
+		assetsById.set(assetA, asset(assetA));
+		assetsById.set(assetB, asset(assetB));
+
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "sampler", assetId: assetA, parameters: {} },
+			context,
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+		const before = context.bufferCache.diagnostics().cachedAssets;
+		expect(before).toBe(1);
+
+		node.update({ kind: "sampler", assetId: assetB, parameters: {} });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Asset A's subscription was released (no other consumer), asset B's
+		// was created — one cached asset either way, not an accumulating set.
+		expect(context.bufferCache.diagnostics().cachedAssets).toBe(1);
+
+		node.dispose();
+		await runtime.close();
+	});
+
+	it("sampler: update() with the same asset id does not resubscribe", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const { context, assetsById, bufferCache } = makeContext(scope);
+		const assetId = ids("asset");
+		assetsById.set(assetId, asset(assetId));
+
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "sampler", assetId, parameters: {} },
+			context,
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+		const subscriptionsBefore =
+			runtime.diagnostics().resources.byType.subscription;
+
+		node.update({ kind: "sampler", assetId, parameters: {} });
+		expect(runtime.diagnostics().resources.byType.subscription).toBe(
+			subscriptionsBefore,
+		);
+		void bufferCache;
+
+		node.dispose();
+		await runtime.close();
+	});
+
+	it("synth: triggers a pitched note without throwing and ignores pad triggers", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const { context } = makeContext(scope);
+
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "synth", parameters: {} },
+			context,
+		);
+		expect(node.kind).toBe("synth");
+		expect(() =>
+			node.trigger({ kind: "pitch", pitch: 60 }, 0, "8n", 0.8),
+		).not.toThrow();
+		expect(() =>
+			node.trigger({ kind: "pad", padId: "pad_x" as PadId }, 0, "8n", 0.8),
+		).not.toThrow();
+
+		node.dispose();
+		await runtime.close();
+	});
+
+	it("drumMachine: reconciling pads reuses unaffected pads and only replaces the changed one", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const { context, assetsById } = makeContext(scope);
+		const assetA = ids("asset");
+		const assetB = ids("asset");
+		assetsById.set(assetA, asset(assetA));
+		assetsById.set(assetB, asset(assetB));
+
+		const padId1 = ids("pad");
+		const padId2 = ids("pad");
+		function pad(id: PadId, assetId: AssetId): DrumPad {
+			return {
+				id,
+				name: id,
+				assetId,
+				chokeGroup: null,
+				parameters: {},
+				mixer: { volume: 0, pan: 0, muted: false },
+			};
+		}
+
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{
+				kind: "drumMachine",
+				pads: [pad(padId1, assetA), pad(padId2, assetB)],
+				parameters: {},
+			},
+			context,
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+		const baselineSubscriptions =
+			runtime.diagnostics().resources.byType.subscription ?? 0;
+		expect(baselineSubscriptions).toBe(2);
+
+		// Only pad 1's asset changes; pad 2 is untouched.
+		const assetC = ids("asset");
+		assetsById.set(assetC, asset(assetC));
+		node.update({
+			kind: "drumMachine",
+			pads: [pad(padId1, assetC), pad(padId2, assetB)],
+			parameters: {},
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Pad 1 re-subscribed (old released, new created); pad 2's own
+		// subscription was never touched, so the total count is unchanged.
+		expect(runtime.diagnostics().resources.byType.subscription).toBe(
+			baselineSubscriptions,
+		);
+
+		node.dispose();
+		await runtime.close();
+	});
+
+	it("drumMachine: removing a pad disposes only that pad's resources", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const { context, assetsById } = makeContext(scope);
+		const assetA = ids("asset");
+		assetsById.set(assetA, asset(assetA));
+		const padId1 = ids("pad");
+		const padId2 = ids("pad");
+		function pad(id: PadId): DrumPad {
+			return {
+				id,
+				name: id,
+				assetId: assetA,
+				chokeGroup: null,
+				parameters: {},
+				mixer: { volume: 0, pan: 0, muted: false },
+			};
+		}
+
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "drumMachine", pads: [pad(padId1), pad(padId2)], parameters: {} },
+			context,
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		node.update({
+			kind: "drumMachine",
+			pads: [pad(padId1)],
+			parameters: {},
+		});
+		await Promise.resolve();
+
+		expect(runtime.diagnostics().resources.byType.subscription).toBe(1);
+
+		node.dispose();
+		await Promise.resolve();
+		expect(runtime.diagnostics().resources.total).toBe(0);
+		await runtime.close();
+	});
+
+	it("dispose() is safe and releases every resource this instrument registered", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const { context, assetsById } = makeContext(scope);
+		const assetId = ids("asset");
+		assetsById.set(assetId, asset(assetId));
+
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "sampler", assetId, parameters: {} },
+			context,
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(runtime.diagnostics().resources.total).toBeGreaterThan(0);
+
+		node.dispose();
+		node.dispose(); // idempotent on the wrapper's own side; scope release below is what's asserted
+		await Promise.resolve();
+		expect(runtime.diagnostics().resources.total).toBe(0);
+
+		await runtime.close();
+	});
+});

--- a/src/audio/InstrumentGraph.test.ts
+++ b/src/audio/InstrumentGraph.test.ts
@@ -307,3 +307,52 @@ describe("createInstrumentNode", () => {
 		await runtime.close();
 	});
 });
+
+describe("playOneShot", () => {
+	it("starts the player at the requested offset inside the buffer", async () => {
+		const Tone = await import("tone");
+		const buffer = Tone.ToneAudioBuffer.fromArray(new Float32Array(1024));
+		const destination = new Tone.Gain(1);
+		const start = vi
+			.spyOn(Tone.Player.prototype, "start")
+			.mockImplementation(function mocked(this: unknown) {
+				return this as never;
+			});
+
+		try {
+			InstrumentGraphModule.playOneShot(
+				buffer,
+				destination,
+				0,
+				"192i",
+				1,
+				0.25,
+			);
+			expect(start).toHaveBeenCalledWith(0, 0.25, "192i");
+		} finally {
+			start.mockRestore();
+			destination.dispose();
+			buffer.dispose();
+		}
+	});
+
+	it("defaults to the start of the buffer when no offset is given", async () => {
+		const Tone = await import("tone");
+		const buffer = Tone.ToneAudioBuffer.fromArray(new Float32Array(1024));
+		const destination = new Tone.Gain(1);
+		const start = vi
+			.spyOn(Tone.Player.prototype, "start")
+			.mockImplementation(function mocked(this: unknown) {
+				return this as never;
+			});
+
+		try {
+			InstrumentGraphModule.playOneShot(buffer, destination, 0, "192i");
+			expect(start).toHaveBeenCalledWith(0, 0, "192i");
+		} finally {
+			start.mockRestore();
+			destination.dispose();
+			buffer.dispose();
+		}
+	});
+});

--- a/src/audio/InstrumentGraph.ts
+++ b/src/audio/InstrumentGraph.ts
@@ -48,6 +48,10 @@ export type InstrumentNodeFactory = (
  * Plays `buffer` once through `destination`, self-disposing once it stops —
  * the "short-lived source node" AUD-08 explicitly permits per note/trigger,
  * as long as its schedule and references don't accumulate after completion.
+ *
+ * `offsetSeconds` is a position inside the buffer's own timeline, so a clip
+ * or placement trimmed at its left edge starts from the material the
+ * arrangement draws rather than from sample zero.
  */
 export function playOneShot(
 	buffer: Tone.ToneAudioBuffer,
@@ -55,11 +59,12 @@ export function playOneShot(
 	time: Tone.Unit.Time,
 	duration: Tone.Unit.Time,
 	playbackRate = 1,
+	offsetSeconds = 0,
 ): void {
 	const player = new Tone.Player(buffer).connect(destination);
 	player.playbackRate = playbackRate;
 	player.onstop = () => player.dispose();
-	player.start(time, 0, duration);
+	player.start(time, offsetSeconds, duration);
 }
 
 /** A live subscription to one asset's decoded buffer, reattachable to a new asset id. */

--- a/src/audio/InstrumentGraph.ts
+++ b/src/audio/InstrumentGraph.ts
@@ -1,0 +1,280 @@
+import * as Tone from "tone";
+import type { DrumPad, Instrument, NoteTrigger } from "../domain/entities";
+import type { AssetId, PadId } from "../domain/ids";
+import type { AudioAssetProjection } from "../projection/audioProjection";
+import type { AudioBufferCache, BufferSubscription } from "./AudioBufferCache";
+import type { AudioProjectScope } from "./AudioRuntime";
+
+/** Schema v1 models `Instrument` as one discriminated union rather than
+ * exporting each variant separately; these local aliases narrow it by `kind`
+ * for the factory below. */
+type SamplerInstrument = Extract<Instrument, { kind: "sampler" }>;
+type SynthInstrument = Extract<Instrument, { kind: "synth" }>;
+type DrumMachineInstrument = Extract<Instrument, { kind: "drumMachine" }>;
+
+/**
+ * A track's sound source, keyed to the track by the track graph that owns it
+ * (PRD AUD-08, section 9.7). `update()` applies an instrument of the *same*
+ * `kind` in place — asset swaps, drum-pad add/remove, and generic parameter
+ * edits are all handled without replacing this node. The owning
+ * `TrackAudioGraph` only ever replaces the whole node when `kind` itself
+ * changes (sampler <-> synth <-> drumMachine, or null <-> present).
+ */
+export interface InstrumentNode {
+	readonly kind: Instrument["kind"];
+	readonly output: Tone.ToneAudioNode;
+	trigger(
+		trigger: NoteTrigger,
+		time: Tone.Unit.Time,
+		duration: Tone.Unit.Time,
+		velocity: number,
+	): void;
+	update(instrument: Instrument): void;
+	dispose(): void;
+}
+
+export interface InstrumentGraphContext {
+	readonly scope: AudioProjectScope;
+	readonly assetsById: ReadonlyMap<AssetId, AudioAssetProjection>;
+	readonly bufferCache: AudioBufferCache<Tone.ToneAudioBuffer>;
+}
+
+export type InstrumentNodeFactory = (
+	instrument: Instrument,
+	context: InstrumentGraphContext,
+) => InstrumentNode;
+
+/**
+ * Plays `buffer` once through `destination`, self-disposing once it stops —
+ * the "short-lived source node" AUD-08 explicitly permits per note/trigger,
+ * as long as its schedule and references don't accumulate after completion.
+ */
+export function playOneShot(
+	buffer: Tone.ToneAudioBuffer,
+	destination: Tone.ToneAudioNode,
+	time: Tone.Unit.Time,
+	duration: Tone.Unit.Time,
+	playbackRate = 1,
+): void {
+	const player = new Tone.Player(buffer).connect(destination);
+	player.playbackRate = playbackRate;
+	player.onstop = () => player.dispose();
+	player.start(time, 0, duration);
+}
+
+/** A live subscription to one asset's decoded buffer, reattachable to a new asset id. */
+interface AssetVoice {
+	assetId: AssetId | null;
+	buffer: Tone.ToneAudioBuffer | null;
+	subscription: BufferSubscription | null;
+	subscriptionHandle: ReturnType<AudioProjectScope["register"]> | null;
+}
+
+function createAssetVoice(): AssetVoice {
+	return {
+		assetId: null,
+		buffer: null,
+		subscription: null,
+		subscriptionHandle: null,
+	};
+}
+
+function attachAssetVoice(
+	voice: AssetVoice,
+	context: InstrumentGraphContext,
+	assetId: AssetId | null,
+): void {
+	voice.subscription?.release();
+	voice.subscription = null;
+	if (voice.subscriptionHandle) {
+		void context.scope.release(voice.subscriptionHandle);
+		voice.subscriptionHandle = null;
+	}
+	voice.buffer = null;
+	voice.assetId = assetId;
+	if (!assetId) return;
+
+	const asset = context.assetsById.get(assetId);
+	if (!asset) return;
+
+	voice.subscriptionHandle = context.scope.register("subscription", () => {});
+	voice.subscription = context.bufferCache.subscribe(asset, (buffer) => {
+		voice.buffer = buffer;
+	});
+}
+
+function releaseAssetVoice(voice: AssetVoice, scope: AudioProjectScope): void {
+	voice.subscription?.release();
+	voice.subscription = null;
+	if (voice.subscriptionHandle) {
+		void scope.release(voice.subscriptionHandle);
+		voice.subscriptionHandle = null;
+	}
+	voice.buffer = null;
+}
+
+// --- Sampler -----------------------------------------------------------
+
+function createSamplerInstrumentNode(
+	instrument: SamplerInstrument,
+	context: InstrumentGraphContext,
+): InstrumentNode {
+	const output = new Tone.Gain(1);
+	const voice = createAssetVoice();
+	attachAssetVoice(voice, context, instrument.assetId);
+
+	return {
+		kind: "sampler",
+		output,
+		trigger(trigger, time, duration) {
+			// Per-pitch playback rate and round-robin are Phase 1 sampler-device
+			// concerns; the v1 scaffold plays the loaded one-shot at normal rate
+			// on any pitch trigger so the note-scheduling contract is provable
+			// ahead of that DSP.
+			if (trigger.kind !== "pitch" || !voice.buffer) return;
+			playOneShot(voice.buffer, output, time, duration);
+		},
+		update(next) {
+			if (next.kind !== "sampler") return;
+			if (next.assetId !== voice.assetId) {
+				attachAssetVoice(voice, context, next.assetId);
+			}
+		},
+		dispose() {
+			releaseAssetVoice(voice, context.scope);
+			output.dispose();
+		},
+	};
+}
+
+// --- Synth ---------------------------------------------------------------
+
+function createSynthInstrumentNode(
+	_instrument: SynthInstrument,
+	_context: InstrumentGraphContext,
+): InstrumentNode {
+	const synth = new Tone.PolySynth(Tone.Synth);
+	const output = new Tone.Gain(1);
+	synth.connect(output);
+
+	return {
+		kind: "synth",
+		output,
+		trigger(trigger, time, duration, velocity) {
+			if (trigger.kind !== "pitch") return;
+			const note = Tone.Frequency(trigger.pitch, "midi").toNote();
+			synth.triggerAttackRelease(note, duration, time, velocity);
+		},
+		update(next) {
+			if (next.kind !== "synth") return;
+			// Schema v1 defines no synth parameters yet — Phase 1 authors them
+			// with the synth device (PRD section 9.5 invariant 10). `parameters`
+			// is carried through for forward compatibility only.
+		},
+		dispose() {
+			synth.dispose();
+			output.dispose();
+		},
+	};
+}
+
+// --- Drum machine ----------------------------------------------------------
+
+interface DrumPadVoice extends AssetVoice {
+	readonly gain: Tone.Gain;
+}
+
+function createDrumPadVoice(
+	pad: DrumPad,
+	context: InstrumentGraphContext,
+	destination: Tone.ToneAudioNode,
+): DrumPadVoice {
+	const gain = new Tone.Gain(
+		dbToLinear(pad.mixer.muted ? null : pad.mixer.volume),
+	).connect(destination);
+	const voice: DrumPadVoice = { ...createAssetVoice(), gain };
+	attachAssetVoice(voice, context, pad.assetId);
+	return voice;
+}
+
+function updateDrumPadMixer(
+	voice: DrumPadVoice,
+	mixer: DrumPad["mixer"],
+): void {
+	voice.gain.gain.rampTo(dbToLinear(mixer.muted ? null : mixer.volume), 0.02);
+}
+
+/** `null` (muted) collapses to silence; otherwise converts the stored decibel value to linear gain. */
+function dbToLinear(db: number | null): number {
+	return db === null ? 0 : Tone.dbToGain(db);
+}
+
+function createDrumMachineInstrumentNode(
+	instrument: DrumMachineInstrument,
+	context: InstrumentGraphContext,
+): InstrumentNode {
+	const output = new Tone.Gain(1);
+	const voices = new Map<PadId, DrumPadVoice>();
+
+	function reconcilePads(pads: readonly DrumPad[]): void {
+		const nextIds = new Set(pads.map((pad) => pad.id));
+		for (const [id, voice] of voices) {
+			if (!nextIds.has(id)) {
+				releaseAssetVoice(voice, context.scope);
+				voice.gain.dispose();
+				voices.delete(id);
+			}
+		}
+		for (const pad of pads) {
+			const existing = voices.get(pad.id);
+			if (existing) {
+				if (existing.assetId !== pad.assetId) {
+					attachAssetVoice(existing, context, pad.assetId);
+				}
+				updateDrumPadMixer(existing, pad.mixer);
+			} else {
+				voices.set(pad.id, createDrumPadVoice(pad, context, output));
+			}
+		}
+	}
+	reconcilePads(instrument.pads);
+
+	return {
+		kind: "drumMachine",
+		output,
+		trigger(trigger, time, duration) {
+			if (trigger.kind !== "pad") return;
+			const voice = voices.get(trigger.padId);
+			if (!voice?.buffer) return;
+			playOneShot(voice.buffer, voice.gain, time, duration);
+		},
+		update(next) {
+			if (next.kind !== "drumMachine") return;
+			reconcilePads(next.pads);
+		},
+		dispose() {
+			for (const voice of voices.values()) {
+				releaseAssetVoice(voice, context.scope);
+				voice.gain.dispose();
+			}
+			voices.clear();
+			output.dispose();
+		},
+	};
+}
+
+// --- Factory ---------------------------------------------------------------
+
+export function createInstrumentNode(
+	instrument: Instrument,
+	context: InstrumentGraphContext,
+): InstrumentNode {
+	switch (instrument.kind) {
+		case "sampler":
+			return createSamplerInstrumentNode(instrument, context);
+		case "synth":
+			return createSynthInstrumentNode(instrument, context);
+		case "drumMachine":
+			return createDrumMachineInstrumentNode(instrument, context);
+	}
+}

--- a/src/audio/MasterAudioGraph.ts
+++ b/src/audio/MasterAudioGraph.ts
@@ -1,0 +1,53 @@
+import * as Tone from "tone";
+import type { AudioMasterProjection } from "../projection/audioProjection";
+import type { AudioProjectScope } from "./AudioRuntime";
+import { DeviceChain, type DeviceNodeFactory } from "./DeviceChain";
+
+/**
+ * The master bus's audio subgraph (PRD AUD-08, section 9.7): an ordered
+ * device chain feeding a volume stage connected to the runtime's shared
+ * destination. There is exactly one of these per {@link ProjectAudioGraph}
+ * and it is never rebuilt for a routine edit — only its device chain and
+ * volume are reconciled in place.
+ */
+export class MasterAudioGraph {
+	private readonly deviceChain: DeviceChain;
+	private readonly volume: Tone.Volume;
+	private readonly volumeHandle: ReturnType<AudioProjectScope["register"]>;
+	private lastProjection: AudioMasterProjection | null = null;
+	private disposed = false;
+
+	constructor(
+		private readonly scope: AudioProjectScope,
+		destination: Tone.ToneAudioNode,
+		createDeviceNode?: DeviceNodeFactory,
+	) {
+		this.deviceChain = new DeviceChain(scope, createDeviceNode);
+		this.volume = new Tone.Volume(0);
+		this.volumeHandle = scope.register("node", () => {
+			this.volume.dispose();
+		});
+		this.deviceChain.output.connect(this.volume);
+		this.volume.connect(destination);
+	}
+
+	/** Where a track or return's post-fader signal connects. */
+	get input(): Tone.ToneAudioNode {
+		return this.deviceChain.input;
+	}
+
+	reconcile(next: AudioMasterProjection): void {
+		if (this.lastProjection === next) return;
+		this.deviceChain.reconcile(next.devices);
+		this.volume.volume.rampTo(next.volume, 0.02);
+		this.lastProjection = next;
+	}
+
+	/** Tears down every node the master bus owns. Safe to call more than once. */
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.deviceChain.dispose();
+		void this.scope.release(this.volumeHandle);
+	}
+}

--- a/src/audio/ProjectAudioGraph.test.ts
+++ b/src/audio/ProjectAudioGraph.test.ts
@@ -1,0 +1,457 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Project } from "../domain/entities";
+import { createFactoryContext, createReturnBus } from "../domain/factories";
+import {
+	createReferenceProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { createSeededIdFactory } from "../domain/ids";
+import { TICKS_PER_SIXTEENTH } from "../domain/time";
+import { buildAudioProjection } from "../projection/audioProjection";
+import { installWebAudioGlobals } from "./testAudioContext";
+
+installWebAudioGlobals();
+
+let AudioRuntimeModule: typeof import("./AudioRuntime");
+let ProjectAudioGraphModule: typeof import("./ProjectAudioGraph");
+
+beforeAll(async () => {
+	AudioRuntimeModule = await import("./AudioRuntime");
+	ProjectAudioGraphModule = await import("./ProjectAudioGraph");
+});
+
+afterEach(async () => {
+	try {
+		await AudioRuntimeModule.getAudioRuntime().close();
+	} catch {
+		// already closed
+	}
+	AudioRuntimeModule.__resetAudioRuntimeForTests();
+});
+
+/** A deterministic transport double: records every schedule/clear call by id
+ * instead of touching a real Tone.Transport, so scheduling can be asserted
+ * without any timing dependence. */
+function fakeTransport(): import("./ProjectAudioGraph").AudioTransport & {
+	scheduled: Map<number, string>;
+	cleared: number[];
+} {
+	let nextId = 1;
+	const scheduled = new Map<number, string>();
+	const cleared: number[] = [];
+	return {
+		bpm: { value: 120 },
+		scheduled,
+		cleared,
+		schedule(_callback, time) {
+			const id = nextId++;
+			scheduled.set(id, time);
+			return id;
+		},
+		clear(id) {
+			cleared.push(id);
+			scheduled.delete(id);
+		},
+	};
+}
+
+/** A loader that resolves manually, so cache races (asset replaced mid-decode)
+ * are fully controllable from the test. */
+function manualBufferLoader(): {
+	loader: import("./AudioBufferCache").AssetBufferLoader<
+		import("tone").ToneAudioBuffer
+	>;
+	pending: {
+		fingerprint: string;
+		resolve: (buffer: import("tone").ToneAudioBuffer) => void;
+	}[];
+} {
+	const pending: {
+		fingerprint: string;
+		resolve: (buffer: import("tone").ToneAudioBuffer) => void;
+	}[] = [];
+	return {
+		pending,
+		loader: {
+			load(asset) {
+				return new Promise((resolve) => {
+					pending.push({ fingerprint: asset.fingerprint, resolve });
+				});
+			},
+		},
+	};
+}
+
+function fakeBuffer(): import("tone").ToneAudioBuffer {
+	return { dispose: () => {} } as unknown as import("tone").ToneAudioBuffer;
+}
+
+describe("ProjectAudioGraph", () => {
+	it("reconciling the same projection object twice is a full no-op", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+		const project = createSliceFixtureProject();
+		const projection = buildAudioProjection(project);
+
+		graph.reconcile(projection);
+		const afterFirst = { ...graph.diagnostics() };
+
+		graph.reconcile(projection);
+		expect(graph.diagnostics()).toEqual(afterFirst);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("editing one track's mixer does not touch other tracks' graphs", async () => {
+		const project = createReferenceProject({
+			trackCount: 4,
+			placementCount: 8,
+		});
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+
+		const before = buildAudioProjection(project);
+		graph.reconcile(before);
+		const [changedTrack, ...untouched] = project.song.tracks;
+		const untouchedGraphsBefore = untouched.map((t) =>
+			graph.trackGraphs.get(t.id),
+		);
+
+		const edited: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.map((track) =>
+					track.id === changedTrack.id
+						? { ...track, mixer: { ...track.mixer, volume: -20 } }
+						: track,
+				),
+			},
+		};
+		const after = buildAudioProjection(edited, before);
+		graph.reconcile(after);
+
+		untouched.forEach((track, index) => {
+			expect(graph.trackGraphs.get(track.id)).toBe(
+				untouchedGraphsBefore[index],
+			);
+		});
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("renaming a track is a complete no-op for its audio graph", async () => {
+		const project = createSliceFixtureProject();
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+
+		const before = buildAudioProjection(project);
+		graph.reconcile(before);
+		const trackId = project.song.tracks[0].id;
+		const graphBefore = graph.trackGraphs.get(trackId);
+
+		const renamed: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.map((track) => ({
+					...track,
+					name: "Renamed",
+				})),
+			},
+		};
+		const after = buildAudioProjection(renamed, before);
+		graph.reconcile(after);
+
+		expect(graph.trackGraphs.get(trackId)).toBe(graphBefore);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("schedules one transport event per note event, at the placement-relative absolute tick", async () => {
+		const project = createSliceFixtureProject();
+		const transport = fakeTransport();
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport,
+		});
+
+		graph.reconcile(buildAudioProjection(project));
+
+		const times = [...transport.scheduled.values()].sort();
+		expect(times).toEqual(
+			[0, 4, 8, 12]
+				.map((sixteenth) => sixteenth * TICKS_PER_SIXTEENTH)
+				.map((ticks) => `${ticks}i`)
+				.sort(),
+		);
+		expect(graph.diagnostics().scheduledPlacements).toBe(1);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("clears every scheduled event for a placement that is removed", async () => {
+		const project = createSliceFixtureProject();
+		const transport = fakeTransport();
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport,
+		});
+
+		const before = buildAudioProjection(project);
+		graph.reconcile(before);
+		expect(transport.scheduled.size).toBe(4);
+
+		const emptied: Project = {
+			...project,
+			song: { ...project.song, placements: [] },
+		};
+		graph.reconcile(buildAudioProjection(emptied, before));
+
+		expect(transport.scheduled.size).toBe(0);
+		expect(transport.cleared).toHaveLength(4);
+		expect(graph.diagnostics().scheduledPlacements).toBe(0);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("swapping a track's instrument asset releases the old buffer subscription and attaches the new one", async () => {
+		const project = createSliceFixtureProject();
+		const { loader, pending } = manualBufferLoader();
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+			bufferLoader: loader,
+		});
+
+		const before = buildAudioProjection(project);
+		graph.reconcile(before);
+		pending[0].resolve(fakeBuffer());
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(graph.diagnostics().buffers.cachedAssets).toBe(1);
+		const subscriptionsBefore =
+			runtime.diagnostics().resources.byType.subscription;
+
+		const newAsset = {
+			...project.song.assets[0],
+			id: createSeededIdFactory("swap-asset")("asset"),
+		};
+		const track = project.song.tracks[0];
+		if (track.instrument?.kind !== "sampler") {
+			throw new Error("expected the slice fixture's track to be a sampler");
+		}
+		const instrument = track.instrument;
+		const edited: Project = {
+			...project,
+			song: {
+				...project.song,
+				assets: [...project.song.assets, newAsset],
+				tracks: project.song.tracks.map((t) =>
+					t.id === track.id
+						? { ...t, instrument: { ...instrument, assetId: newAsset.id } }
+						: t,
+				),
+			},
+		};
+		graph.reconcile(buildAudioProjection(edited, before));
+		pending[1].resolve(fakeBuffer());
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Old asset's subscription released, new asset's created: the count of
+		// live subscriptions this track holds does not grow.
+		expect(runtime.diagnostics().resources.byType.subscription).toBe(
+			subscriptionsBefore,
+		);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("replacing an asset's content twice in a row never lets the stale decode win, and never recreates the instrument", async () => {
+		const project = createSliceFixtureProject();
+		const { loader, pending } = manualBufferLoader();
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+			bufferLoader: loader,
+		});
+
+		const before = buildAudioProjection(project);
+		graph.reconcile(before);
+		const trackGraphBefore = graph.trackGraphs.get(project.song.tracks[0].id);
+		// The initial decode is left unresolved on purpose — a track/instrument
+		// reconcile must never depend on a buffer already being loaded.
+
+		const withUrl = (project: Project, url: string): Project => ({
+			...project,
+			song: {
+				...project.song,
+				assets: project.song.assets.map((asset) => ({ ...asset, url })),
+			},
+		});
+
+		let latest = before;
+		latest = buildAudioProjection(withUrl(project, "/samples/v2.wav"), latest);
+		graph.reconcile(latest);
+		latest = buildAudioProjection(withUrl(project, "/samples/v3.wav"), latest);
+		graph.reconcile(latest);
+
+		// Only the asset's content changed, not which asset id the track
+		// references, so the track's instrument identity is untouched
+		// throughout every one of these edits.
+		expect(graph.trackGraphs.get(project.song.tracks[0].id)).toBe(
+			trackGraphBefore,
+		);
+		expect(pending).toHaveLength(3);
+
+		// Resolve out of order: the newest decode first, then the two stale
+		// ones. Neither stale completion may overwrite the newest result.
+		pending[2].resolve(fakeBuffer());
+		await Promise.resolve();
+		await Promise.resolve();
+		pending[1].resolve(fakeBuffer());
+		pending[0].resolve(fakeBuffer());
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(graph.diagnostics().buffers.cachedAssets).toBe(1);
+		expect(graph.diagnostics().buffers.pendingLoads).toBe(0);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("removing a return bus disposes it only after the track sends targeting it are gone", async () => {
+		const context = createFactoryContext();
+		const bus = createReturnBus(context, { name: "Reverb", order: 0 });
+		const project = createSliceFixtureProject();
+		const withReturn: Project = {
+			...project,
+			song: {
+				...project.song,
+				returns: [bus],
+				tracks: project.song.tracks.map((track) => ({
+					...track,
+					sendConfig: [{ returnId: bus.id, level: 0.5, preFader: false }],
+				})),
+			},
+		};
+
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+		const before = buildAudioProjection(withReturn);
+		graph.reconcile(before);
+		expect(graph.returnGraphs.size).toBe(1);
+
+		const removed: Project = {
+			...withReturn,
+			song: {
+				...withReturn.song,
+				returns: [],
+				tracks: withReturn.song.tracks.map((track) => ({
+					...track,
+					sendConfig: [],
+				})),
+			},
+		};
+		expect(() =>
+			graph.reconcile(buildAudioProjection(removed, before)),
+		).not.toThrow();
+		expect(graph.returnGraphs.size).toBe(0);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("adding and removing a track creates/disposes only that track's graph", async () => {
+		const project = createReferenceProject({
+			trackCount: 2,
+			placementCount: 4,
+		});
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+
+		const before = buildAudioProjection(project);
+		graph.reconcile(before);
+		expect(graph.trackGraphs.size).toBe(2);
+		const survivingId = project.song.tracks[0].id;
+		const survivorBefore = graph.trackGraphs.get(survivingId);
+
+		const removedOne: Project = {
+			...project,
+			song: {
+				...project.song,
+				tracks: project.song.tracks.slice(0, 1),
+				placements: project.song.placements.filter(
+					(p) => p.trackId === survivingId,
+				),
+			},
+		};
+		graph.reconcile(buildAudioProjection(removedOne, before));
+		expect(graph.trackGraphs.size).toBe(1);
+		expect(graph.trackGraphs.get(survivingId)).toBe(survivorBefore);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("dispose() releases every resource this graph registered and is idempotent", async () => {
+		const project = createSliceFixtureProject();
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+
+		graph.reconcile(buildAudioProjection(project));
+		expect(runtime.diagnostics().resources.byOwner.p).toBeGreaterThan(0);
+
+		await graph.dispose();
+		await expect(graph.dispose()).resolves.toBeUndefined(); // idempotent
+
+		expect(runtime.diagnostics().resources.byOwner.p).toBeUndefined();
+
+		await runtime.close();
+	});
+
+	it("dispose() never touches the shared runtime or another project's scope", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const other = new ProjectAudioGraphModule.ProjectAudioGraph(
+			runtime,
+			"other",
+			{
+				transport: fakeTransport(),
+			},
+		);
+		other.reconcile(buildAudioProjection(createSliceFixtureProject()));
+
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+		graph.reconcile(buildAudioProjection(createSliceFixtureProject()));
+
+		await graph.dispose();
+
+		expect(runtime.diagnostics().resources.byOwner.other).toBeGreaterThan(0);
+		expect(runtime.getState()).not.toBe("closed");
+
+		await other.dispose();
+		await runtime.close();
+	});
+});

--- a/src/audio/ProjectAudioGraph.test.ts
+++ b/src/audio/ProjectAudioGraph.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Project } from "../domain/entities";
 import { createFactoryContext, createReturnBus } from "../domain/factories";
 import {
@@ -6,7 +6,7 @@ import {
 	createSliceFixtureProject,
 } from "../domain/fixtures";
 import { createSeededIdFactory } from "../domain/ids";
-import { TICKS_PER_SIXTEENTH } from "../domain/time";
+import { TICKS_PER_SIXTEENTH, ticksToSeconds } from "../domain/time";
 import { buildAudioProjection } from "../projection/audioProjection";
 import { installWebAudioGlobals } from "./testAudioContext";
 
@@ -35,22 +35,29 @@ afterEach(async () => {
 function fakeTransport(): import("./ProjectAudioGraph").AudioTransport & {
 	scheduled: Map<number, string>;
 	cleared: number[];
+	callbacks: Map<number, (time: number) => void>;
 } {
 	let nextId = 1;
 	const scheduled = new Map<number, string>();
 	const cleared: number[] = [];
+	// Kept so a test can fire a scheduled event and assert what actually
+	// reaches Tone, rather than only that something was scheduled.
+	const callbacks = new Map<number, (time: number) => void>();
 	return {
 		bpm: { value: 120 },
 		scheduled,
 		cleared,
-		schedule(_callback, time) {
+		callbacks,
+		schedule(callback, time) {
 			const id = nextId++;
 			scheduled.set(id, time);
+			callbacks.set(id, callback);
 			return id;
 		},
 		clear(id) {
 			cleared.push(id);
 			scheduled.delete(id);
+			callbacks.delete(id);
 		},
 	};
 }
@@ -452,6 +459,81 @@ describe("ProjectAudioGraph", () => {
 		expect(runtime.getState()).not.toBe("closed");
 
 		await other.dispose();
+		await runtime.close();
+	});
+
+	// Every fixture in this repo authors its audio at `sourceTempo === tempo`,
+	// where buffer seconds and song seconds coincide and a units bug in either
+	// `player.start()` argument is invisible. This is the one test that pulls
+	// them apart, so it is the only thing standing between a rate != 1 project
+	// and silently truncated or overrunning loops (also inherited by the
+	// AUD-05/AUD-06 offline and stem exports, which reuse this expansion).
+	it("hands Tone buffer-timeline seconds for a loop whose sample tempo differs from the song", async () => {
+		const Tone = await import("tone");
+		const base = createReferenceProject({
+			trackCount: 1,
+			waveformTrackCount: 1,
+			placementCount: 1,
+			minutes: 1,
+			automationLaneCount: 0,
+		});
+		// Authored at 60 BPM, played back in a 120 BPM song => playbackRate 2.
+		const project: Project = {
+			...base,
+			clips: base.clips.map((clip) =>
+				clip.content.kind === "audioLoop"
+					? { ...clip, content: { ...clip.content, sourceTempo: 60 } }
+					: clip,
+			),
+		};
+
+		const { loader, pending } = manualBufferLoader();
+		const transport = fakeTransport();
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport,
+			bufferLoader: loader,
+		});
+
+		const projection = buildAudioProjection(project);
+		graph.reconcile(projection);
+		for (const p of pending) p.resolve(fakeBuffer());
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const start = vi
+			.spyOn(Tone.Player.prototype, "start")
+			.mockImplementation(function mocked(this: unknown) {
+				return this as never;
+			});
+
+		try {
+			for (const callback of transport.callbacks.values()) callback(0);
+
+			expect(start).toHaveBeenCalled();
+			const [, offsetArg, durationArg] = start.mock.calls[0];
+			// Both must be plain buffer-seconds numbers. A tick string like
+			// "768i" here is the regression: Tone divides the duration by the
+			// playback rate, so song-timeline ticks sound for half as long at
+			// rate 2.
+			expect(typeof offsetArg).toBe("number");
+			expect(typeof durationArg).toBe("number");
+
+			// The scheduled event covers min(clip length, placement duration)
+			// of song time; at rate 2 that has to reach Tone doubled, so that
+			// Tone's divide-by-rate leaves the correct sounded length.
+			const clip = project.clips.find((c) => c.content.kind === "audioLoop");
+			const placement = project.song.placements.find(
+				(p) => p.clipId === clip?.id,
+			);
+			if (!clip || !placement) throw new Error("fixture has no audio loop");
+			const eventTicks = Math.min(clip.lengthTicks, placement.durationTicks);
+			expect(durationArg).toBeCloseTo(ticksToSeconds(eventTicks, 120) * 2);
+		} finally {
+			start.mockRestore();
+		}
+
+		await graph.dispose();
 		await runtime.close();
 	});
 });

--- a/src/audio/ProjectAudioGraph.ts
+++ b/src/audio/ProjectAudioGraph.ts
@@ -19,7 +19,11 @@ import { playOneShot } from "./InstrumentGraph";
 import { MasterAudioGraph } from "./MasterAudioGraph";
 import { ReturnAudioGraph } from "./ReturnAudioGraph";
 import type { ResourceHandle } from "./resourceRegistry";
-import { computePlacementSchedule, ticksToToneTime } from "./scheduling";
+import {
+	audioLoopOffsetSeconds,
+	computePlacementSchedule,
+	ticksToToneTime,
+} from "./scheduling";
 import { TrackAudioGraph } from "./TrackAudioGraph";
 import { toneBufferLoader } from "./toneBufferLoader";
 
@@ -300,6 +304,7 @@ export class ProjectAudioGraph {
 			if (asset) {
 				entry.handles.push(this.subscribeAudioLoopAsset(asset, bufferBox));
 			}
+			const offsetSeconds = audioLoopOffsetSeconds(loop, tempo);
 			const scheduleId = this.transport.schedule((time) => {
 				const track = this.tracks.get(loop.trackId);
 				if (track && bufferBox.current) {
@@ -309,6 +314,7 @@ export class ProjectAudioGraph {
 						time,
 						ticksToToneTime(loop.durationTicks),
 						loop.playbackRate,
+						offsetSeconds,
 					);
 				}
 			}, ticksToToneTime(loop.absoluteTicks));

--- a/src/audio/ProjectAudioGraph.ts
+++ b/src/audio/ProjectAudioGraph.ts
@@ -20,6 +20,7 @@ import { MasterAudioGraph } from "./MasterAudioGraph";
 import { ReturnAudioGraph } from "./ReturnAudioGraph";
 import type { ResourceHandle } from "./resourceRegistry";
 import {
+	audioLoopDurationSeconds,
 	audioLoopOffsetSeconds,
 	computePlacementSchedule,
 	ticksToToneTime,
@@ -305,6 +306,7 @@ export class ProjectAudioGraph {
 				entry.handles.push(this.subscribeAudioLoopAsset(asset, bufferBox));
 			}
 			const offsetSeconds = audioLoopOffsetSeconds(loop, tempo);
+			const durationSeconds = audioLoopDurationSeconds(loop, tempo);
 			const scheduleId = this.transport.schedule((time) => {
 				const track = this.tracks.get(loop.trackId);
 				if (track && bufferBox.current) {
@@ -312,7 +314,7 @@ export class ProjectAudioGraph {
 						bufferBox.current,
 						track.audioInput,
 						time,
-						ticksToToneTime(loop.durationTicks),
+						durationSeconds,
 						loop.playbackRate,
 						offsetSeconds,
 					);

--- a/src/audio/ProjectAudioGraph.ts
+++ b/src/audio/ProjectAudioGraph.ts
@@ -1,0 +1,364 @@
+import * as Tone from "tone";
+import type { AssetId, PlacementId, ReturnId, TrackId } from "../domain/ids";
+import type {
+	AudioAssetProjection,
+	AudioClipProjection,
+	AudioPlacementProjection,
+	AudioSongProjection,
+} from "../projection/audioProjection";
+import {
+	type AssetBufferLoader,
+	AudioBufferCache,
+	type AudioBufferCacheDiagnostics,
+	type BufferSubscription,
+} from "./AudioBufferCache";
+import type { AudioHost, AudioProjectScope } from "./AudioRuntime";
+import type { DeviceNodeFactory } from "./DeviceChain";
+import type { InstrumentNodeFactory } from "./InstrumentGraph";
+import { playOneShot } from "./InstrumentGraph";
+import { MasterAudioGraph } from "./MasterAudioGraph";
+import { ReturnAudioGraph } from "./ReturnAudioGraph";
+import type { ResourceHandle } from "./resourceRegistry";
+import { computePlacementSchedule, ticksToToneTime } from "./scheduling";
+import { TrackAudioGraph } from "./TrackAudioGraph";
+import { toneBufferLoader } from "./toneBufferLoader";
+
+/**
+ * The transport this graph schedules against. An interface rather than a
+ * direct `Tone.getTransport()` reference so scheduling can be reconciled and
+ * tested (owner-tracked handles, no leaked/duplicate schedules) without a
+ * real Tone context (PRD AUD-03/AUD-08).
+ */
+export interface AudioTransport {
+	bpm: { value: number };
+	schedule(callback: (time: number) => void, time: string): number;
+	clear(id: number): void;
+}
+
+const liveTransport: AudioTransport = {
+	get bpm() {
+		return Tone.getTransport().bpm;
+	},
+	schedule(callback, time) {
+		return Tone.getTransport().schedule(callback, time);
+	},
+	clear(id) {
+		Tone.getTransport().clear(id);
+	},
+};
+
+export interface ProjectAudioGraphOptions {
+	transport?: AudioTransport;
+	bufferLoader?: AssetBufferLoader<Tone.ToneAudioBuffer>;
+	createInstrument?: InstrumentNodeFactory;
+	createDeviceNode?: DeviceNodeFactory;
+}
+
+/** Everything scheduled for one placement, so a later reconcile pass can tell
+ * whether it needs to be re-derived (placement, clip, or tempo changed) or
+ * left alone, and can release exactly this placement's handles either way. */
+interface PlacementScheduleEntry {
+	placementRef: AudioPlacementProjection;
+	clipRef: AudioClipProjection;
+	tempo: number;
+	handles: ResourceHandle[];
+}
+
+/**
+ * The audio engine's stable, ID-keyed project graph (PRD AUD-03, AUD-08;
+ * section 9.7). Owns the master bus, return buses, track graphs, the asset
+ * buffer cache, and the arrangement's transport schedule, all reconciled from
+ * a read-only {@link AudioSongProjection} instead of rebuilt from a mutable
+ * project object. Replacing this graph (e.g. opening a different project)
+ * leaves the {@link AudioRuntime}'s shared context and transport intact.
+ */
+export class ProjectAudioGraph {
+	private readonly scope: AudioProjectScope;
+	private readonly transport: AudioTransport;
+	private readonly bufferCache: AudioBufferCache<Tone.ToneAudioBuffer>;
+	private readonly master: MasterAudioGraph;
+	private readonly returns = new Map<ReturnId, ReturnAudioGraph>();
+	private readonly tracks = new Map<TrackId, TrackAudioGraph>();
+	private readonly placementSchedules = new Map<
+		PlacementId,
+		PlacementScheduleEntry
+	>();
+	private readonly createInstrument?: InstrumentNodeFactory;
+	private readonly createDeviceNode?: DeviceNodeFactory;
+	/**
+	 * One persistent map, mutated in place every reconcile rather than
+	 * replaced. Track/instrument graphs are constructed once and capture a
+	 * reference to this same map; if it were rebuilt fresh each reconcile,
+	 * every already-constructed graph would keep looking up assets in a
+	 * stale, ever-older snapshot instead of the current asset list.
+	 */
+	private readonly assetsById = new Map<AssetId, AudioAssetProjection>();
+	private lastProjection: AudioSongProjection | null = null;
+	private disposed = false;
+
+	constructor(
+		private readonly runtime: AudioHost,
+		ownerId: string,
+		options: ProjectAudioGraphOptions = {},
+	) {
+		this.scope = runtime.openProjectScope(ownerId);
+		this.transport = options.transport ?? liveTransport;
+		this.bufferCache = new AudioBufferCache(
+			options.bufferLoader ?? toneBufferLoader,
+		);
+		this.createInstrument = options.createInstrument;
+		this.createDeviceNode = options.createDeviceNode;
+		this.master = new MasterAudioGraph(
+			this.scope,
+			this.runtime.getDestination(),
+			this.createDeviceNode,
+		);
+	}
+
+	/** Read access for tests and diagnostics; not part of the reconciliation contract. */
+	get trackGraphs(): ReadonlyMap<TrackId, TrackAudioGraph> {
+		return this.tracks;
+	}
+
+	get returnGraphs(): ReadonlyMap<ReturnId, ReturnAudioGraph> {
+		return this.returns;
+	}
+
+	diagnostics(): {
+		tracks: number;
+		returns: number;
+		scheduledPlacements: number;
+		buffers: AudioBufferCacheDiagnostics;
+	} {
+		return {
+			tracks: this.tracks.size,
+			returns: this.returns.size,
+			scheduledPlacements: this.placementSchedules.size,
+			buffers: this.bufferCache.diagnostics(),
+		};
+	}
+
+	/**
+	 * Reconciles this graph against `next`. Passing the exact projection
+	 * object the audio projection handed back last time is a complete no-op —
+	 * every entry within it that is itself unchanged (by reference) is
+	 * likewise skipped, so an edit to one track, return, or placement never
+	 * touches any other entity's nodes or schedule.
+	 */
+	reconcile(next: AudioSongProjection): void {
+		if (this.lastProjection === next) return;
+
+		this.assetsById.clear();
+		for (const asset of next.assets) {
+			this.assetsById.set(asset.id, asset);
+			this.bufferCache.refresh(asset);
+		}
+
+		this.transport.bpm.value = next.tempo;
+
+		this.master.reconcile(next.master);
+		this.syncReturns(next);
+
+		const anySolo = next.tracks.some((track) => track.mixer.soloed);
+		this.syncTracks(next, anySolo);
+
+		// Returns no longer referenced are only safe to dispose once no track
+		// send still targets them — i.e. after `syncTracks` above.
+		this.pruneReturns(next);
+
+		this.syncSchedule(next);
+
+		this.lastProjection = next;
+	}
+
+	private syncReturns(next: AudioSongProjection): void {
+		for (const returnProjection of next.returns) {
+			let graph = this.returns.get(returnProjection.id);
+			if (!graph) {
+				graph = new ReturnAudioGraph(
+					returnProjection.id,
+					this.scope,
+					this.master.input,
+					this.createDeviceNode,
+				);
+				this.returns.set(returnProjection.id, graph);
+			}
+			graph.reconcile(returnProjection);
+		}
+	}
+
+	private pruneReturns(next: AudioSongProjection): void {
+		for (const [id, graph] of this.returns) {
+			if (!next.returnsById.has(id)) {
+				graph.dispose();
+				this.returns.delete(id);
+			}
+		}
+	}
+
+	private syncTracks(next: AudioSongProjection, anySolo: boolean): void {
+		for (const [id, graph] of this.tracks) {
+			if (!next.tracksById.has(id)) {
+				graph.dispose();
+				this.tracks.delete(id);
+			}
+		}
+
+		for (const trackProjection of next.tracks) {
+			let graph = this.tracks.get(trackProjection.id);
+			if (!graph) {
+				graph = new TrackAudioGraph(
+					trackProjection.id,
+					{
+						scope: this.scope,
+						assetsById: this.assetsById,
+						bufferCache: this.bufferCache,
+						getReturnInput: (returnId) => this.returns.get(returnId)?.input,
+						createInstrument: this.createInstrument,
+						createDeviceNode: this.createDeviceNode,
+					},
+					this.master.input,
+				);
+				this.tracks.set(trackProjection.id, graph);
+			}
+			const effectiveMuted =
+				trackProjection.mixer.muted ||
+				(anySolo && !trackProjection.mixer.soloed);
+			graph.reconcile(trackProjection, effectiveMuted);
+		}
+	}
+
+	private syncSchedule(next: AudioSongProjection): void {
+		const nextIds = new Set(next.placements.map((placement) => placement.id));
+
+		for (const [id, entry] of this.placementSchedules) {
+			if (!nextIds.has(id)) {
+				this.releaseSchedule(entry);
+				this.placementSchedules.delete(id);
+			}
+		}
+
+		for (const placement of next.placements) {
+			const clip = next.clipsById.get(placement.clipId);
+			if (!clip) continue; // domain invariants forbid a dangling clip reference; defensive only
+
+			const existing = this.placementSchedules.get(placement.id);
+			if (
+				existing &&
+				existing.placementRef === placement &&
+				existing.clipRef === clip &&
+				existing.tempo === next.tempo
+			) {
+				continue;
+			}
+			if (existing) this.releaseSchedule(existing);
+
+			const entry: PlacementScheduleEntry = {
+				placementRef: placement,
+				clipRef: clip,
+				tempo: next.tempo,
+				handles: [],
+			};
+			this.scheduleNotesAndLoops(placement, clip, next.tempo, entry);
+			this.placementSchedules.set(placement.id, entry);
+		}
+	}
+
+	private scheduleNotesAndLoops(
+		placement: AudioPlacementProjection,
+		clip: AudioClipProjection,
+		tempo: number,
+		entry: PlacementScheduleEntry,
+	): void {
+		const { notes, audioLoops } = computePlacementSchedule(
+			placement,
+			clip,
+			tempo,
+		);
+
+		for (const note of notes) {
+			const scheduleId = this.transport.schedule((time) => {
+				this.tracks
+					.get(note.trackId)
+					?.trigger(
+						note.trigger,
+						time,
+						ticksToToneTime(note.durationTicks),
+						note.velocity,
+					);
+			}, ticksToToneTime(note.absoluteTicks));
+			entry.handles.push(
+				this.scope.register("schedule", () => this.transport.clear(scheduleId)),
+			);
+		}
+
+		for (const loop of audioLoops) {
+			const bufferBox: { current: Tone.ToneAudioBuffer | null } = {
+				current: null,
+			};
+			const asset = this.assetsById.get(loop.assetId);
+			if (asset) {
+				entry.handles.push(this.subscribeAudioLoopAsset(asset, bufferBox));
+			}
+			const scheduleId = this.transport.schedule((time) => {
+				const track = this.tracks.get(loop.trackId);
+				if (track && bufferBox.current) {
+					playOneShot(
+						bufferBox.current,
+						track.audioInput,
+						time,
+						ticksToToneTime(loop.durationTicks),
+						loop.playbackRate,
+					);
+				}
+			}, ticksToToneTime(loop.absoluteTicks));
+			entry.handles.push(
+				this.scope.register("schedule", () => this.transport.clear(scheduleId)),
+			);
+		}
+	}
+
+	private subscribeAudioLoopAsset(
+		asset: AudioAssetProjection,
+		bufferBox: { current: Tone.ToneAudioBuffer | null },
+	): ResourceHandle {
+		const subscription: BufferSubscription = this.bufferCache.subscribe(
+			asset,
+			(buffer) => {
+				bufferBox.current = buffer;
+			},
+		);
+		return this.scope.register("subscription", () => subscription.release());
+	}
+
+	private releaseSchedule(entry: PlacementScheduleEntry): void {
+		for (const handle of entry.handles) void this.scope.release(handle);
+	}
+
+	/**
+	 * Tears down every track, return, and the master bus, clears the
+	 * arrangement schedule, and releases the buffer cache. Safe to call more
+	 * than once; the runtime/context and any other project graph are
+	 * untouched (PRD AUD-07).
+	 */
+	async dispose(): Promise<void> {
+		if (this.disposed) return;
+		this.disposed = true;
+
+		for (const [, entry] of this.placementSchedules) {
+			this.releaseSchedule(entry);
+		}
+		this.placementSchedules.clear();
+
+		for (const [, graph] of this.tracks) graph.dispose();
+		this.tracks.clear();
+
+		for (const [, graph] of this.returns) graph.dispose();
+		this.returns.clear();
+
+		this.master.dispose();
+		this.bufferCache.dispose();
+
+		await this.scope.dispose();
+	}
+}

--- a/src/audio/ReturnAudioGraph.ts
+++ b/src/audio/ReturnAudioGraph.ts
@@ -1,0 +1,58 @@
+import * as Tone from "tone";
+import type { ReturnId } from "../domain/ids";
+import type { AudioReturnProjection } from "../projection/audioProjection";
+import type { AudioProjectScope } from "./AudioRuntime";
+import { DeviceChain, type DeviceNodeFactory } from "./DeviceChain";
+
+/**
+ * One return bus's audio subgraph, keyed by its stable id (PRD AUD-08,
+ * section 9.7): an ordered device chain feeding a pan/volume/mute channel
+ * strip. Track sends connect into {@link ReturnAudioGraph.input}; the strip's
+ * output feeds the master bus.
+ */
+export class ReturnAudioGraph {
+	readonly id: ReturnId;
+	private readonly deviceChain: DeviceChain;
+	private readonly panVol: Tone.PanVol;
+	private readonly panVolHandle: ReturnType<AudioProjectScope["register"]>;
+	private lastProjection: AudioReturnProjection | null = null;
+	private disposed = false;
+
+	constructor(
+		id: ReturnId,
+		private readonly scope: AudioProjectScope,
+		destination: Tone.ToneAudioNode,
+		createDeviceNode?: DeviceNodeFactory,
+	) {
+		this.id = id;
+		this.deviceChain = new DeviceChain(scope, createDeviceNode);
+		this.panVol = new Tone.PanVol(0, 0);
+		this.panVolHandle = scope.register("node", () => {
+			this.panVol.dispose();
+		});
+		this.deviceChain.output.connect(this.panVol.input);
+		this.panVol.connect(destination);
+	}
+
+	/** Where a track's send gain connects. */
+	get input(): Tone.ToneAudioNode {
+		return this.deviceChain.input;
+	}
+
+	reconcile(next: AudioReturnProjection): void {
+		if (this.lastProjection === next) return;
+		this.deviceChain.reconcile(next.devices);
+		this.panVol.volume.rampTo(next.mixer.volume, 0.02);
+		this.panVol.pan.rampTo(next.mixer.pan, 0.02);
+		this.panVol.mute = next.mixer.muted;
+		this.lastProjection = next;
+	}
+
+	/** Tears down every node this return bus owns. Safe to call more than once. */
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.deviceChain.dispose();
+		void this.scope.release(this.panVolHandle);
+	}
+}

--- a/src/audio/ReturnAudioGraph.ts
+++ b/src/audio/ReturnAudioGraph.ts
@@ -26,7 +26,10 @@ export class ReturnAudioGraph {
 	) {
 		this.id = id;
 		this.deviceChain = new DeviceChain(scope, createDeviceNode);
-		this.panVol = new Tone.PanVol(0, 0);
+		// Explicit channelCount: 2 — Tone.PanVol's Panner otherwise inherits
+		// Web Audio's channelCount: 1 / channelCountMode: "explicit" default and
+		// downmixes every stereo signal to mono before panning.
+		this.panVol = new Tone.PanVol({ pan: 0, volume: 0, channelCount: 2 });
 		this.panVolHandle = scope.register("node", () => {
 			this.panVol.dispose();
 		});

--- a/src/audio/TrackAudioGraph.test.ts
+++ b/src/audio/TrackAudioGraph.test.ts
@@ -1,0 +1,409 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Device, Instrument, Send, TrackMixer } from "../domain/entities";
+import { createSeededIdFactory } from "../domain/ids";
+import type { AudioTrackProjection } from "../projection/audioProjection";
+import type { DeviceNode, DeviceNodeFactory } from "./DeviceChain";
+import type { InstrumentNode, InstrumentNodeFactory } from "./InstrumentGraph";
+import { installWebAudioGlobals } from "./testAudioContext";
+
+installWebAudioGlobals();
+
+let Tone: typeof import("tone");
+let AudioRuntimeModule: typeof import("./AudioRuntime");
+let TrackAudioGraphModule: typeof import("./TrackAudioGraph");
+
+beforeAll(async () => {
+	Tone = await import("tone");
+	AudioRuntimeModule = await import("./AudioRuntime");
+	TrackAudioGraphModule = await import("./TrackAudioGraph");
+});
+
+afterEach(async () => {
+	try {
+		await AudioRuntimeModule.getAudioRuntime().close();
+	} catch {
+		// already closed
+	}
+	AudioRuntimeModule.__resetAudioRuntimeForTests();
+});
+
+const ids = createSeededIdFactory("track-audio-graph-test");
+
+function mixer(overrides: Partial<TrackMixer> = {}): TrackMixer {
+	return { volume: 0, pan: 0, muted: false, soloed: false, ...overrides };
+}
+
+function trackProjection(
+	overrides: Partial<AudioTrackProjection> = {},
+): AudioTrackProjection {
+	return {
+		id: ids("track"),
+		type: "instrument",
+		instrument: { kind: "sampler", assetId: null, parameters: {} },
+		devices: [],
+		sendConfig: [],
+		mixer: mixer(),
+		fingerprint: "f",
+		topologyFingerprint: "t",
+		...overrides,
+	};
+}
+
+/** Spies on every instrument node this factory creates/updates/disposes. */
+function spyInstrumentFactory(): {
+	factory: InstrumentNodeFactory;
+	create: ReturnType<typeof vi.fn>;
+	update: ReturnType<typeof vi.fn>;
+	dispose: ReturnType<typeof vi.fn>;
+} {
+	const create = vi.fn();
+	const update = vi.fn();
+	const dispose = vi.fn();
+	const factory: InstrumentNodeFactory = (instrument) => {
+		create(instrument.kind);
+		const output = new Tone.Gain(1);
+		const node: InstrumentNode = {
+			kind: instrument.kind,
+			output,
+			trigger: vi.fn(),
+			update: (next: Instrument) => update(next.kind),
+			dispose: () => {
+				dispose(instrument.kind);
+				output.dispose();
+			},
+		};
+		return node;
+	};
+	return { factory, create, update, dispose };
+}
+
+/** Spies on every device node this factory creates/updates/disposes. */
+function spyDeviceFactory(): {
+	factory: DeviceNodeFactory;
+	create: ReturnType<typeof vi.fn>;
+	update: ReturnType<typeof vi.fn>;
+	dispose: ReturnType<typeof vi.fn>;
+} {
+	const create = vi.fn();
+	const update = vi.fn();
+	const dispose = vi.fn();
+	const factory: DeviceNodeFactory = (device) => {
+		create(device.id);
+		const node = new Tone.Gain(1);
+		const result: DeviceNode = {
+			id: device.id,
+			type: device.type,
+			input: node,
+			output: node,
+			update: (d: Device) => update(d.id),
+			dispose: () => {
+				dispose(device.id);
+				node.dispose();
+			},
+		};
+		return result;
+	};
+	return { factory, create, update, dispose };
+}
+
+function device(id: string, order: number): Device {
+	return {
+		id: id as Device["id"],
+		type: "generic",
+		order,
+		bypassed: false,
+		parameters: {},
+		preset: null,
+	};
+}
+
+describe("TrackAudioGraph", () => {
+	it("reconciling the exact same projection reference is a complete no-op", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const instrumentSpy = spyInstrumentFactory();
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => undefined,
+				createInstrument: instrumentSpy.factory,
+			},
+			runtime.getDestination(),
+		);
+
+		const projection = trackProjection();
+		track.reconcile(projection, false);
+		expect(instrumentSpy.create).toHaveBeenCalledTimes(1);
+
+		track.reconcile(projection, false);
+		expect(instrumentSpy.create).toHaveBeenCalledTimes(1);
+		expect(instrumentSpy.update).not.toHaveBeenCalled();
+
+		track.dispose();
+		return runtime.close();
+	});
+
+	it("a mixer-only edit updates volume/pan but never recreates the instrument or devices", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const instrumentSpy = spyInstrumentFactory();
+		const deviceSpy = spyDeviceFactory();
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => undefined,
+				createInstrument: instrumentSpy.factory,
+				createDeviceNode: deviceSpy.factory,
+			},
+			runtime.getDestination(),
+		);
+
+		const instrument: Instrument = {
+			kind: "sampler",
+			assetId: null,
+			parameters: {},
+		};
+		const devices = [device("dev_a", 0)];
+		const first = trackProjection({ instrument, devices });
+		track.reconcile(first, false);
+		expect(instrumentSpy.create).toHaveBeenCalledTimes(1);
+		expect(deviceSpy.create).toHaveBeenCalledTimes(1);
+
+		const second = trackProjection({
+			instrument,
+			devices,
+			mixer: mixer({ volume: -12, pan: 0.5 }),
+		});
+		track.reconcile(second, false);
+
+		expect(instrumentSpy.create).toHaveBeenCalledTimes(1);
+		expect(instrumentSpy.dispose).not.toHaveBeenCalled();
+		// The instrument reference itself did not change, so the identity
+		// short-circuit skips even a redundant `update()` call.
+		expect(instrumentSpy.update).not.toHaveBeenCalled();
+		expect(deviceSpy.create).toHaveBeenCalledTimes(1);
+		expect(deviceSpy.dispose).not.toHaveBeenCalled();
+
+		track.dispose();
+		return runtime.close();
+	});
+
+	it("an instrument kind change disposes the old node and creates a new one", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const instrumentSpy = spyInstrumentFactory();
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => undefined,
+				createInstrument: instrumentSpy.factory,
+			},
+			runtime.getDestination(),
+		);
+
+		track.reconcile(
+			trackProjection({
+				instrument: { kind: "sampler", assetId: null, parameters: {} },
+			}),
+			false,
+		);
+		track.reconcile(
+			trackProjection({ instrument: { kind: "synth", parameters: {} } }),
+			false,
+		);
+
+		expect(instrumentSpy.create).toHaveBeenCalledTimes(2);
+		expect(instrumentSpy.create).toHaveBeenNthCalledWith(1, "sampler");
+		expect(instrumentSpy.create).toHaveBeenNthCalledWith(2, "synth");
+		expect(instrumentSpy.dispose).toHaveBeenCalledExactlyOnceWith("sampler");
+
+		track.dispose();
+		return runtime.close();
+	});
+
+	it("removing the instrument disposes it; re-adding one creates a fresh node", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const instrumentSpy = spyInstrumentFactory();
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => undefined,
+				createInstrument: instrumentSpy.factory,
+			},
+			runtime.getDestination(),
+		);
+
+		track.reconcile(
+			trackProjection({ type: "audio", instrument: null }),
+			false,
+		);
+		expect(instrumentSpy.create).not.toHaveBeenCalled();
+
+		track.reconcile(
+			trackProjection({
+				instrument: { kind: "sampler", assetId: null, parameters: {} },
+			}),
+			false,
+		);
+		expect(instrumentSpy.create).toHaveBeenCalledTimes(1);
+
+		track.dispose();
+		return runtime.close();
+	});
+
+	it("adding one device creates only that device; the existing one is untouched", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const deviceSpy = spyDeviceFactory();
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => undefined,
+				createDeviceNode: deviceSpy.factory,
+			},
+			runtime.getDestination(),
+		);
+
+		track.reconcile(trackProjection({ devices: [device("dev_a", 0)] }), false);
+		track.reconcile(
+			trackProjection({ devices: [device("dev_a", 0), device("dev_b", 1)] }),
+			false,
+		);
+
+		expect(deviceSpy.create).toHaveBeenCalledTimes(2);
+		expect(deviceSpy.create).toHaveBeenNthCalledWith(2, "dev_b");
+		expect(deviceSpy.dispose).not.toHaveBeenCalled();
+
+		track.dispose();
+		return runtime.close();
+	});
+
+	it("creates a send gain per targeted return and ramps its level on change, without recreating it", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const destination = runtime.getDestination();
+		const returnInput = new Tone.Gain(1);
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => returnInput,
+			},
+			destination,
+		);
+
+		const returnId = ids("return");
+		const send: Send = { returnId, level: 0.5, preFader: false };
+		track.reconcile(trackProjection({ sendConfig: [send] }), false);
+		const nodesAfterCreate = runtime.diagnostics().resources.byType.node ?? 0;
+		expect(nodesAfterCreate).toBeGreaterThan(0);
+
+		track.reconcile(
+			trackProjection({ sendConfig: [{ ...send, level: 0.8 }] }),
+			false,
+		);
+		expect(runtime.diagnostics().resources.byType.node).toBe(nodesAfterCreate);
+
+		// Flipping preFader reconnects the existing gain rather than creating
+		// a second one.
+		track.reconcile(
+			trackProjection({ sendConfig: [{ ...send, preFader: true }] }),
+			false,
+		);
+		expect(runtime.diagnostics().resources.byType.node).toBe(nodesAfterCreate);
+
+		track.reconcile(trackProjection({ sendConfig: [] }), false);
+		expect(runtime.diagnostics().resources.byType.node).toBe(
+			nodesAfterCreate - 1,
+		);
+
+		track.dispose();
+		returnInput.dispose();
+		return runtime.close();
+	});
+
+	it("effectiveMuted is applied every reconcile pass even when the track's own projection is unchanged", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => undefined,
+			},
+			runtime.getDestination(),
+		);
+
+		const projection = trackProjection();
+		track.reconcile(projection, false);
+		track.reconcile(projection, true); // another track soloed elsewhere
+
+		expect(() => track.dispose()).not.toThrow();
+		return runtime.close();
+	});
+
+	it("dispose() releases every resource this track registered and is idempotent", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const instrumentSpy = spyInstrumentFactory();
+		const deviceSpy = spyDeviceFactory();
+		const destination = runtime.getDestination();
+		const returnInput = new Tone.Gain(1);
+		const track = new TrackAudioGraphModule.TrackAudioGraph(
+			ids("track"),
+			{
+				scope,
+				assetsById: new Map(),
+				bufferCache: {} as never,
+				getReturnInput: () => returnInput,
+				createInstrument: instrumentSpy.factory,
+				createDeviceNode: deviceSpy.factory,
+			},
+			destination,
+		);
+
+		const returnId = ids("return");
+		track.reconcile(
+			trackProjection({
+				devices: [device("dev_a", 0)],
+				sendConfig: [{ returnId, level: 0.5, preFader: false }],
+			}),
+			false,
+		);
+		expect(runtime.diagnostics().resources.byOwner.p).toBeGreaterThan(0);
+
+		track.dispose();
+		track.dispose(); // idempotent
+		await Promise.resolve();
+
+		// "p" is this track's scope owner; the runtime's own context
+		// registration under a different owner is untouched by a track's
+		// dispose and is not this assertion's concern.
+		expect(runtime.diagnostics().resources.byOwner.p).toBeUndefined();
+		expect(instrumentSpy.dispose).toHaveBeenCalledTimes(1);
+		expect(deviceSpy.dispose).toHaveBeenCalledTimes(1);
+
+		returnInput.dispose();
+		await runtime.close();
+	});
+});

--- a/src/audio/TrackAudioGraph.test.ts
+++ b/src/audio/TrackAudioGraph.test.ts
@@ -4,7 +4,7 @@ import { createSeededIdFactory } from "../domain/ids";
 import type { AudioTrackProjection } from "../projection/audioProjection";
 import type { DeviceNode, DeviceNodeFactory } from "./DeviceChain";
 import type { InstrumentNode, InstrumentNodeFactory } from "./InstrumentGraph";
-import { installWebAudioGlobals } from "./testAudioContext";
+import { installWebAudioGlobals, rms } from "./testAudioContext";
 
 installWebAudioGlobals();
 
@@ -405,5 +405,45 @@ describe("TrackAudioGraph", () => {
 
 		returnInput.dispose();
 		await runtime.close();
+	});
+
+	it("the channel strip preserves a hard-left stereo signal instead of downmixing it to mono", async () => {
+		const rendered = await Tone.Offline(
+			({ destination }) => {
+				const runtime = new AudioRuntimeModule.AudioRuntime();
+				const scope = runtime.openProjectScope("p");
+				const track = new TrackAudioGraphModule.TrackAudioGraph(
+					ids("track"),
+					{
+						scope,
+						assetsById: new Map(),
+						bufferCache: {} as never,
+						getReturnInput: () => undefined,
+					},
+					destination,
+				);
+				track.reconcile(
+					trackProjection({ type: "audio", instrument: null }),
+					false,
+				);
+
+				// Feed a stereo signal with energy only in the left channel into the
+				// track's channel strip; the right channel of `merge`'s input 1 is
+				// left unconnected (silence).
+				const merge = new Tone.Merge();
+				merge.connect(track.audioInput);
+				const noise = new Tone.Noise("white");
+				noise.connect(merge, 0, 0);
+				noise.start(0).stop(0.05);
+			},
+			0.05,
+			2,
+		);
+
+		const left = rms(Float32Array.from(rendered.getChannelData(0)));
+		const right = rms(Float32Array.from(rendered.getChannelData(1)));
+
+		expect(left).toBeGreaterThan(0.01);
+		expect(right).toBeLessThan(0.001);
 	});
 });

--- a/src/audio/TrackAudioGraph.ts
+++ b/src/audio/TrackAudioGraph.ts
@@ -1,0 +1,208 @@
+import * as Tone from "tone";
+import type { NoteTrigger, Send } from "../domain/entities";
+import type { AssetId, ReturnId, TrackId } from "../domain/ids";
+import type {
+	AudioAssetProjection,
+	AudioTrackProjection,
+} from "../projection/audioProjection";
+import type { AudioBufferCache } from "./AudioBufferCache";
+import type { AudioProjectScope } from "./AudioRuntime";
+import { DeviceChain, type DeviceNodeFactory } from "./DeviceChain";
+import {
+	createInstrumentNode,
+	type InstrumentNode,
+	type InstrumentNodeFactory,
+} from "./InstrumentGraph";
+
+/** One track's send: which return it targets, its own gain node, and which
+ * fader stage it currently taps (needed to reconnect in place if `preFader`
+ * flips without the send itself being added or removed). */
+interface TrackedSend {
+	readonly gain: Tone.Gain;
+	readonly handle: ReturnType<AudioProjectScope["register"]>;
+	preFader: boolean;
+}
+
+export interface TrackAudioGraphContext {
+	readonly scope: AudioProjectScope;
+	readonly assetsById: ReadonlyMap<AssetId, AudioAssetProjection>;
+	readonly bufferCache: AudioBufferCache<Tone.ToneAudioBuffer>;
+	getReturnInput(id: ReturnId): Tone.ToneAudioNode | undefined;
+	readonly createInstrument?: InstrumentNodeFactory;
+	readonly createDeviceNode?: DeviceNodeFactory;
+}
+
+/**
+ * One track's audio subgraph, keyed by the track's stable id (PRD AUD-08,
+ * section 9.7): an instrument, an ordered device chain, sends, and a
+ * channel-strip (pan/volume/mute). Reconciling against an unchanged
+ * `AudioTrackProjection` (the exact object reference the audio projection
+ * handed back last time) is a complete no-op — renaming, reordering, or any
+ * other non-audio edit to this track never touches its nodes.
+ */
+export class TrackAudioGraph {
+	readonly id: TrackId;
+	private readonly deviceChain: DeviceChain;
+	private readonly panVol: Tone.PanVol;
+	private readonly panVolHandle: ReturnType<AudioProjectScope["register"]>;
+	private instrumentNode: InstrumentNode | null = null;
+	private instrumentHandle: ReturnType<AudioProjectScope["register"]> | null =
+		null;
+	private lastInstrumentRef: AudioTrackProjection["instrument"] | null = null;
+	private readonly sends = new Map<ReturnId, TrackedSend>();
+	private lastProjection: AudioTrackProjection | null = null;
+	private disposed = false;
+
+	constructor(
+		id: TrackId,
+		private readonly context: TrackAudioGraphContext,
+		destination: Tone.ToneAudioNode,
+	) {
+		this.id = id;
+		this.deviceChain = new DeviceChain(context.scope, context.createDeviceNode);
+		this.panVol = new Tone.PanVol(0, 0);
+		this.panVolHandle = context.scope.register("node", () => {
+			this.panVol.dispose();
+		});
+		this.deviceChain.output.connect(this.panVol.input);
+		this.panVol.connect(destination);
+	}
+
+	/** The pre-fader tap point: after devices, before pan/volume/mute. */
+	private get preFaderTap(): Tone.ToneAudioNode {
+		return this.deviceChain.output;
+	}
+
+	/**
+	 * The post-fader tap point: after pan/volume/mute. `PanVol.output` is
+	 * typed as the general `OutputNode` union (it can, for other Tone
+	 * components, be a raw `AudioNode`) but is always the `Tone.Volume`
+	 * instance `PanVol` itself constructs.
+	 */
+	private get postFaderTap(): Tone.ToneAudioNode {
+		return this.panVol.output as Tone.ToneAudioNode;
+	}
+
+	/**
+	 * Reconciles this track against `next`. `effectiveMuted` folds in the
+	 * project-wide mute/solo rule (mute wins; any soloed track silences every
+	 * non-soloed one) and is re-applied every pass since it depends on every
+	 * other track's solo state, not just this track's own projection.
+	 */
+	reconcile(next: AudioTrackProjection, effectiveMuted: boolean): void {
+		if (this.lastProjection !== next) {
+			this.reconcileInstrument(next.instrument);
+			this.deviceChain.reconcile(next.devices);
+			this.reconcileSends(next.sendConfig);
+			this.panVol.volume.rampTo(next.mixer.volume, 0.02);
+			this.panVol.pan.rampTo(next.mixer.pan, 0.02);
+			this.lastProjection = next;
+		}
+		this.panVol.mute = effectiveMuted;
+	}
+
+	/** Triggers this track's instrument, if it has one. A no-op for `audio` tracks (no instrument) or while nothing is loaded yet. */
+	trigger(
+		trigger: NoteTrigger,
+		time: Tone.Unit.Time,
+		duration: Tone.Unit.Time,
+		velocity: number,
+	): void {
+		this.instrumentNode?.trigger(trigger, time, duration, velocity);
+	}
+
+	/** Where an `audioLoop` clip's player connects for this (`audio`-type) track. */
+	get audioInput(): Tone.ToneAudioNode {
+		return this.deviceChain.input;
+	}
+
+	private reconcileInstrument(next: AudioTrackProjection["instrument"]): void {
+		if (!next) {
+			this.disposeInstrument();
+			this.lastInstrumentRef = null;
+			return;
+		}
+		if (next === this.lastInstrumentRef) return;
+		if (this.instrumentNode && this.instrumentNode.kind === next.kind) {
+			this.instrumentNode.update(next);
+			this.lastInstrumentRef = next;
+			return;
+		}
+		this.disposeInstrument();
+		const factory = this.context.createInstrument ?? createInstrumentNode;
+		const node = factory(next, {
+			scope: this.context.scope,
+			assetsById: this.context.assetsById,
+			bufferCache: this.context.bufferCache,
+		});
+		this.instrumentHandle = this.context.scope.register("node", () =>
+			node.dispose(),
+		);
+		node.output.connect(this.deviceChain.input);
+		this.instrumentNode = node;
+		this.lastInstrumentRef = next;
+	}
+
+	private disposeInstrument(): void {
+		if (this.instrumentHandle) {
+			void this.context.scope.release(this.instrumentHandle);
+			this.instrumentHandle = null;
+		}
+		this.instrumentNode = null;
+	}
+
+	private reconcileSends(sendConfig: readonly Send[]): void {
+		const nextIds = new Set(sendConfig.map((send) => send.returnId));
+		for (const [returnId, tracked] of this.sends) {
+			if (!nextIds.has(returnId)) {
+				void this.context.scope.release(tracked.handle);
+				this.sends.delete(returnId);
+			}
+		}
+
+		for (const send of sendConfig) {
+			const target = this.context.getReturnInput(send.returnId);
+			if (!target) continue; // domain invariants forbid a dangling return reference; defensive only
+
+			const existing = this.sends.get(send.returnId);
+			const tap = send.preFader ? this.preFaderTap : this.postFaderTap;
+			if (!existing) {
+				const gain = new Tone.Gain(send.level);
+				tap.connect(gain);
+				gain.connect(target);
+				const handle = this.context.scope.register("node", () => {
+					gain.dispose();
+				});
+				this.sends.set(send.returnId, {
+					gain,
+					handle,
+					preFader: send.preFader,
+				});
+				continue;
+			}
+
+			existing.gain.gain.rampTo(send.level, 0.02);
+			if (existing.preFader !== send.preFader) {
+				const previousTap = existing.preFader
+					? this.preFaderTap
+					: this.postFaderTap;
+				previousTap.disconnect(existing.gain);
+				tap.connect(existing.gain);
+				existing.preFader = send.preFader;
+			}
+		}
+	}
+
+	/** Tears down every node this track owns. Safe to call more than once. */
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.disposeInstrument();
+		for (const [, tracked] of this.sends) {
+			void this.context.scope.release(tracked.handle);
+		}
+		this.sends.clear();
+		this.deviceChain.dispose();
+		void this.context.scope.release(this.panVolHandle);
+	}
+}

--- a/src/audio/TrackAudioGraph.ts
+++ b/src/audio/TrackAudioGraph.ts
@@ -60,7 +60,10 @@ export class TrackAudioGraph {
 	) {
 		this.id = id;
 		this.deviceChain = new DeviceChain(context.scope, context.createDeviceNode);
-		this.panVol = new Tone.PanVol(0, 0);
+		// Explicit channelCount: 2 — Tone.PanVol's Panner otherwise inherits
+		// Web Audio's channelCount: 1 / channelCountMode: "explicit" default and
+		// downmixes every stereo signal to mono before panning.
+		this.panVol = new Tone.PanVol({ pan: 0, volume: 0, channelCount: 2 });
 		this.panVolHandle = context.scope.register("node", () => {
 			this.panVol.dispose();
 		});

--- a/src/audio/scheduling.test.ts
+++ b/src/audio/scheduling.test.ts
@@ -139,6 +139,31 @@ describe("computePlacementSchedule", () => {
 		]);
 	});
 
+	it("keeps repeating a looped placement with a non-zero clip offset through the placement's full duration", () => {
+		// clip length 768 ticks, note events at clip ticks 0 and 384;
+		// placement { startTicks: 0, durationTicks: 1536, clipOffsetTicks: 384, looped: true }
+		// should produce absolute ticks 0, 384, 768, 1152 (the tail of the
+		// third wrap must not be dropped just because clipOffsetTicks shifted
+		// every repeat later).
+		const clip = notesClip(
+			[note(0, TICKS_PER_SIXTEENTH), note(384, TICKS_PER_SIXTEENTH)],
+			768,
+		);
+		const schedule = computePlacementSchedule(
+			placement({
+				looped: true,
+				durationTicks: toTicks(1536),
+				clipOffsetTicks: toTicks(384),
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.notes.map((n) => n.absoluteTicks)).toEqual([
+			0, 384, 768, 1152,
+		]);
+	});
+
 	it("computes an audio loop's playback rate from tempo / source tempo", () => {
 		const clip = audioLoopClip(100);
 		const schedule = computePlacementSchedule(placement(), clip, 120);

--- a/src/audio/scheduling.test.ts
+++ b/src/audio/scheduling.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { NoteEvent } from "../domain/entities";
+import type { AssetId, ClipId, PlacementId, TrackId } from "../domain/ids";
+import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH, toTicks } from "../domain/time";
+import type {
+	AudioClipProjection,
+	AudioPlacementProjection,
+} from "../projection/audioProjection";
+import { computePlacementSchedule, ticksToToneTime } from "./scheduling";
+
+const trackId = "trk_00000000000000000001" as TrackId;
+const clipId = "clp_00000000000000000001" as ClipId;
+const placementId = "plc_00000000000000000001" as PlacementId;
+const assetId = "ast_00000000000000000001" as AssetId;
+
+function note(startTicks: number, durationTicks: number): NoteEvent {
+	return {
+		id: `evt_${startTicks}` as NoteEvent["id"],
+		trigger: { kind: "pitch", pitch: 60 },
+		startTicks: toTicks(startTicks),
+		durationTicks: toTicks(durationTicks),
+		velocity: 0.8,
+		probability: null,
+	};
+}
+
+function notesClip(
+	events: NoteEvent[],
+	lengthTicks = TICKS_PER_BAR,
+): AudioClipProjection {
+	return {
+		id: clipId,
+		trackId,
+		lengthTicks: toTicks(lengthTicks),
+		content: { kind: "notes", events },
+		fingerprint: "fp",
+	};
+}
+
+function audioLoopClip(
+	sourceTempo: number,
+	lengthTicks = TICKS_PER_BAR,
+): AudioClipProjection {
+	return {
+		id: clipId,
+		trackId,
+		lengthTicks: toTicks(lengthTicks),
+		content: {
+			kind: "audioLoop",
+			assetId,
+			sourceTempo,
+			startOffsetTicks: toTicks(0),
+		},
+		fingerprint: "fp",
+	};
+}
+
+function placement(
+	overrides: Partial<AudioPlacementProjection> = {},
+): AudioPlacementProjection {
+	return {
+		id: placementId,
+		clipId,
+		trackId,
+		startTicks: toTicks(0),
+		durationTicks: toTicks(TICKS_PER_BAR),
+		clipOffsetTicks: toTicks(0),
+		looped: false,
+		fingerprint: "fp",
+		...overrides,
+	};
+}
+
+describe("computePlacementSchedule", () => {
+	it("places a note at placement start + event start, in the placement's track", () => {
+		const clip = notesClip([note(0, TICKS_PER_SIXTEENTH)]);
+		const schedule = computePlacementSchedule(
+			placement({ startTicks: toTicks(TICKS_PER_BAR) }),
+			clip,
+			120,
+		);
+
+		expect(schedule.notes).toHaveLength(1);
+		expect(schedule.notes[0].trackId).toBe(trackId);
+		expect(schedule.notes[0].absoluteTicks).toBe(TICKS_PER_BAR);
+		expect(schedule.notes[0].durationTicks).toBe(TICKS_PER_SIXTEENTH);
+	});
+
+	it("drops a note that falls before the placement's clip offset", () => {
+		const clip = notesClip([note(0, TICKS_PER_SIXTEENTH)]);
+		const schedule = computePlacementSchedule(
+			placement({ clipOffsetTicks: toTicks(TICKS_PER_SIXTEENTH) }),
+			clip,
+			120,
+		);
+
+		expect(schedule.notes).toHaveLength(0);
+	});
+
+	it("trims a note's duration to the placement's remaining bounds", () => {
+		const clip = notesClip([
+			note(TICKS_PER_BAR - TICKS_PER_SIXTEENTH, TICKS_PER_SIXTEENTH * 4),
+		]);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		expect(schedule.notes).toHaveLength(1);
+		expect(schedule.notes[0].durationTicks).toBe(TICKS_PER_SIXTEENTH);
+	});
+
+	it("does not repeat a non-looped placement even when the clip is shorter", () => {
+		const clip = notesClip(
+			[note(0, TICKS_PER_SIXTEENTH)],
+			TICKS_PER_SIXTEENTH * 4,
+		);
+		const schedule = computePlacementSchedule(
+			placement({ looped: false, durationTicks: toTicks(TICKS_PER_BAR * 4) }),
+			clip,
+			120,
+		);
+
+		expect(schedule.notes).toHaveLength(1);
+	});
+
+	it("repeats a looped placement's clip across the full placement duration", () => {
+		const clip = notesClip([note(0, TICKS_PER_SIXTEENTH)], TICKS_PER_BAR);
+		const schedule = computePlacementSchedule(
+			placement({
+				looped: true,
+				durationTicks: toTicks(TICKS_PER_BAR * 3),
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.notes.map((n) => n.absoluteTicks)).toEqual([
+			0,
+			TICKS_PER_BAR,
+			TICKS_PER_BAR * 2,
+		]);
+	});
+
+	it("computes an audio loop's playback rate from tempo / source tempo", () => {
+		const clip = audioLoopClip(100);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		expect(schedule.audioLoops).toHaveLength(1);
+		expect(schedule.audioLoops[0].playbackRate).toBeCloseTo(1.2);
+		expect(schedule.audioLoops[0].assetId).toBe(assetId);
+	});
+
+	it("repeats a looped audio loop clip across the placement duration", () => {
+		const clip = audioLoopClip(120, TICKS_PER_BAR);
+		const schedule = computePlacementSchedule(
+			placement({
+				looped: true,
+				durationTicks: toTicks(TICKS_PER_BAR * 2),
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.audioLoops.map((l) => l.absoluteTicks)).toEqual([
+			0,
+			TICKS_PER_BAR,
+		]);
+	});
+});
+
+describe("ticksToToneTime", () => {
+	it("formats ticks using Tone's ticks time notation", () => {
+		expect(ticksToToneTime(480)).toBe("480i");
+		expect(ticksToToneTime(0)).toBe("0i");
+	});
+
+	it("rounds and clamps to a non-negative integer", () => {
+		expect(ticksToToneTime(3.6)).toBe("4i");
+		expect(ticksToToneTime(-5)).toBe("0i");
+	});
+});

--- a/src/audio/scheduling.test.ts
+++ b/src/audio/scheduling.test.ts
@@ -6,7 +6,11 @@ import type {
 	AudioClipProjection,
 	AudioPlacementProjection,
 } from "../projection/audioProjection";
-import { computePlacementSchedule, ticksToToneTime } from "./scheduling";
+import {
+	audioLoopOffsetSeconds,
+	computePlacementSchedule,
+	ticksToToneTime,
+} from "./scheduling";
 
 const trackId = "trk_00000000000000000001" as TrackId;
 const clipId = "clp_00000000000000000001" as ClipId;
@@ -40,6 +44,7 @@ function notesClip(
 function audioLoopClip(
 	sourceTempo: number,
 	lengthTicks = TICKS_PER_BAR,
+	startOffsetTicks = 0,
 ): AudioClipProjection {
 	return {
 		id: clipId,
@@ -49,7 +54,7 @@ function audioLoopClip(
 			kind: "audioLoop",
 			assetId,
 			sourceTempo,
-			startOffsetTicks: toTicks(0),
+			startOffsetTicks: toTicks(startOffsetTicks),
 		},
 		fingerprint: "fp",
 	};
@@ -188,6 +193,136 @@ describe("computePlacementSchedule", () => {
 			0,
 			TICKS_PER_BAR,
 		]);
+	});
+
+	it("plays a left-trimmed audio loop from inside the sample rather than dropping it", () => {
+		// The user drags the placement's left edge one beat right: clip length
+		// 768 ticks, placement { start 0, duration 768, clipOffset 192 }. The
+		// renderer draws a trimmed placement, so the engine must play the same
+		// 576 ticks — starting 192 ticks into the sample — not fall silent.
+		const clip = audioLoopClip(120, 768);
+		const schedule = computePlacementSchedule(
+			placement({
+				startTicks: toTicks(0),
+				durationTicks: toTicks(768),
+				clipOffsetTicks: toTicks(192),
+				looped: false,
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.audioLoops).toHaveLength(1);
+		expect(schedule.audioLoops[0].absoluteTicks).toBe(0);
+		expect(schedule.audioLoops[0].sourceOffsetTicks).toBe(192);
+		expect(schedule.audioLoops[0].durationTicks).toBe(576);
+	});
+
+	it("starts a left-trimmed looped audio placement at the placement start", () => {
+		// Same trim, but looped across two clip lengths: the first repeat must
+		// still sound at the placement start, and every later repeat lands on
+		// the placement's own grid.
+		const clip = audioLoopClip(120, 768);
+		const schedule = computePlacementSchedule(
+			placement({
+				startTicks: toTicks(0),
+				durationTicks: toTicks(1536),
+				clipOffsetTicks: toTicks(192),
+				looped: true,
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.audioLoops.map((l) => l.absoluteTicks)).toEqual([
+			0, 576, 1344,
+		]);
+		expect(schedule.audioLoops.map((l) => l.sourceOffsetTicks)).toEqual([
+			192, 0, 0,
+		]);
+		expect(schedule.audioLoops.map((l) => l.durationTicks)).toEqual([
+			576, 768, 192,
+		]);
+	});
+
+	it("honours a clip's authored startOffsetTicks as the sample's start position", () => {
+		const clip = audioLoopClip(120, TICKS_PER_BAR, 192);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		expect(schedule.audioLoops).toHaveLength(1);
+		expect(schedule.audioLoops[0].absoluteTicks).toBe(0);
+		expect(schedule.audioLoops[0].sourceOffsetTicks).toBe(192);
+	});
+
+	it("adds a placement's left trim to the clip's authored start offset", () => {
+		const clip = audioLoopClip(120, 768, 96);
+		const schedule = computePlacementSchedule(
+			placement({
+				durationTicks: toTicks(768),
+				clipOffsetTicks: toTicks(192),
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.audioLoops).toHaveLength(1);
+		expect(schedule.audioLoops[0].sourceOffsetTicks).toBe(288);
+	});
+
+	it("drops an audio loop repeat that ends before the placement's clip offset", () => {
+		// clipOffsetTicks past a whole clip length: the first repeat is entirely
+		// trimmed away, and the repeats that do overlap start mid-sample.
+		const clip = audioLoopClip(120, 384);
+		const schedule = computePlacementSchedule(
+			placement({
+				looped: true,
+				durationTicks: toTicks(384),
+				clipOffsetTicks: toTicks(576),
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.audioLoops.map((l) => l.absoluteTicks)).toEqual([0, 192]);
+		expect(schedule.audioLoops.map((l) => l.sourceOffsetTicks)).toEqual([
+			192, 0,
+		]);
+		expect(schedule.audioLoops.map((l) => l.durationTicks)).toEqual([192, 192]);
+	});
+
+	it("drops a non-looped audio placement trimmed past the end of its clip", () => {
+		const clip = audioLoopClip(120, 384);
+		const schedule = computePlacementSchedule(
+			placement({
+				looped: false,
+				durationTicks: toTicks(384),
+				clipOffsetTicks: toTicks(576),
+			}),
+			clip,
+			120,
+		);
+
+		expect(schedule.audioLoops).toHaveLength(0);
+	});
+});
+
+describe("audioLoopOffsetSeconds", () => {
+	it("converts the source offset at the sample's authored tempo, not the song tempo", () => {
+		// A one-bar sample authored at 60 BPM is 4s long and plays at rate 2 in
+		// a 120 BPM song. One beat into that sample is 1s of buffer, not the
+		// 0.5s a song-tempo conversion would give.
+		const clip = audioLoopClip(60, TICKS_PER_BAR, 192);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		expect(schedule.audioLoops).toHaveLength(1);
+		expect(audioLoopOffsetSeconds(schedule.audioLoops[0], 120)).toBeCloseTo(1);
+	});
+
+	it("is zero for an untrimmed loop", () => {
+		const clip = audioLoopClip(120);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		expect(audioLoopOffsetSeconds(schedule.audioLoops[0], 120)).toBe(0);
 	});
 });
 

--- a/src/audio/scheduling.test.ts
+++ b/src/audio/scheduling.test.ts
@@ -7,6 +7,7 @@ import type {
 	AudioPlacementProjection,
 } from "../projection/audioProjection";
 import {
+	audioLoopDurationSeconds,
 	audioLoopOffsetSeconds,
 	computePlacementSchedule,
 	ticksToToneTime,
@@ -323,6 +324,43 @@ describe("audioLoopOffsetSeconds", () => {
 		const schedule = computePlacementSchedule(placement(), clip, 120);
 
 		expect(audioLoopOffsetSeconds(schedule.audioLoops[0], 120)).toBe(0);
+	});
+});
+
+describe("audioLoopDurationSeconds", () => {
+	// `Tone.Player` divides the duration it is given by the playback rate to get
+	// the wall-clock length it sounds for, so this helper has to pre-multiply by
+	// the rate. Both cases below sound for the same 2s the arrangement draws for
+	// a one-bar placement at 120 BPM; only the number handed to Tone differs.
+	it("scales by the playback rate so a fast sample is not truncated", () => {
+		// Authored at 60 BPM, played at 120 => rate 2. Tone will halve whatever
+		// we pass, so the song-time 2s has to go in as 4s.
+		const clip = audioLoopClip(60, TICKS_PER_BAR);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		const [loop] = schedule.audioLoops;
+		expect(loop.playbackRate).toBeCloseTo(2);
+		expect(audioLoopDurationSeconds(loop, 120)).toBeCloseTo(4);
+	});
+
+	it("scales by the playback rate so a slow sample does not overrun", () => {
+		// Authored at 140 BPM, played at 120 => rate ~0.857. Tone divides by
+		// that, so passing the song-time 2s would sound for ~2.333s and flam
+		// into the next repeat.
+		const clip = audioLoopClip(140, TICKS_PER_BAR);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		const [loop] = schedule.audioLoops;
+		expect(audioLoopDurationSeconds(loop, 120)).toBeCloseTo(2 * (120 / 140));
+	});
+
+	it("is the plain song-time duration at unity rate", () => {
+		const clip = audioLoopClip(120);
+		const schedule = computePlacementSchedule(placement(), clip, 120);
+
+		expect(audioLoopDurationSeconds(schedule.audioLoops[0], 120)).toBeCloseTo(
+			2,
+		);
 	});
 });
 

--- a/src/audio/scheduling.ts
+++ b/src/audio/scheduling.ts
@@ -1,0 +1,103 @@
+import type { NoteTrigger } from "../domain/entities";
+import type { AssetId, TrackId } from "../domain/ids";
+import type { Ticks } from "../domain/time";
+import { toTicks } from "../domain/time";
+import type {
+	AudioClipProjection,
+	AudioPlacementProjection,
+} from "../projection/audioProjection";
+
+/**
+ * Pure musical-time scheduling math (PRD AUD-08/AUD-03, section 9.7:
+ * "Scheduling uses musical-time projections ... rather than anonymous global
+ * callbacks"). This module never touches Tone or the transport — it only
+ * expands one placement's clip content into the absolute-tick events
+ * `ProjectAudioGraph` schedules, so the expansion itself (looping, trimming a
+ * clip to its placement bounds) is testable without any audio context at all.
+ */
+
+export interface ScheduledNote {
+	readonly trackId: TrackId;
+	readonly absoluteTicks: Ticks;
+	readonly durationTicks: Ticks;
+	readonly trigger: NoteTrigger;
+	readonly velocity: number;
+}
+
+export interface ScheduledAudioLoop {
+	readonly trackId: TrackId;
+	readonly absoluteTicks: Ticks;
+	readonly durationTicks: Ticks;
+	readonly assetId: AssetId;
+	/** Ratio of song tempo to the loop's authored source tempo. */
+	readonly playbackRate: number;
+}
+
+export interface PlacementSchedule {
+	readonly notes: readonly ScheduledNote[];
+	readonly audioLoops: readonly ScheduledAudioLoop[];
+}
+
+/**
+ * Expands one placement's clip content into absolute-tick events, trimmed to
+ * the placement's bounds and repeated across it when `placement.looped`.
+ */
+export function computePlacementSchedule(
+	placement: AudioPlacementProjection,
+	clip: AudioClipProjection,
+	tempo: number,
+): PlacementSchedule {
+	const notes: ScheduledNote[] = [];
+	const audioLoops: ScheduledAudioLoop[] = [];
+	const clipLength = clip.lengthTicks;
+	const repeatCount =
+		placement.looped && clipLength > 0
+			? Math.max(1, Math.ceil(placement.durationTicks / clipLength))
+			: 1;
+
+	for (let repeat = 0; repeat < repeatCount; repeat += 1) {
+		const repeatOffset = repeat * clipLength;
+		if (repeatOffset >= placement.durationTicks) break;
+
+		if (clip.content.kind === "notes") {
+			for (const event of clip.content.events) {
+				const startInPlacement =
+					event.startTicks - placement.clipOffsetTicks + repeatOffset;
+				if (
+					startInPlacement < 0 ||
+					startInPlacement >= placement.durationTicks
+				) {
+					continue;
+				}
+				const remaining = placement.durationTicks - startInPlacement;
+				notes.push({
+					trackId: placement.trackId,
+					absoluteTicks: toTicks(placement.startTicks + startInPlacement),
+					durationTicks: toTicks(Math.min(event.durationTicks, remaining)),
+					trigger: event.trigger,
+					velocity: event.velocity,
+				});
+			}
+		} else {
+			const startInPlacement = repeatOffset - placement.clipOffsetTicks;
+			if (startInPlacement < 0 || startInPlacement >= placement.durationTicks) {
+				continue;
+			}
+			const remaining = placement.durationTicks - startInPlacement;
+			audioLoops.push({
+				trackId: placement.trackId,
+				absoluteTicks: toTicks(placement.startTicks + startInPlacement),
+				durationTicks: toTicks(Math.min(clipLength, remaining)),
+				assetId: clip.content.assetId,
+				playbackRate: tempo / clip.content.sourceTempo,
+			});
+		}
+	}
+
+	return { notes, audioLoops };
+}
+
+/** Tone.js Time notation for an absolute tick position ("<n>i" = n ticks). */
+export function ticksToToneTime(ticks: number): string {
+	return `${Math.max(0, Math.round(ticks))}i`;
+}

--- a/src/audio/scheduling.ts
+++ b/src/audio/scheduling.ts
@@ -53,6 +53,24 @@ export function audioLoopOffsetSeconds(
 	return ticksToSeconds(loop.sourceOffsetTicks, tempo) * loop.playbackRate;
 }
 
+/**
+ * The `player.start()` duration for a scheduled loop, in the decoded buffer's
+ * own seconds — the same timeline as the offset above, and for the same reason.
+ *
+ * `Tone.Player` divides this by the playback rate to get the wall-clock length
+ * it sounds for (`Player.js`: `computedDuration = toSeconds(duration) /
+ * playbackRate`), so passing song-timeline seconds makes a non-unity rate
+ * truncate the loop (rate > 1) or overrun into the next repeat (rate < 1).
+ * Scaling by the rate cancels that division and leaves the event sounding for
+ * exactly the song-time span the arrangement draws.
+ */
+export function audioLoopDurationSeconds(
+	loop: ScheduledAudioLoop,
+	tempo: number,
+): number {
+	return ticksToSeconds(loop.durationTicks, tempo) * loop.playbackRate;
+}
+
 export interface PlacementSchedule {
 	readonly notes: readonly ScheduledNote[];
 	readonly audioLoops: readonly ScheduledAudioLoop[];

--- a/src/audio/scheduling.ts
+++ b/src/audio/scheduling.ts
@@ -52,12 +52,19 @@ export function computePlacementSchedule(
 	const clipLength = clip.lengthTicks;
 	const repeatCount =
 		placement.looped && clipLength > 0
-			? Math.max(1, Math.ceil(placement.durationTicks / clipLength))
+			? Math.max(
+					1,
+					Math.ceil(
+						(placement.durationTicks + placement.clipOffsetTicks) / clipLength,
+					),
+				)
 			: 1;
 
 	for (let repeat = 0; repeat < repeatCount; repeat += 1) {
 		const repeatOffset = repeat * clipLength;
-		if (repeatOffset >= placement.durationTicks) break;
+		if (repeatOffset - placement.clipOffsetTicks >= placement.durationTicks) {
+			break;
+		}
 
 		if (clip.content.kind === "notes") {
 			for (const event of clip.content.events) {

--- a/src/audio/scheduling.ts
+++ b/src/audio/scheduling.ts
@@ -1,7 +1,7 @@
 import type { NoteTrigger } from "../domain/entities";
 import type { AssetId, TrackId } from "../domain/ids";
 import type { Ticks } from "../domain/time";
-import { toTicks } from "../domain/time";
+import { ticksToSeconds, toTicks } from "../domain/time";
 import type {
 	AudioClipProjection,
 	AudioPlacementProjection,
@@ -31,6 +31,26 @@ export interface ScheduledAudioLoop {
 	readonly assetId: AssetId;
 	/** Ratio of song tempo to the loop's authored source tempo. */
 	readonly playbackRate: number;
+	/**
+	 * Where inside the clip's own timeline this event starts, in ticks: the
+	 * clip's authored `startOffsetTicks` plus however much of this repeat the
+	 * placement's left-edge trim (`clipOffsetTicks`) cuts away. The consumer
+	 * converts it to buffer seconds — see `audioLoopOffsetSeconds`.
+	 */
+	readonly sourceOffsetTicks: Ticks;
+}
+
+/**
+ * The `player.start()` offset for a scheduled loop, in the decoded buffer's
+ * own seconds. The sample was authored at the clip's source tempo, so a
+ * clip-tick offset is song-tempo seconds scaled by the playback rate
+ * (`ticksToSeconds(t, tempo) * tempo / sourceTempo === ticksToSeconds(t, sourceTempo)`).
+ */
+export function audioLoopOffsetSeconds(
+	loop: ScheduledAudioLoop,
+	tempo: number,
+): number {
+	return ticksToSeconds(loop.sourceOffsetTicks, tempo) * loop.playbackRate;
 }
 
 export interface PlacementSchedule {
@@ -87,16 +107,26 @@ export function computePlacementSchedule(
 			}
 		} else {
 			const startInPlacement = repeatOffset - placement.clipOffsetTicks;
-			if (startInPlacement < 0 || startInPlacement >= placement.durationTicks) {
+			if (startInPlacement >= placement.durationTicks) {
 				continue;
 			}
-			const remaining = placement.durationTicks - startInPlacement;
+			// A repeat straddling the placement's left edge is not skipped: it
+			// sounds at the placement start, from `trimmed` ticks into the
+			// sample, so a left-edge trim plays the material the arrangement
+			// renderer draws instead of falling silent.
+			const trimmed = Math.max(0, -startInPlacement);
+			if (trimmed >= clipLength) {
+				continue;
+			}
+			const startedAt = startInPlacement + trimmed;
+			const remaining = placement.durationTicks - startedAt;
 			audioLoops.push({
 				trackId: placement.trackId,
-				absoluteTicks: toTicks(placement.startTicks + startInPlacement),
-				durationTicks: toTicks(Math.min(clipLength, remaining)),
+				absoluteTicks: toTicks(placement.startTicks + startedAt),
+				durationTicks: toTicks(Math.min(clipLength - trimmed, remaining)),
 				assetId: clip.content.assetId,
 				playbackRate: tempo / clip.content.sourceTempo,
+				sourceOffsetTicks: toTicks(clip.content.startOffsetTicks + trimmed),
 			});
 		}
 	}

--- a/src/audio/toneBufferLoader.ts
+++ b/src/audio/toneBufferLoader.ts
@@ -1,0 +1,19 @@
+import * as Tone from "tone";
+import type { AssetBufferLoader } from "./AudioBufferCache";
+
+/**
+ * Decodes an asset's audio through Tone's own buffer loading. The only place
+ * that touches Tone in the buffer-cache module pair — `AudioBufferCache`
+ * itself stays Tone-agnostic so its generation/refcount bookkeeping can be
+ * tested without any Web Audio globals installed.
+ */
+export const toneBufferLoader: AssetBufferLoader<Tone.ToneAudioBuffer> = {
+	async load(asset) {
+		if (!asset.url) {
+			throw new Error(`Asset "${asset.id}" has no URL to decode`);
+		}
+		const buffer = new Tone.ToneAudioBuffer();
+		await buffer.load(asset.url);
+		return buffer;
+	},
+};


### PR DESCRIPTION
Implements [`FND-007`](../blob/main/docs/backlog.md#fnd-007---stable-id-keyed-audio-graph) — `ProjectAudioGraph` and the track/device factories that reconcile typed domain changes narrowly instead of rebuilding Tone objects from Solid effects.

PRD: `AUD-03`, `AUD-08`; 9.7.

## What this adds

- **`ProjectAudioGraph`**, reconciling a read-only `AudioSongProjection` into a graph keyed by track, instrument, device, return, and asset IDs. Passing back the same projection object is a complete no-op; editing one track never touches another's nodes or schedule.
- **`TrackAudioGraph` / `ReturnAudioGraph` / `MasterAudioGraph`**, one channel strip each plus a `DeviceChain` that reconciles an ordered `Device[]` by id — only added/removed devices create or dispose a node, and reordering relinks without recreating.
- **`AudioBufferCache`**, keyed by asset ID and content fingerprint, with refcounted eviction and generation-tracked cancellation so a stale decode can never reconnect or overwrite a newer one. It imports no Tone itself; `toneBufferLoader.ts` is the only production loader that does.
- **`scheduling.ts`**, expanding placements into absolute-tick events as a pure function, scheduled against the transport with an owner-tracked handle per event rather than anonymous global callbacks.

## Acceptance checkboxes met

- [x] Graph registries key tracks, instruments, devices, returns, schedules, and assets by stable domain IDs
- [x] Parameter edits preserve node identity and use smoothing; topology edits affect only the owned subgraph
- [x] Buffer cache is keyed by asset ID/revision and cancels stale asynchronous loads deterministically
- [x] Scheduling uses musical-time projections and tracked owner handles rather than anonymous global callbacks
- [x] Instrumented tests prove stable identities, no unrelated node churn, idempotent teardown, and no stale-load reconnection

## Review

The branch went through three Opus review rounds. Round 1 raised three findings (loop-offset scheduling, a buffer-cache use-after-dispose, mono channel strips); round 2 independently verified all three were genuinely fixed — by reverting the sources while keeping the new tests and confirming they fail — and raised one more.

**Round 2's finding: a left-trimmed audio placement was silent.** `computePlacementSchedule` discarded `placement.clipOffsetTicks` in the `audioLoop` branch, so a placement trimmed at its left edge produced *zero* transport events while the arrangement renderer still drew it. Fixed by carrying a `sourceOffsetTicks` through to `player.start()`. Round 3 verified this with a 560-case sweep over clip length × offset × duration × looped × authored offset: no silent-but-drawn placements, no gaps, overlaps, or overruns.

**Round 3's finding: the sibling `duration` argument had the same units bug.** `Tone.Player` computes `toSeconds(duration) / playbackRate`, so its `duration` is a length in the decoded buffer's timeline, not the song's — but the graph passed song-timeline ticks. Any clip whose `sourceTempo` differs from the song tempo was mistimed: a one-bar sample authored at 60 BPM in a 120 BPM song sounds for 1s of its 2s region, and a 140 BPM one overruns by 0.333s and flams into the next repeat. `AUD-05`/`AUD-06` offline and stem export reuse this expansion, so exports inherited it. Fixed with `audioLoopDurationSeconds`, a sibling of the offset helper so both `player.start()` arguments are derived the same way.

Worth flagging for reviewers: **every audio fixture in the repo authors at `sourceTempo === tempo`**, the one case where buffer seconds and song seconds coincide — which is why all 768 tests passed with that bug present. The new `ProjectAudioGraph` test is the first to pull the two tempos apart, firing the scheduled transport callback and asserting what actually reaches `Tone.Player.start`. It was confirmed to fail against the prior commit (`expected 'string' to be 'number'`) before passing with the fix.

Full unit suite green: 65 files, 768 tests, `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMeruF1MYJavtosdz4bZhg)_