### PR TITLE
docs: tell Claude to set up a null ALSA device before audio tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ bun run check        # Run Biome linting and formatting (auto-fix)
 bun run check:ci     # Same checks, non-mutating (CI gate; use `check` locally)
 
 # Testing
-bun run test              # Unit + component tests, once
+bun run test              # Unit + component tests, once (needs an audio output device — see Testing below)
 bun run test:watch        # Unit + component tests, watch mode
 bun run test:ui           # Unit + component tests, Vitest UI
 bun run test:emulator     # Firebase Emulator suite (Firestore rules, etc.)
@@ -265,6 +265,32 @@ See [`docs/testing.md`](./docs/testing.md) for what each suite covers, how CI ga
 - Beyond unit/component tests, the project has a Firebase Emulator suite (`tests/emulator/`, `bun run test:emulator`) and a Playwright browser E2E suite (`e2e/`, `bun run test:browser`) — see [`docs/testing.md`](./docs/testing.md) for what each covers and how CI gates on them
 - Use `src/shared/id.ts`'s `createId`/`createSeededIdFactory` for entity IDs and `src/shared/clock.ts`'s `Clock` for anything that needs the current time, rather than calling `nanoid()`/`Date.now()` directly, so tests can be deterministic
 - Use `src/testing/fixtures.ts`'s builders (`buildProject`, `buildTrack`, ...) instead of hand-writing fixture literals in new tests
+
+### Set up a null ALSA device before running tests that touch an `AudioContext`
+
+**Do this once per machine/container before `bun run test`.** Importing `tone` creates a real (non-offline) global `AudioContext` as a side effect, and `node-web-audio-api`'s `cpal` backend refuses to create one when the host has no default output device. Containers, CI runners, and headless VMs have no `/dev/snd`, so any suite that reaches Tone (e.g. `src/audio/ToneInstrument.test.ts`) fails at import time with:
+
+```
+InvalidStateError: cpal backend error during default_output_config: DeviceUnavailable
+```
+
+That is an environment problem, not a test bug — do not "fix" it by mocking Tone, skipping the file, or editing `src/audio/testAudioContext.ts`. Point ALSA's default PCM at its built-in `null` device instead (it discards every sample and needs no audio hardware and no `snd-dummy` kernel module):
+
+```bash
+# Only if the ALSA runtime library is missing (check: dpkg -l libasound2t64)
+sudo apt-get update && sudo apt-get install -y libasound2t64
+
+cat > "$HOME/.asoundrc" <<'EOF'
+pcm.!default {
+    type null
+}
+ctl.!default {
+    type null
+}
+EOF
+```
+
+Use `/etc/asound.conf` (same contents) instead when the suite runs as a different user than the one whose `$HOME` you wrote to. A machine with real audio hardware needs none of this. `.github/workflows/ci.yml`'s `checks` job runs exactly these steps before `bun run test`; see [`docs/testing.md`](./docs/testing.md#unit-and-component-tests) for the full background.
 
 ## Important Configuration Notes
 


### PR DESCRIPTION
Importing `tone` creates a real global AudioContext, and node-web-audio-api's
cpal backend fails with DeviceUnavailable when the host has no default output
device — every container and headless runner. CI already works around this;
CLAUDE.md did not say so, so an agent hitting the failure locally had no
pointer and could plausibly "fix" it by mocking Tone or skipping the file.

Document the ~/.asoundrc null-PCM setup as a prerequisite of `bun run test`,
with the libasound2t64 install, the /etc/asound.conf alternative, and a link
to the full background in docs/testing.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hbeyQVK36ibwjWDHjEDan