### PR TITLE
DEC-001: record anonymous project upgrade path across devices

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -422,7 +422,8 @@ Tasks in this phase may proceed in parallel after `FND-009`, subject to their ad
 Implement anonymous entry plus create, open, rename, duplicate, and confirmed-delete flows against the v1 repository.
 
 - [ ] Blank and starter creation, independent deep duplication, empty/loading/error states, and last-modified metadata are tested.
-- [ ] Anonymous retention and upgrade messaging match `DEC-001`; refresh preserves the session.
+- [ ] Anonymous retention (180 days from last access, reset on access) matches `DEC-001`; refresh preserves the session.
+- [ ] Each device locally records which anonymous projects were created or edited there; authenticating on that device offers to pair those local records to the account, and a paired project's local record is deleted. A device shared by multiple people is not reconciled — the authenticating user is offered whatever anonymous projects were edited on that device (`DEC-001`).
 - [ ] Dashboard browser tests cover access control and destructive confirmation.
 - [ ] Emits `anon_session_created`, `account_upgraded`, `project_created` (with `source`, `template_id`, `genre`), `project_opened` (with `project_age_bucket`, `track_count_bucket`, `is_first_open`), and `project_deleted`. `project_opened` is what makes the 1- and 7-day reopen measure computable, so its parameters are not optional.
 
@@ -855,7 +856,7 @@ Complete rule audits, validation, quotas, deletion/retention, CSP/secrets review
 
 - [ ] Security emulator tests and abuse cases cover all public backend surfaces and asset access.
 - [ ] Crash, save failure, audio start failure, export result, AI failure, and leak signals are actionable without recording project content.
-- [ ] Anonymous retention/deletion, analytics consent/retention (`DEC-009`), and AI data handling match product decisions and user-facing disclosures.
+- [ ] Anonymous retention/deletion (180-day last-access window), the device-local pairing record's lifecycle (created on anonymous edit, deleted once paired to an account), analytics consent/retention (`DEC-009`), and AI data handling match product decisions and user-facing disclosures.
 - [ ] Every event in the PRD OPS-02 catalog is confirmed firing from the deployed production build with the expected parameters, and any gap is filed against its owning task rather than patched here.
 - [ ] Release dashboards compute the PRD section 11 primary, supporting, and guardrail measures — including crash-free session rate — from real cohort data with internal traffic excluded.
 
@@ -966,9 +967,16 @@ Add curated, trusted-creator tutorial video recommendations that the assistant c
 
 Let users build and publish their own packs, acquire packs from other creators, and sell premium packs.
 
-Deliberately the last thing on this backlog. It depends on user sample imports (`P1-005`) for user-owned content, and on `DEC-010` for whether Solid Groove wants this business at all and on what rights, revenue-sharing, and moderation terms. It is a commercial and operational commitment — creator agreements, payments, moderation, takedown, support — far more than it is a feature.
+Deliberately the last thing on this backlog by feature scope. It depends on user sample imports (`P1-005`) for user-owned content, and on `DEC-010` for whether Solid Groove wants this business at all and on what rights, revenue-sharing, and moderation terms. It is a commercial and operational commitment — creator agreements, payments, moderation, takedown, support — far more than it is a feature. `P2-004` follows it below as an operational chore rather than a feature.
 
 Scope when unparked, at minimum: pack authoring and versioning from a user's own library; publication review, reporting, and a takedown that disables a pack for new use without breaking projects already referencing it; entitlement and per-user pack visibility with defined behaviour when access ends; purchase, refund, and payout handling; and discovery that does not turn the library into the undifferentiated catalogue the sample plan rejects. Nothing here may introduce a second content model beside `LIB-04` packs.
+
+### P2-004 - Anonymous project expiry cleanup
+
+`Status: parked | Owner: unassigned | Dependencies: REL-003, DEC-001`<br>
+`PRD: 16 | Evidence: pending`
+
+Build the scheduled job that deletes anonymous projects 180 days after their last access, per `DEC-001`. The job must resolve last-access per project (reset by any open/access, not just edits), only ever delete anonymous-owned projects, and be safe to retry and idempotent against partial prior runs. It must also account for the `LOOP-001` device-local pairing flow: a project paired to an authenticated account before expiry is no longer anonymous and is never a deletion candidate, and the job itself does not touch the device-local pairing records, which are owned and cleaned up client-side by `LOOP-001`.
 
 ## 10. Completion log
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1484,6 +1484,8 @@ A feature is done only when:
 - SolidStart/SolidJS/TypeScript, Tone.js over Web Audio, and Firebase Auth/Firestore/Storage/Functions are committed alpha technologies.
 - One long-lived real-time Tone/Web Audio context per document and stable, incrementally reconciled audio graphs are hard alpha architecture decisions.
 - The alpha arrangement is a hybrid virtualized DOM plus layered Canvas 2D renderer; WebGL/WebGPU and WASM require measured failure plus an approved ADR.
+- An anonymous project is retained until 180 days after its last access; opening or otherwise accessing it resets the timer. Deletion is scoped to anonymous projects only, and authenticating as an account owner before expiry keeps the project indefinitely (`DEC-001`).
+- Upgrading from anonymous to an authenticated account never loses an anonymous project. Each device records, in local browser storage, which anonymous projects were created or edited there. When that device is used to authenticate, the user is offered a pairing flow that attaches its locally-recorded anonymous projects to the authenticated account; once a project is paired, its local record is deleted. Multiple people sharing one device is explicitly out of scope: whichever anonymous projects were edited on a device are assumed to belong to whoever next authenticates on it (`DEC-001`).
 
 ### Product-owner decisions required before Phase 3 or launch
 
@@ -1492,7 +1494,6 @@ A feature is done only when:
 - For the later pack marketplace (LIB-05): who may publish a pack, what rights and revenue-sharing terms apply to a creator, what moderation and takedown process governs published content, and what happens to a project that uses a pack after that pack is withdrawn or the user's access to it ends? (Post-alpha; unscheduled.)
 - Which sample/preset sources have acceptable commercial licensing and attribution terms?
 - Which AI provider, model budget, usage limit, and data-retention policy are acceptable for the alpha?
-- Will anonymous projects expire, and what exact upgrade path protects them across devices?
 - Should native Live Set generation be maintained directly or delivered through a supported partner/integration route?
 - Who are the first 8-20 target testers, and what existing tools/genres should the cohort represent?
 - What consent, retention, and regional policy applies to product analytics and error reports — is analytics on by default with an opt-out, how long is event and error data retained, and does the Sentry data region satisfy any regional constraint, or does that constraint reopen self-hosting? (`DEC-009`.)


### PR DESCRIPTION
Records the full DEC-001 decision in PRD section 16: anonymous projects are retained until 180 days after last access (reset on access), and upgrading to an authenticated account never loses an anonymous project — each device keeps a local record of anonymous projects created/edited there and offers to pair them to the account on login, with the shared-device case explicitly out of scope. Updates LOOP-001 and HARD-003 backlog acceptance criteria accordingly and adds P2-004 for the server-side expiry cleanup job.

Closes #30.

Generated with [Claude Code](https://claude.ai/code)