### PR TITLE
LOOP-001: anonymous start and project dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,13 +53,15 @@ src/
 ├── components/         # Reusable UI components
 │   ├── Dashboard.tsx
 │   ├── LoginButton.tsx
-│   └── ProjectList.tsx
+│   ├── ProjectList.tsx
+│   └── ConfirmDialog.tsx   # Accessible confirmation modal for destructive actions (PRD PRJ-02)
 ├── editor/             # The FND-009 foundation vertical slice: editor state, audio wiring, and its 16-step UI
 │   ├── EditorSession.ts     # Framework-free CommandHistory + ProjectAutosave + repository-watch wiring for one open project
 │   ├── useEditorSession.ts  # Solid adapter: loads a project, exposes EditorSession as reactive state
 │   ├── useProjectAudio.ts   # Wires one project onto ProjectAudioGraph/AudioRuntime; play/stop and audio_start_failed
 │   ├── starterProject.ts    # Builds the "New Project" starter (one sampler track, pack-qualified asset, one note clip)
 │   ├── StepGrid.tsx         # The slice's 16-step grid; dispatches note.add/note.remove through the command layer
+│   ├── deviceProjectRecord.ts # Device-local "opened before" bookkeeping for project_opened's is_first_open (LOOP-001)
 │   └── EditorView.tsx       # The project route's top-level component
 ├── domain/             # Canonical schema-v1 domain model (authoritative)
 │   ├── entities.ts          # Entity shapes and their Zod schemas
@@ -70,6 +72,7 @@ src/
 │   ├── parse.ts             # Validation and domain invariants
 │   ├── serialize.ts         # Deterministic JSON serialization
 │   ├── factories.ts         # Blank/entity factories
+│   ├── duplicateProject.ts  # Independent deep duplication with fresh IDs for every mutable entity (PRJ-02)
 │   └── fixtures.ts          # Deterministic reference projects
 ├── persistence/        # Schema-v1 Firestore layout and repository boundary
 │   ├── documents.ts         # Collection paths, document shapes, chunk overflow

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,7 +69,7 @@ bun run test:browser
 
 Config: `playwright.config.ts`. `webServer` starts `bun run dev` with `VITE_MOCK_BACKEND=true` and waits for it before running tests, so the suite needs no real Firebase project — see `src/auth/authService.ts` for the mock auth implementation it exercises and `src/projectRepositoryClient.ts` for the in-memory `ProjectRepository` it exercises (a fresh, empty store per page load — this suite cannot prove persistence across a real reload, which is what `e2e-emulator/` is for; see below).
 
-Suite location: `e2e/`. `e2e/smoke.spec.ts` is PRD section 14's "anonymous start" required end-to-end layer: it loads the landing page, starts an anonymous session, and confirms the dashboard renders its empty state, then creates a project and confirms the `FND-009` slice's 16-step grid renders on it.
+Suite location: `e2e/`. `e2e/smoke.spec.ts` is PRD section 14's "anonymous start" required end-to-end layer: it loads the landing page, starts an anonymous session, and confirms the dashboard renders its empty state, then creates a project and confirms the `FND-009` slice's 16-step grid renders on it. The same file's `dashboard project management` block is `LOOP-001`'s dashboard coverage against the mock backend: a Blank Project's empty editor state, and rename/duplicate/confirmed-delete acting only on the row they were invoked on.
 
 ### Browser E2E suite against the Firebase Emulator
 
@@ -80,6 +80,8 @@ bun run test:browser:emulator
 Config: `playwright.emulator.config.ts`. Unlike the suite above, this points the *real* Firebase SDK at a local Firestore + Auth emulator (`VITE_FIRESTORE_EMULATOR_HOST`/`VITE_AUTH_EMULATOR_HOST`, wired in `src/firebaseConfig.ts`) instead of the in-memory mock — `bun run test:browser:emulator` runs `firebase emulators:exec --only firestore,auth` around the Playwright run, the same pattern `test:emulator` uses. This is what proves the `FND-009` slice's "save it, reload it, reproduce playback" step against a real backend: the in-memory repository above is a fresh, empty store on every page load, so it cannot prove anything survives an actual `page.reload()`.
 
 Suite location: `e2e-emulator/`. `e2e-emulator/slice.spec.ts` exercises the whole `FND-009` slice in the gating browsers (chromium, firefox — see `playwright.emulator.config.ts`): anonymous start, create a project, toggle steps on the grid, press play, undo a step, confirm the save status settles, reload the page, and confirm the reloaded project shows the same steps and the same pack dependency it saved.
+
+`e2e-emulator/dashboard.spec.ts` is `LOOP-001`'s access-control and destructive-confirmation coverage — the reason it needs the real emulator rather than the mock backend: a second `browser.newContext()` gets its own anonymous Firebase identity, so it can prove a project created by one anonymous session neither appears in another session's listing nor opens by URL (Firestore's security rules deny the read; the repository maps that `permission-denied` onto the same "not found" state an unknown ID would produce). The same file confirms a cancelled delete leaves a project in place and a confirmed one is gone after a real `page.reload()`.
 
 ### Playback is asserted in Chromium only — a known, tracked gap
 

--- a/e2e-emulator/dashboard.spec.ts
+++ b/e2e-emulator/dashboard.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * `LOOP-001` — the anonymous-start dashboard's access control and destructive
+ * confirmation, exercised against a real (emulated) backend so Firestore
+ * security rules are actually enforced (the mock backend in `e2e/` has no
+ * server-side security boundary to prove).
+ */
+test.describe("dashboard access control", () => {
+	test("a project created by one anonymous session is invisible and inaccessible to another", async ({
+		browser,
+	}) => {
+		const ownerContext = await browser.newContext();
+		const strangerContext = await browser.newContext();
+		try {
+			const ownerPage = await ownerContext.newPage();
+			await ownerPage.goto("/dashboard");
+			await expect(
+				ownerPage.getByRole("heading", { name: "Projects" }),
+			).toBeVisible();
+			await ownerPage.getByRole("button", { name: "New Project" }).click();
+			await expect(ownerPage).toHaveURL(/\/projects\/prj_/);
+			const projectUrl = ownerPage.url();
+
+			// A second, independent anonymous identity: its own browser context
+			// gets its own Auth persistence, so this is a genuinely different uid.
+			const strangerPage = await strangerContext.newPage();
+			await strangerPage.goto("/dashboard");
+			await expect(
+				strangerPage.getByRole("heading", { name: "Projects" }),
+			).toBeVisible();
+			// The owner's project does not leak into the stranger's listing —
+			// `listProjects` is scoped to the caller's own uid.
+			await expect(strangerPage.getByText("No projects yet")).toBeVisible();
+
+			// Navigating straight to the owner's project URL: Firestore's security
+			// rules deny the read (`isMember` requires owner or collaborator), and
+			// the repository maps that `permission-denied` onto the same
+			// `not_found` result an unknown project ID would produce — so this
+			// reads as "not found" rather than a crash or a leaked existence check.
+			await strangerPage.goto(projectUrl);
+			await expect(
+				strangerPage.getByRole("heading", { name: "This groove is broken" }),
+			).toBeVisible();
+		} finally {
+			await ownerContext.close();
+			await strangerContext.close();
+		}
+	});
+});
+
+test.describe("destructive confirmation", () => {
+	test("deleting a project requires confirmation, and the deletion persists across reload", async ({
+		page,
+	}) => {
+		await page.goto("/dashboard");
+		await page.getByRole("button", { name: "New Project" }).click();
+		await expect(page).toHaveURL(/\/projects\/prj_/);
+
+		await page.goto("/dashboard");
+		await expect(page.getByText("Untitled Project")).toBeVisible();
+
+		// Cancelling the confirmation leaves the project in place.
+		await page.getByRole("button", { name: /^delete$/i }).click();
+		const dialog = page.getByRole("alertdialog", {
+			name: /delete this project/i,
+		});
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole("button", { name: /^cancel$/i }).click();
+		await expect(dialog).not.toBeVisible();
+		await expect(page.getByText("Untitled Project")).toBeVisible();
+
+		// Confirming actually deletes it.
+		await page.getByRole("button", { name: /^delete$/i }).click();
+		await page
+			.getByRole("alertdialog", { name: /delete this project/i })
+			.getByRole("button", { name: /^delete$/i })
+			.click();
+		await expect(page.getByText("No projects yet")).toBeVisible();
+
+		// The deletion is a real write against the emulator, not just local
+		// state — a reload still shows it gone.
+		await page.reload();
+		await expect(page.getByText("No projects yet")).toBeVisible();
+	});
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -75,3 +75,76 @@ test.describe("new project", () => {
 		).toBeVisible();
 	});
 });
+
+// `LOOP-001`: the dashboard's project-management surface — blank creation,
+// rename, duplicate, and confirmed delete — against the in-memory mock
+// backend. See `e2e-emulator/dashboard.spec.ts` for the access-control and
+// persisted-delete coverage a real backend is needed to prove.
+test.describe("dashboard project management", () => {
+	test("creates a genuinely empty project via Blank Project", async ({
+		page,
+	}) => {
+		await page.goto("/dashboard");
+
+		await page.getByRole("button", { name: "Blank Project" }).click();
+
+		await expect(page).toHaveURL(/\/projects\/prj_/);
+		await expect(
+			page.getByText("This project has no sampler track yet."),
+		).toBeVisible();
+	});
+
+	test("renames, duplicates, and deletes a project from the dashboard", async ({
+		page,
+	}) => {
+		await page.goto("/dashboard");
+		await page.getByRole("button", { name: "New Project" }).click();
+		await expect(page).toHaveURL(/\/projects\/prj_/);
+
+		await page.goto("/dashboard");
+		await expect(page.getByText("Untitled Project")).toBeVisible();
+
+		// Rename.
+		await page.getByRole("button", { name: /rename/i }).click();
+		await page
+			.getByRole("textbox", { name: /rename untitled project/i })
+			.fill("My First Groove");
+		await page.getByRole("button", { name: /^save$/i }).click();
+		await expect(page.getByText("My First Groove")).toBeVisible();
+		await expect(page.getByText("Untitled Project")).not.toBeVisible();
+
+		// Duplicate: an independent second project appears alongside it.
+		await page.getByRole("button", { name: /duplicate/i }).click();
+		await expect(page.getByText("My First Groove copy")).toBeVisible();
+		await expect(
+			page.getByText("My First Groove", { exact: true }),
+		).toBeVisible();
+
+		// Delete requires confirmation. Only the duplicate's card is targeted
+		// (its text is a superset of the original's, so filtering on the full
+		// "... copy" text is what tells the two cards apart).
+		const duplicateCard = page
+			.locator(".project-card")
+			.filter({ hasText: "My First Groove copy" });
+		await duplicateCard.getByRole("button", { name: /^delete$/i }).click();
+		const dialog = page.getByRole("alertdialog", {
+			name: /delete this project/i,
+		});
+		await expect(dialog).toBeVisible();
+
+		// Cancelling keeps it.
+		await dialog.getByRole("button", { name: /^cancel$/i }).click();
+		await expect(page.getByText("My First Groove copy")).toBeVisible();
+
+		// Confirming removes only that one.
+		await duplicateCard.getByRole("button", { name: /^delete$/i }).click();
+		await page
+			.getByRole("alertdialog", { name: /delete this project/i })
+			.getByRole("button", { name: /^delete$/i })
+			.click();
+		await expect(page.getByText("My First Groove copy")).not.toBeVisible();
+		await expect(
+			page.getByText("My First Groove", { exact: true }),
+		).toBeVisible();
+	});
+});

--- a/src/auth/AuthProvider.test.tsx
+++ b/src/auth/AuthProvider.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import { memoryStorage } from "../testing/storage";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+	vi.resetModules();
+});
+
+type AuthCallback = (user: unknown) => void;
+
+/** A controllable `authService` double: the test decides when it "resolves". */
+function createFakeAuthService() {
+	let callback: AuthCallback | null = null;
+	return {
+		service: {
+			onAuthStateChanged: vi.fn((cb: AuthCallback) => {
+				callback = cb;
+				return () => {
+					callback = null;
+				};
+			}),
+			signInAnonymously: vi.fn(() => Promise.resolve()),
+			signInWithGoogle: vi.fn(() => Promise.resolve()),
+			linkWithGoogle: vi.fn(() => Promise.resolve()),
+			signOut: vi.fn(() => Promise.resolve()),
+			getCurrentUser: vi.fn(() => null),
+		},
+		emit(user: unknown) {
+			callback?.(user);
+		},
+	};
+}
+
+async function renderAuthProvider() {
+	const fake = createFakeAuthService();
+	vi.doMock("./authService", () => ({ authService: fake.service }));
+
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+
+	const { AuthProvider } = await import("./AuthProvider");
+	render(() => (
+		<AuthProvider analytics={analytics}>
+			<div>child</div>
+		</AuthProvider>
+	));
+
+	return { fake, transport };
+}
+
+describe("AuthProvider", () => {
+	it("signs in anonymously and logs anon_session_created when there is no existing session", async () => {
+		const { fake, transport } = await renderAuthProvider();
+
+		fake.emit(null);
+
+		await waitFor(() => {
+			expect(fake.service.signInAnonymously).toHaveBeenCalledTimes(1);
+		});
+		await waitFor(() => {
+			expect(transport.named("anon_session_created")).toHaveLength(1);
+		});
+	});
+
+	it("does not sign in anonymously or log anon_session_created for a returning session", async () => {
+		const { fake, transport } = await renderAuthProvider();
+
+		fake.emit({ uid: "user_returning", isAnonymous: true });
+
+		// Give any (incorrect) async sign-in attempt a chance to happen.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(fake.service.signInAnonymously).not.toHaveBeenCalled();
+		expect(transport.named("anon_session_created")).toHaveLength(0);
+	});
+
+	it("does not log anon_session_created again on a second null->user cycle from the same provider instance", async () => {
+		const { fake, transport } = await renderAuthProvider();
+
+		fake.emit(null);
+		await waitFor(() => {
+			expect(transport.named("anon_session_created")).toHaveLength(1);
+		});
+
+		fake.emit({ uid: "mock-anon-123", isAnonymous: true });
+		await Promise.resolve();
+
+		expect(transport.named("anon_session_created")).toHaveLength(1);
+	});
+});

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -7,7 +7,10 @@ import {
 	useContext,
 } from "solid-js";
 import { createStore } from "solid-js/store";
-import { analytics } from "../analytics/analytics";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
 import { authService } from "./authService";
 
 interface AuthState {
@@ -18,7 +21,13 @@ interface AuthState {
 
 const AuthContext = createContext<AuthState>();
 
-export function AuthProvider(props: ParentProps) {
+export interface AuthProviderProps extends ParentProps {
+	/** Overridden in tests; defaults to the app-wide analytics boundary. */
+	analytics?: Analytics;
+}
+
+export function AuthProvider(props: AuthProviderProps) {
+	const analytics = props.analytics ?? defaultAnalytics;
 	const [state, setState] = createStore<AuthState>({
 		user: null,
 		loading: true,
@@ -40,11 +49,19 @@ export function AuthProvider(props: ParentProps) {
 			if (!user) {
 				// No session yet: sign the visitor in anonymously so they can
 				// start working immediately. Firebase persists this session
-				// locally, so returning users keep their work and uid.
-				authService.signInAnonymously().catch((error) => {
-					console.error("Error signing in anonymously:", error);
-					setState({ user: null, loading: false, isAnonymous: false });
-				});
+				// locally, so returning users keep their work and uid, and this
+				// branch never runs for them — `onAuthStateChanged` reports their
+				// existing user directly instead. That is what makes it safe to
+				// log `anon_session_created` (PRD `OPS-02`) unconditionally here:
+				// reaching this branch at all means a genuinely new anonymous
+				// Firebase identity is about to be created, not a returning one.
+				authService
+					.signInAnonymously()
+					.then(() => analytics.log("anon_session_created"))
+					.catch((error) => {
+						console.error("Error signing in anonymously:", error);
+						setState({ user: null, loading: false, isAnonymous: false });
+					});
 				return;
 			}
 

--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -1,0 +1,61 @@
+.confirm-dialog-backdrop {
+	position: fixed;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	background: rgba(0, 0, 0, 0.55);
+	z-index: 100;
+}
+
+.confirm-dialog {
+	width: 100%;
+	max-width: 360px;
+	padding: 20px;
+	border-radius: 12px;
+	background: var(--color-background-secondary);
+	border: 1px solid rgba(255, 255, 255, 0.12);
+	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+
+.confirm-dialog-title {
+	margin: 0 0 8px;
+	font-size: var(--font-size-base);
+	font-weight: 600;
+}
+
+.confirm-dialog-message {
+	margin: 0 0 20px;
+	color: var(--color-foreground);
+	font-size: var(--font-size-small);
+}
+
+.confirm-dialog-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}
+
+.confirm-dialog-actions button {
+	padding: 8px 14px;
+	border-radius: 8px;
+	cursor: pointer;
+}
+
+.confirm-dialog-actions button:disabled {
+	opacity: 0.6;
+	cursor: default;
+}
+
+.confirm-dialog-confirm {
+	background: #d64545;
+	color: #fff;
+	border: 1px solid #d64545;
+}
+
+.confirm-dialog-cancel {
+	background: transparent;
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	color: var(--color-text);
+}

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ConfirmDialog from "./ConfirmDialog";
+
+afterEach(() => cleanup());
+
+describe("ConfirmDialog", () => {
+	it("renders as an alertdialog with the given title and message", () => {
+		render(() => (
+			<ConfirmDialog
+				title="Delete this project?"
+				message="This cannot be undone."
+				onConfirm={() => {}}
+				onCancel={() => {}}
+			/>
+		));
+
+		expect(
+			screen.getByRole("alertdialog", { name: "Delete this project?" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+	});
+
+	it("calls onConfirm when the confirm button is clicked", () => {
+		const onConfirm = vi.fn();
+		render(() => (
+			<ConfirmDialog
+				title="Delete?"
+				message="Sure?"
+				onConfirm={onConfirm}
+				onCancel={() => {}}
+			/>
+		));
+
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		const onCancel = vi.fn();
+		render(() => (
+			<ConfirmDialog
+				title="Delete?"
+				message="Sure?"
+				onConfirm={() => {}}
+				onCancel={onCancel}
+			/>
+		));
+
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onCancel when Escape is pressed", () => {
+		const onCancel = vi.fn();
+		render(() => (
+			<ConfirmDialog
+				title="Delete?"
+				message="Sure?"
+				onConfirm={() => {}}
+				onCancel={onCancel}
+			/>
+		));
+
+		fireEvent.keyDown(document, { key: "Escape" });
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables both actions while busy", () => {
+		render(() => (
+			<ConfirmDialog
+				title="Delete?"
+				message="Sure?"
+				busy
+				onConfirm={() => {}}
+				onCancel={() => {}}
+			/>
+		));
+
+		expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+	});
+
+	it("supports custom confirm/cancel labels", () => {
+		render(() => (
+			<ConfirmDialog
+				title="Discard changes?"
+				message="Sure?"
+				confirmLabel="Discard"
+				cancelLabel="Keep editing"
+				onConfirm={() => {}}
+				onCancel={() => {}}
+			/>
+		));
+
+		expect(screen.getByRole("button", { name: "Discard" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Keep editing" }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,64 @@
+import { createEffect, type JSX, onCleanup } from "solid-js";
+import "./ConfirmDialog.css";
+
+export interface ConfirmDialogProps {
+	title: string;
+	message: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	/** Disables both actions while the confirmed action is in flight. */
+	busy?: boolean;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+/**
+ * A minimal, accessible confirmation modal for destructive actions (PRD
+ * `PRJ-02`: "Destructive deletion requires confirmation").
+ *
+ * `role="alertdialog"` plus `aria-modal` marks it for assistive technology.
+ * Dismissal is keyboard-first rather than click-outside: the `Escape` key and
+ * the `Cancel` button both cancel, so nothing here needs a mouse-only handler
+ * on a non-interactive backdrop element.
+ */
+export default function ConfirmDialog(props: ConfirmDialogProps): JSX.Element {
+	createEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") props.onCancel();
+		};
+		document.addEventListener("keydown", onKeyDown);
+		onCleanup(() => document.removeEventListener("keydown", onKeyDown));
+	});
+
+	return (
+		<div class="confirm-dialog-backdrop">
+			<div
+				class="confirm-dialog"
+				role="alertdialog"
+				aria-modal="true"
+				aria-label={props.title}
+			>
+				<p class="confirm-dialog-title">{props.title}</p>
+				<p class="confirm-dialog-message">{props.message}</p>
+				<div class="confirm-dialog-actions">
+					<button
+						type="button"
+						class="confirm-dialog-cancel"
+						disabled={props.busy}
+						onClick={() => props.onCancel()}
+					>
+						{props.cancelLabel ?? "Cancel"}
+					</button>
+					<button
+						type="button"
+						class="confirm-dialog-confirm"
+						disabled={props.busy}
+						onClick={() => props.onConfirm()}
+					>
+						{props.confirmLabel ?? "Delete"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -1,5 +1,16 @@
-import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	within,
+} from "@solidjs/testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import type { ProjectMetadata } from "../domain/entities";
+import { memoryStorage } from "../testing/storage";
 import Dashboard from "./Dashboard";
 
 afterEach(() => {
@@ -18,16 +29,26 @@ vi.mock("../auth/AuthProvider", () => ({
 	}),
 }));
 
+const navigate = vi.fn();
 vi.mock("@solidjs/router", () => ({
-	useNavigate: () => vi.fn(),
+	useNavigate: () => navigate,
 	A: (props: { href: string; children?: unknown }) => (
 		<a href={props.href}>{props.children as never}</a>
 	),
 }));
 
-const { listProjects, createProject } = vi.hoisted(() => ({
+const {
+	listProjects,
+	createProject,
+	saveMetadata,
+	loadProject,
+	deleteProject,
+} = vi.hoisted(() => ({
 	listProjects: vi.fn(),
 	createProject: vi.fn(),
+	saveMetadata: vi.fn(),
+	loadProject: vi.fn(),
+	deleteProject: vi.fn(),
 }));
 
 vi.mock("../projectRepositoryClient", () => ({
@@ -35,11 +56,41 @@ vi.mock("../projectRepositoryClient", () => ({
 		Promise.resolve({
 			listProjects: (...args: unknown[]) => listProjects(...args),
 			createProject: (...args: unknown[]) => createProject(...args),
+			saveMetadata: (...args: unknown[]) => saveMetadata(...args),
+			loadProject: (...args: unknown[]) => loadProject(...args),
+			deleteProject: (...args: unknown[]) => deleteProject(...args),
 		}),
 }));
 
+function makeMetadata(
+	overrides: Partial<ProjectMetadata> = {},
+): ProjectMetadata {
+	return {
+		id: "prj_abc" as ProjectMetadata["id"],
+		name: "My Groove",
+		schemaVersion: 1,
+		revision: 0,
+		ownerId: "user-1",
+		collaboratorIds: [],
+		createdAt: Date.now(),
+		modifiedAt: Date.now(),
+		template: null,
+		genre: null,
+		packDependencies: [],
+		...overrides,
+	};
+}
+
 function renderDashboard() {
-	return render(() => <Dashboard />);
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+	render(() => <Dashboard analytics={analytics} />);
+	return { transport };
 }
 
 describe("Dashboard", () => {
@@ -79,21 +130,7 @@ describe("Dashboard", () => {
 	});
 
 	it("renders the listed projects", async () => {
-		listProjects.mockResolvedValue([
-			{
-				id: "prj_abc",
-				name: "My Groove",
-				schemaVersion: 1,
-				revision: 0,
-				ownerId: "user-1",
-				collaboratorIds: [],
-				createdAt: Date.now(),
-				modifiedAt: Date.now(),
-				template: null,
-				genre: null,
-				packDependencies: [],
-			},
-		]);
+		listProjects.mockResolvedValue([makeMetadata()]);
 
 		renderDashboard();
 
@@ -123,5 +160,187 @@ describe("Dashboard", () => {
 		).toBeInTheDocument();
 		// The button re-enables so the user can try again.
 		expect(newProjectButton).not.toBeDisabled();
+	});
+
+	describe("creation", () => {
+		it("creates an audible starter and logs project_created(source: template)", async () => {
+			listProjects.mockResolvedValue([]);
+			createProject.mockResolvedValue({
+				ok: true,
+				revision: 0,
+				modifiedAt: Date.now(),
+			});
+			const { transport } = renderDashboard();
+
+			fireEvent.click(
+				await screen.findByRole("button", { name: /^new project$/i }),
+			);
+
+			await vi.waitFor(() => expect(createProject).toHaveBeenCalledTimes(1));
+			const created = createProject.mock.calls[0][0];
+			expect(created.song.tracks.length).toBeGreaterThan(0);
+			expect(transport.named("project_created")).toHaveLength(1);
+			expect(transport.named("project_created")[0]?.params).toMatchObject({
+				source: "template",
+			});
+			expect(navigate).toHaveBeenCalledWith(`/projects/${created.metadata.id}`);
+		});
+
+		it("creates a genuinely empty project and logs project_created(source: blank)", async () => {
+			listProjects.mockResolvedValue([]);
+			createProject.mockResolvedValue({
+				ok: true,
+				revision: 0,
+				modifiedAt: Date.now(),
+			});
+			const { transport } = renderDashboard();
+
+			fireEvent.click(
+				await screen.findByRole("button", { name: /blank project/i }),
+			);
+
+			await vi.waitFor(() => expect(createProject).toHaveBeenCalledTimes(1));
+			const created = createProject.mock.calls[0][0];
+			expect(created.song.tracks).toHaveLength(0);
+			expect(transport.named("project_created")[0]?.params).toMatchObject({
+				source: "blank",
+			});
+		});
+	});
+
+	describe("rename", () => {
+		it("renames a project and reflects the new name", async () => {
+			listProjects.mockResolvedValue([makeMetadata({ revision: 3 })]);
+			saveMetadata.mockResolvedValue({
+				ok: true,
+				revision: 4,
+				modifiedAt: Date.now(),
+			});
+			renderDashboard();
+
+			fireEvent.click(await screen.findByRole("button", { name: /rename/i }));
+			const input = screen.getByRole("textbox", { name: /rename my groove/i });
+			fireEvent.input(input, { target: { value: "Renamed Groove" } });
+			fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+			await screen.findByText("Renamed Groove");
+			expect(saveMetadata).toHaveBeenCalledWith(
+				"prj_abc",
+				{ name: "Renamed Groove" },
+				3,
+			);
+		});
+
+		it("shows an inline error and keeps editing when rename fails", async () => {
+			listProjects.mockResolvedValue([makeMetadata()]);
+			saveMetadata.mockResolvedValue({
+				ok: false,
+				reason: "revision_conflict",
+				message: "Someone else changed this project first.",
+				retryable: false,
+			});
+			renderDashboard();
+
+			fireEvent.click(await screen.findByRole("button", { name: /rename/i }));
+			fireEvent.input(
+				screen.getByRole("textbox", { name: /rename my groove/i }),
+				{
+					target: { value: "New name" },
+				},
+			);
+			fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+			expect(
+				await screen.findByText("Someone else changed this project first."),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("duplicate", () => {
+		it("duplicates a project, adds it to the list, and logs project_created(source: duplicate)", async () => {
+			const original = makeMetadata();
+			listProjects.mockResolvedValue([original]);
+			loadProject.mockResolvedValue({
+				ok: true,
+				value: {
+					metadata: original,
+					song: {
+						tempo: 120,
+						timeSignature: { numerator: 4, denominator: 4 },
+						tracks: [],
+						returns: [],
+						master: { volume: 0, devices: [] },
+						sections: [],
+						placements: [],
+						automation: [],
+						assets: [],
+					},
+					clips: [],
+				},
+			});
+			createProject.mockResolvedValue({
+				ok: true,
+				revision: 0,
+				modifiedAt: Date.now(),
+			});
+			const { transport } = renderDashboard();
+
+			fireEvent.click(
+				await screen.findByRole("button", { name: /duplicate/i }),
+			);
+
+			await vi.waitFor(() => expect(createProject).toHaveBeenCalledTimes(1));
+			expect(await screen.findByText("My Groove copy")).toBeInTheDocument();
+			// The original stays, so the list now shows both.
+			expect(screen.getAllByText(/My Groove/)).toHaveLength(2);
+			expect(transport.named("project_created")[0]?.params).toMatchObject({
+				source: "duplicate",
+			});
+		});
+	});
+
+	describe("delete", () => {
+		it("requires confirmation before deleting", async () => {
+			listProjects.mockResolvedValue([makeMetadata()]);
+			renderDashboard();
+
+			fireEvent.click(await screen.findByRole("button", { name: /^delete$/i }));
+
+			expect(
+				screen.getByRole("alertdialog", { name: /delete this project/i }),
+			).toBeInTheDocument();
+			expect(deleteProject).not.toHaveBeenCalled();
+		});
+
+		it("keeps the project when the confirmation is cancelled", async () => {
+			listProjects.mockResolvedValue([makeMetadata()]);
+			renderDashboard();
+
+			fireEvent.click(await screen.findByRole("button", { name: /^delete$/i }));
+			fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+			expect(deleteProject).not.toHaveBeenCalled();
+			expect(await screen.findByText("My Groove")).toBeInTheDocument();
+		});
+
+		it("deletes after confirmation and logs project_deleted", async () => {
+			listProjects.mockResolvedValue([makeMetadata()]);
+			deleteProject.mockResolvedValue(undefined);
+			const { transport } = renderDashboard();
+
+			fireEvent.click(await screen.findByRole("button", { name: /^delete$/i }));
+			const dialog = screen.getByRole("alertdialog", {
+				name: /delete this project/i,
+			});
+			fireEvent.click(
+				within(dialog).getByRole("button", { name: /^delete$/i }),
+			);
+
+			await vi.waitFor(() =>
+				expect(deleteProject).toHaveBeenCalledWith("prj_abc"),
+			);
+			expect(await screen.findByText("No projects yet")).toBeInTheDocument();
+			expect(transport.named("project_deleted")).toHaveLength(1);
+		});
 	});
 });

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,9 @@
 import { useNavigate } from "@solidjs/router";
-import { HiSolidArrowPath, HiSolidPlus } from "solid-icons/hi";
+import {
+	HiSolidArrowPath,
+	HiSolidDocumentText,
+	HiSolidPlus,
+} from "solid-icons/hi";
 import {
 	createEffect,
 	createMemo,
@@ -9,10 +13,19 @@ import {
 	Show,
 	Switch,
 } from "solid-js";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
+import { projectAgeBucket } from "../analytics/buckets";
 import { useAuth } from "../auth/AuthProvider";
+import { duplicateProject } from "../domain/duplicateProject";
 import type { ProjectMetadata } from "../domain/entities";
+import { createBlankProject } from "../domain/factories";
+import type { ProjectId } from "../domain/ids";
 import { createStarterProject } from "../editor/starterProject";
 import { getProjectRepository } from "../projectRepositoryClient";
+import type { ProjectActionResult } from "./ProjectList";
 import ProjectList from "./ProjectList";
 import TapeLoader from "./TapeLoader";
 import UpgradeAccountPrompt from "./UpgradeAccountPrompt";
@@ -23,7 +36,13 @@ interface ProjectsState {
 	data: ProjectMetadata[];
 }
 
-export default function Dashboard() {
+export interface DashboardProps {
+	/** Overridden in tests; defaults to the app-wide analytics boundary. */
+	analytics?: Analytics;
+}
+
+export default function Dashboard(props: DashboardProps = {}) {
+	const analytics = props.analytics ?? defaultAnalytics;
 	const auth = useAuth();
 	const navigate = useNavigate();
 	const userId = createMemo(() => auth?.user?.uid);
@@ -79,23 +98,128 @@ export default function Dashboard() {
 
 	const retryFetchProjects = () => setRetryCount((count) => count + 1);
 
-	const createProject = async () => {
+	/**
+	 * `source: "blank"` creates a genuinely empty project; `source: "template"`
+	 * uses the `FND-009` starter — audible content with no genre attached (the
+	 * `DEC-002` featured genre templates are `LOOP-015`'s scope, not this one's).
+	 * Both are the PRD `PRJ-01`/`PRJ-02` creation paths this task owns.
+	 */
+	const createProject = async (source: "blank" | "template") => {
 		const id = userId();
 		if (!id || creating()) return;
 		setCreating(true);
 		setCreateError(null);
 		try {
 			const repository = await getProjectRepository();
-			const project = createStarterProject(id);
+			const project =
+				source === "blank"
+					? createBlankProject({
+							ownerId: id,
+							name: "Untitled Project",
+							template: "blank",
+						})
+					: createStarterProject(id);
 			const result = await repository.createProject(project);
 			if (!result.ok) {
 				throw new Error(result.message);
 			}
+			analytics.log("project_created", { source });
 			navigate(`/projects/${project.metadata.id}`);
 		} catch (error) {
 			console.error("Error creating project:", error);
 			setCreateError("Couldn't create a new project. Please try again.");
 			setCreating(false);
+		}
+	};
+
+	const renameProject = async (
+		projectId: string,
+		name: string,
+	): Promise<ProjectActionResult> => {
+		const current = projectsState().data.find((p) => p.id === projectId);
+		if (!current)
+			return { ok: false, message: "That project is no longer here." };
+		try {
+			const repository = await getProjectRepository();
+			const result = await repository.saveMetadata(
+				projectId as ProjectId,
+				{ name },
+				current.revision,
+			);
+			if (!result.ok) {
+				return { ok: false, message: result.message };
+			}
+			setProjectsState((state) => ({
+				...state,
+				data: state.data.map((project) =>
+					project.id === projectId
+						? {
+								...project,
+								name,
+								revision: result.revision,
+								modifiedAt: result.modifiedAt,
+							}
+						: project,
+				),
+			}));
+			return { ok: true };
+		} catch (error) {
+			console.error("Error renaming project:", error);
+			return { ok: false, message: "Couldn't rename this project." };
+		}
+	};
+
+	const duplicateExistingProject = async (
+		projectId: string,
+	): Promise<ProjectActionResult> => {
+		const id = userId();
+		if (!id) return { ok: false, message: "Not signed in." };
+		try {
+			const repository = await getProjectRepository();
+			const loaded = await repository.loadProject(projectId as ProjectId);
+			if (!loaded.ok) {
+				return {
+					ok: false,
+					message: "Couldn't load this project to duplicate.",
+				};
+			}
+			const duplicate = duplicateProject(loaded.value, { ownerId: id });
+			const result = await repository.createProject(duplicate);
+			if (!result.ok) {
+				return { ok: false, message: result.message };
+			}
+			analytics.log("project_created", { source: "duplicate" });
+			setProjectsState((state) => ({
+				...state,
+				data: [...state.data, duplicate.metadata],
+			}));
+			return { ok: true };
+		} catch (error) {
+			console.error("Error duplicating project:", error);
+			return { ok: false, message: "Couldn't duplicate this project." };
+		}
+	};
+
+	const deleteProject = async (
+		projectId: string,
+	): Promise<ProjectActionResult> => {
+		const current = projectsState().data.find((p) => p.id === projectId);
+		try {
+			const repository = await getProjectRepository();
+			await repository.deleteProject(projectId as ProjectId);
+			analytics.log("project_deleted", {
+				project_age_bucket: projectAgeBucket(
+					Date.now() - (current?.createdAt ?? Date.now()),
+				),
+			});
+			setProjectsState((state) => ({
+				...state,
+				data: state.data.filter((project) => project.id !== projectId),
+			}));
+			return { ok: true };
+		} catch (error) {
+			console.error("Error deleting project:", error);
+			return { ok: false, message: "Couldn't delete this project." };
 		}
 	};
 
@@ -111,21 +235,32 @@ export default function Dashboard() {
 				    single reactive container to update correctly on retry. */}
 				<div>
 					<div class="dashboard-actions">
-						<button
-							type="button"
-							class="new-project"
-							disabled={creating()}
-							onClick={createProject}
-						>
-							<HiSolidPlus size={18} />
-							<span>New Project</span>
-						</button>
+						<div class="action-row">
+							<button
+								type="button"
+								class="new-project"
+								disabled={creating()}
+								onClick={() => void createProject("template")}
+							>
+								<HiSolidPlus size={18} />
+								<span>New Project</span>
+							</button>
+							<button
+								type="button"
+								class="blank-project"
+								disabled={creating()}
+								onClick={() => void createProject("blank")}
+							>
+								<HiSolidDocumentText size={18} />
+								<span>Blank Project</span>
+							</button>
+						</div>
 						<Show when={createError()}>
 							<p class="create-error">{createError()}</p>
 						</Show>
 					</div>
 					<Show when={auth?.isAnonymous}>
-						<UpgradeAccountPrompt />
+						<UpgradeAccountPrompt analytics={analytics} />
 					</Show>
 					<Switch>
 						<Match when={projectsState().error}>
@@ -142,7 +277,12 @@ export default function Dashboard() {
 							</div>
 						</Match>
 						<Match when={projectsState().data}>
-							<ProjectList projects={projectsState().data} />
+							<ProjectList
+								projects={projectsState().data}
+								onRename={renameProject}
+								onDuplicate={duplicateExistingProject}
+								onDelete={deleteProject}
+							/>
 						</Match>
 					</Switch>
 				</div>

--- a/src/components/ProjectList.test.tsx
+++ b/src/components/ProjectList.test.tsx
@@ -1,12 +1,18 @@
 import { MemoryRouter, Route } from "@solidjs/router";
-import { cleanup, render, screen } from "@solidjs/testing-library";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	within,
+} from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ProjectMetadata } from "../domain/entities";
 import {
 	createFactoryContext,
 	createProjectMetadata,
 } from "../domain/factories";
-import ProjectList from "./ProjectList";
+import ProjectList, { type ProjectActionResult } from "./ProjectList";
 
 afterEach(() => cleanup());
 
@@ -22,10 +28,34 @@ function makeProjectMetadata(
 
 // ProjectList links to project routes with <A>, which needs a matched Route
 // context to resolve against — a bare MemoryRouter isn't enough.
-function renderWithRouter(projects: ProjectMetadata[]) {
+function renderWithRouter(
+	projects: ProjectMetadata[],
+	handlers: {
+		onRename?: (
+			id: string,
+			name: string,
+		) => Promise<ProjectActionResult> | ProjectActionResult;
+		onDuplicate?: (
+			id: string,
+		) => Promise<ProjectActionResult> | ProjectActionResult;
+		onDelete?: (
+			id: string,
+		) => Promise<ProjectActionResult> | ProjectActionResult;
+	} = {},
+) {
 	return render(() => (
 		<MemoryRouter>
-			<Route path="/" component={() => <ProjectList projects={projects} />} />
+			<Route
+				path="/"
+				component={() => (
+					<ProjectList
+						projects={projects}
+						onRename={handlers.onRename}
+						onDuplicate={handlers.onDuplicate}
+						onDelete={handlers.onDelete}
+					/>
+				)}
+			/>
 		</MemoryRouter>
 	));
 }
@@ -45,5 +75,124 @@ describe("ProjectList", () => {
 
 		expect(screen.getByText("My Groove")).toBeInTheDocument();
 		expect(screen.queryByText("No projects yet")).not.toBeInTheDocument();
+	});
+
+	it("shows last-modified time and the template/genre badges when present", () => {
+		renderWithRouter([
+			makeProjectMetadata({
+				name: "House Jam",
+				modifiedAt: Date.now(),
+				template: "starter",
+				genre: "house",
+			}),
+		]);
+
+		expect(screen.getByText(/Edited/)).toBeInTheDocument();
+		expect(screen.getByText("starter")).toBeInTheDocument();
+		expect(screen.getByText("house")).toBeInTheDocument();
+	});
+
+	it("renames a project via the inline form", async () => {
+		const project = makeProjectMetadata({ name: "Old Name" });
+		const onRename = vi.fn().mockResolvedValue({ ok: true });
+		renderWithRouter([project], { onRename });
+
+		fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+		const input = screen.getByRole("textbox", { name: /rename old name/i });
+		fireEvent.input(input, { target: { value: "New Name" } });
+		fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+		await vi.waitFor(() =>
+			expect(onRename).toHaveBeenCalledWith(project.id, "New Name"),
+		);
+	});
+
+	it("cancels the rename form without calling onRename", () => {
+		const project = makeProjectMetadata({ name: "Old Name" });
+		const onRename = vi.fn();
+		renderWithRouter([project], { onRename });
+
+		fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+		fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+		expect(onRename).not.toHaveBeenCalled();
+		expect(screen.getByText("Old Name")).toBeInTheDocument();
+	});
+
+	it("shows an inline error when rename fails", async () => {
+		const project = makeProjectMetadata({ name: "Old Name" });
+		const onRename = vi.fn().mockResolvedValue({
+			ok: false,
+			message: "Someone else changed this project first.",
+		});
+		renderWithRouter([project], { onRename });
+
+		fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+		fireEvent.input(screen.getByRole("textbox", { name: /rename old name/i }), {
+			target: { value: "New Name" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+		expect(
+			await screen.findByText("Someone else changed this project first."),
+		).toBeInTheDocument();
+	});
+
+	it("calls onDuplicate when Duplicate is clicked", async () => {
+		const project = makeProjectMetadata({ name: "My Groove" });
+		const onDuplicate = vi.fn().mockResolvedValue({ ok: true });
+		renderWithRouter([project], { onDuplicate });
+
+		fireEvent.click(screen.getByRole("button", { name: /duplicate/i }));
+
+		await vi.waitFor(() =>
+			expect(onDuplicate).toHaveBeenCalledWith(project.id),
+		);
+	});
+
+	describe("delete confirmation", () => {
+		it("opens a confirmation dialog and does not call onDelete before it is confirmed", () => {
+			const project = makeProjectMetadata({ name: "My Groove" });
+			const onDelete = vi.fn();
+			renderWithRouter([project], { onDelete });
+
+			fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+			expect(
+				screen.getByRole("alertdialog", { name: /delete this project/i }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/"My Groove" will be permanently deleted/),
+			).toBeInTheDocument();
+			expect(onDelete).not.toHaveBeenCalled();
+		});
+
+		it("calls onDelete only after the dialog is confirmed", async () => {
+			const project = makeProjectMetadata({ name: "My Groove" });
+			const onDelete = vi.fn().mockResolvedValue({ ok: true });
+			renderWithRouter([project], { onDelete });
+
+			fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+			const dialog = screen.getByRole("alertdialog", {
+				name: /delete this project/i,
+			});
+			fireEvent.click(
+				within(dialog).getByRole("button", { name: /^delete$/i }),
+			);
+
+			await vi.waitFor(() => expect(onDelete).toHaveBeenCalledWith(project.id));
+		});
+
+		it("dismisses the dialog and calls nothing when cancelled", () => {
+			const project = makeProjectMetadata({ name: "My Groove" });
+			const onDelete = vi.fn();
+			renderWithRouter([project], { onDelete });
+
+			fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+			fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+			expect(onDelete).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -1,13 +1,111 @@
 import { A } from "@solidjs/router";
 import since from "since-time-ago";
-import { For, type JSX, Show } from "solid-js";
+import {
+	HiSolidDocumentDuplicate,
+	HiSolidPencil,
+	HiSolidTrash,
+} from "solid-icons/hi";
+import { createSignal, For, type JSX, Show } from "solid-js";
 import type { ProjectMetadata } from "../domain/entities";
+import ConfirmDialog from "./ConfirmDialog";
 
-type ProjectListProps = {
+/** The outcome of a row action, for inline per-row error display. */
+export interface ProjectActionResult {
+	readonly ok: boolean;
+	readonly message?: string;
+}
+
+export interface ProjectListProps {
 	projects: ProjectMetadata[];
-};
+	/** Persists a new name. The row returns to read mode on success. */
+	onRename?: (
+		projectId: string,
+		name: string,
+	) => Promise<ProjectActionResult> | ProjectActionResult;
+	onDuplicate?: (
+		projectId: string,
+	) => Promise<ProjectActionResult> | ProjectActionResult;
+	/** Called only after the destructive-confirmation dialog is confirmed. */
+	onDelete?: (
+		projectId: string,
+	) => Promise<ProjectActionResult> | ProjectActionResult;
+}
 
 export default function ProjectList(props: ProjectListProps): JSX.Element {
+	const [renamingId, setRenamingId] = createSignal<string | null>(null);
+	const [draftName, setDraftName] = createSignal("");
+	const [pendingDeleteId, setPendingDeleteId] = createSignal<string | null>(
+		null,
+	);
+	const [busyId, setBusyId] = createSignal<string | null>(null);
+	const [rowError, setRowError] = createSignal<{
+		id: string;
+		message: string;
+	} | null>(null);
+
+	const startRename = (project: ProjectMetadata) => {
+		setRowError(null);
+		setRenamingId(project.id);
+		setDraftName(project.name);
+	};
+
+	const cancelRename = () => {
+		setRenamingId(null);
+		setDraftName("");
+	};
+
+	const saveRename = async (projectId: string) => {
+		const name = draftName().trim();
+		if (!name || !props.onRename) {
+			cancelRename();
+			return;
+		}
+		setBusyId(projectId);
+		const result = await props.onRename(projectId, name);
+		setBusyId(null);
+		if (result.ok) {
+			cancelRename();
+			setRowError(null);
+		} else {
+			setRowError({
+				id: projectId,
+				message: result.message ?? "Rename failed.",
+			});
+		}
+	};
+
+	const duplicate = async (projectId: string) => {
+		if (!props.onDuplicate) return;
+		setRowError(null);
+		setBusyId(projectId);
+		const result = await props.onDuplicate(projectId);
+		setBusyId(null);
+		if (!result.ok) {
+			setRowError({
+				id: projectId,
+				message: result.message ?? "Couldn't duplicate this project.",
+			});
+		}
+	};
+
+	const confirmDelete = async () => {
+		const projectId = pendingDeleteId();
+		if (!projectId || !props.onDelete) {
+			setPendingDeleteId(null);
+			return;
+		}
+		setBusyId(projectId);
+		const result = await props.onDelete(projectId);
+		setBusyId(null);
+		setPendingDeleteId(null);
+		if (!result.ok) {
+			setRowError({
+				id: projectId,
+				message: result.message ?? "Couldn't delete this project.",
+			});
+		}
+	};
+
 	return (
 		<div class="project-list">
 			<Show
@@ -24,15 +122,109 @@ export default function ProjectList(props: ProjectListProps): JSX.Element {
 				<For each={props.projects}>
 					{(project) => (
 						<div class="project-card">
-							<p class="project-title">
-								<A href={`/projects/${project.id}`}>{project.name}</A>
-							</p>
+							<Show
+								when={renamingId() === project.id}
+								fallback={
+									<p class="project-title">
+										<A href={`/projects/${project.id}`}>{project.name}</A>
+									</p>
+								}
+							>
+								<form
+									class="project-rename-form"
+									onSubmit={(event) => {
+										event.preventDefault();
+										void saveRename(project.id);
+									}}
+								>
+									<input
+										class="project-rename-input"
+										type="text"
+										value={draftName()}
+										maxLength={120}
+										aria-label={`Rename ${project.name}`}
+										onInput={(event) => setDraftName(event.currentTarget.value)}
+										// Opening rename mode is itself the user's request to type
+										// a new name immediately.
+										autofocus
+									/>
+									<button type="submit" disabled={busyId() === project.id}>
+										Save
+									</button>
+									<button
+										type="button"
+										disabled={busyId() === project.id}
+										onClick={cancelRename}
+									>
+										Cancel
+									</button>
+								</form>
+							</Show>
+
 							<p class="project-meta">
-								<span>Created {since(new Date(project.createdAt))}</span>
+								<span>Edited {since(new Date(project.modifiedAt))}</span>
+								<Show when={project.template}>
+									<span class="project-badge">{project.template}</span>
+								</Show>
+								<Show when={project.genre}>
+									<span class="project-badge">{project.genre}</span>
+								</Show>
 							</p>
+
+							<Show when={renamingId() !== project.id}>
+								<div class="project-card-actions">
+									<button
+										type="button"
+										class="project-action"
+										disabled={busyId() === project.id}
+										onClick={() => startRename(project)}
+									>
+										<HiSolidPencil size={14} />
+										<span>Rename</span>
+									</button>
+									<button
+										type="button"
+										class="project-action"
+										disabled={busyId() === project.id}
+										onClick={() => void duplicate(project.id)}
+									>
+										<HiSolidDocumentDuplicate size={14} />
+										<span>Duplicate</span>
+									</button>
+									<button
+										type="button"
+										class="project-action project-action-destructive"
+										disabled={busyId() === project.id}
+										onClick={() => setPendingDeleteId(project.id)}
+									>
+										<HiSolidTrash size={14} />
+										<span>Delete</span>
+									</button>
+								</div>
+							</Show>
+
+							<Show when={rowError()?.id === project.id}>
+								<p class="project-row-error">{rowError()?.message}</p>
+							</Show>
 						</div>
 					)}
 				</For>
+			</Show>
+
+			<Show when={pendingDeleteId()}>
+				{(projectId) => {
+					const project = props.projects.find((p) => p.id === projectId());
+					return (
+						<ConfirmDialog
+							title="Delete this project?"
+							message={`"${project?.name ?? "This project"}" will be permanently deleted. This cannot be undone.`}
+							confirmLabel="Delete"
+							busy={busyId() === projectId()}
+							onCancel={() => setPendingDeleteId(null)}
+							onConfirm={() => void confirmDelete()}
+						/>
+					);
+				}}
 			</Show>
 		</div>
 	);

--- a/src/components/UpgradeAccountPrompt.test.tsx
+++ b/src/components/UpgradeAccountPrompt.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import { memoryStorage } from "../testing/storage";
+import UpgradeAccountPrompt from "./UpgradeAccountPrompt";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+const { linkWithGoogle } = vi.hoisted(() => ({
+	linkWithGoogle: vi.fn(),
+}));
+
+vi.mock("../auth/authService", () => ({
+	authService: {
+		linkWithGoogle: (...args: unknown[]) => linkWithGoogle(...args),
+	},
+}));
+
+function renderPrompt() {
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+	render(() => <UpgradeAccountPrompt analytics={analytics} />);
+	return { transport };
+}
+
+describe("UpgradeAccountPrompt", () => {
+	it("states the anonymous retention window and the upgrade promise", () => {
+		renderPrompt();
+
+		expect(
+			screen.getByText(/kept for 180 days after you last open them/i),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/keep your work indefinitely and open it on any device/i,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("logs account_upgraded with method: google after a successful link", async () => {
+		linkWithGoogle.mockResolvedValue(undefined);
+		const { transport } = renderPrompt();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /sign up with google/i }),
+		);
+
+		await screen.findByRole("button", { name: /sign up with google/i });
+		expect(transport.named("account_upgraded")).toHaveLength(1);
+		expect(transport.named("account_upgraded")[0]?.params).toMatchObject({
+			method: "google",
+		});
+	});
+
+	it("does not log account_upgraded when linking fails", async () => {
+		linkWithGoogle.mockRejectedValue(new Error("already in use"));
+		const { transport } = renderPrompt();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /sign up with google/i }),
+		);
+
+		await screen.findByText(/could not link a google account/i);
+		expect(transport.named("account_upgraded")).toHaveLength(0);
+	});
+});

--- a/src/components/UpgradeAccountPrompt.tsx
+++ b/src/components/UpgradeAccountPrompt.tsx
@@ -1,13 +1,27 @@
 import { HiSolidUser } from "solid-icons/hi";
 import { createSignal, Show } from "solid-js";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
 import { authService } from "../auth/authService";
+
+export interface UpgradeAccountPromptProps {
+	/** Overridden in tests; defaults to the app-wide analytics boundary. */
+	analytics?: Analytics;
+}
 
 /**
  * Shown to anonymous users. Links a Google account to the current anonymous
  * account (in place, keeping the same uid) so their existing work becomes
  * accessible from other machines.
+ *
+ * The retention promise it states (PRD `DEC-001`, section 16): an anonymous
+ * project is kept for 180 days from its last access, and upgrading is what
+ * makes that indefinite and available on other devices.
  */
-export default function UpgradeAccountPrompt() {
+export default function UpgradeAccountPrompt(props: UpgradeAccountPromptProps) {
+	const analytics = props.analytics ?? defaultAnalytics;
 	const [busy, setBusy] = createSignal(false);
 	const [error, setError] = createSignal<string | null>(null);
 
@@ -16,6 +30,10 @@ export default function UpgradeAccountPrompt() {
 		setError(null);
 		try {
 			await authService.linkWithGoogle();
+			// PRD `OPS-02`: `account_upgraded` fires when "an anonymous account
+			// becomes a registered account". Google is the alpha's only linking
+			// provider (see `authService.linkWithGoogle`).
+			analytics.log("account_upgraded", { method: "google" });
 		} catch (err) {
 			console.error("Error linking Google account:", err);
 			setError(
@@ -29,8 +47,9 @@ export default function UpgradeAccountPrompt() {
 	return (
 		<div class="upgrade-prompt">
 			<p class="upgrade-message">
-				You're working as a guest. Sign up to save your work and open it on any
-				device.
+				You're working as a guest. Guest projects are kept for 180 days after
+				you last open them, then removed. Sign up to keep your work indefinitely
+				and open it on any device.
 			</p>
 			<button type="button" disabled={busy()} onClick={upgrade}>
 				<HiSolidUser size={18} />

--- a/src/domain/duplicateProject.test.ts
+++ b/src/domain/duplicateProject.test.ts
@@ -1,0 +1,515 @@
+import { describe, expect, it } from "vitest";
+import { duplicateProject } from "./duplicateProject";
+import type { AutomationLane, Device, Project, Song } from "./entities";
+import {
+	createAsset,
+	createAudioLoopClip,
+	createDrumMachineInstrument,
+	createDrumPad,
+	createEmptySong,
+	createFactoryContext,
+	createNoteClip,
+	createNoteEvent,
+	createPack,
+	createPlacement,
+	createProjectMetadata,
+	createReturnBus,
+	createSamplerInstrument,
+	createSection,
+	createSend,
+	createTrack,
+} from "./factories";
+import { createSeededIdFactory } from "./ids";
+import { derivePackDependencies } from "./packs";
+import { assertProject } from "./parse";
+import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH, toTicks } from "./time";
+
+/**
+ * A project exercising every referenceable entity kind `duplicateProject` must
+ * remap: sampler + drum-machine tracks (with a pad-triggered note clip), an
+ * audio-loop clip, a return bus with its own device chain and a track send
+ * into it, master devices, a section, and automation lanes across all five
+ * target scopes (track, trackDevice, send, return, master).
+ */
+function buildRichProject(seed = "duplicate-fixture"): Project {
+	const context = createFactoryContext({
+		ids: createSeededIdFactory(seed),
+		now: 1_700_000_000_000,
+	});
+
+	const pack = createPack(context, {
+		name: "House Drums",
+		description: "Fixture pack",
+	});
+
+	const kickAsset = createAsset(context, {
+		pack,
+		name: "Kick",
+		storageRef: "samples/kick.wav",
+		url: "/samples/kick.wav",
+		durationSeconds: 0.5,
+		sampleRate: 44_100,
+		channelCount: 1,
+	});
+	const loopAsset = createAsset(context, {
+		pack,
+		name: "Loop",
+		kind: "loop",
+		storageRef: "samples/loop.wav",
+		url: "/samples/loop.wav",
+		durationSeconds: 4,
+		sampleRate: 44_100,
+		channelCount: 2,
+	});
+
+	const kickPad = createDrumPad(context, {
+		name: "Kick",
+		assetId: kickAsset.id,
+	});
+
+	const returnBus = createReturnBus(context, { name: "Reverb", order: 0 });
+	const returnDevice: Device = {
+		id: context.ids("device"),
+		type: "reverb",
+		order: 0,
+		bypassed: false,
+		parameters: { wet: 0.4 },
+		preset: null,
+	};
+	const returnWithDevice = { ...returnBus, devices: [returnDevice] };
+
+	const trackDevice: Device = {
+		id: context.ids("device"),
+		type: "eq",
+		order: 0,
+		bypassed: false,
+		parameters: { gain: 0 },
+		preset: null,
+	};
+
+	const drumTrack = createTrack(context, {
+		name: "Drums",
+		order: 0,
+		instrument: createDrumMachineInstrument([kickPad]),
+		devices: [trackDevice],
+		sendConfig: [createSend(returnBus.id, 0.5)],
+	});
+	const samplerTrack = createTrack(context, {
+		name: "Bass",
+		order: 1,
+		instrument: createSamplerInstrument(kickAsset.id),
+	});
+	const audioTrack = createTrack(context, {
+		name: "Break",
+		order: 2,
+		type: "audio",
+		instrument: null,
+	});
+
+	const masterDevice: Device = {
+		id: context.ids("device"),
+		type: "limiter",
+		order: 0,
+		bypassed: false,
+		parameters: {},
+		preset: null,
+	};
+
+	const drumClip = createNoteClip(context, {
+		trackId: drumTrack.id,
+		name: "Beat",
+		lengthTicks: TICKS_PER_BAR,
+		events: [0, 8].map((sixteenth) =>
+			createNoteEvent(context, {
+				startTicks: sixteenth * TICKS_PER_SIXTEENTH,
+				durationTicks: TICKS_PER_SIXTEENTH,
+				padId: kickPad.id,
+			}),
+		),
+	});
+	const bassClip = createNoteClip(context, {
+		trackId: samplerTrack.id,
+		name: "Bassline",
+		lengthTicks: TICKS_PER_BAR,
+		events: [
+			createNoteEvent(context, {
+				startTicks: 0,
+				durationTicks: TICKS_PER_SIXTEENTH,
+				pitch: 36,
+			}),
+		],
+	});
+	const loopClip = createAudioLoopClip(context, {
+		trackId: audioTrack.id,
+		assetId: loopAsset.id,
+		name: "Break loop",
+		lengthTicks: TICKS_PER_BAR * 2,
+	});
+
+	const section = createSection(context, {
+		name: "Intro",
+		startTicks: 0,
+		durationTicks: TICKS_PER_BAR * 2,
+	});
+
+	const automation: AutomationLane[] = [
+		{
+			id: context.ids("automation"),
+			target: {
+				scope: "track",
+				trackId: drumTrack.id,
+				parameterId: "track.volume",
+			},
+			interpolation: "linear",
+			points: [{ tick: toTicks(0), value: 0.8 }],
+		},
+		{
+			id: context.ids("automation"),
+			target: {
+				scope: "trackDevice",
+				trackId: drumTrack.id,
+				deviceId: trackDevice.id,
+				parameterId: "track.pan",
+			},
+			interpolation: "step",
+			points: [{ tick: toTicks(0), value: 0 }],
+		},
+		{
+			id: context.ids("automation"),
+			target: {
+				scope: "send",
+				trackId: drumTrack.id,
+				returnId: returnBus.id,
+				parameterId: "track.sendLevel",
+			},
+			interpolation: "linear",
+			points: [{ tick: toTicks(0), value: 0.5 }],
+		},
+		{
+			id: context.ids("automation"),
+			target: {
+				scope: "return",
+				returnId: returnBus.id,
+				parameterId: "return.volume",
+			},
+			interpolation: "linear",
+			points: [{ tick: toTicks(0), value: 0.9 }],
+		},
+		{
+			id: context.ids("automation"),
+			target: { scope: "master", parameterId: "master.volume" },
+			interpolation: "linear",
+			points: [{ tick: toTicks(0), value: 1 }],
+		},
+	];
+
+	const song: Song = {
+		...createEmptySong(120),
+		tracks: [drumTrack, samplerTrack, audioTrack],
+		returns: [returnWithDevice],
+		master: { ...createEmptySong(120).master, devices: [masterDevice] },
+		sections: [section],
+		assets: [kickAsset, loopAsset],
+		placements: [
+			createPlacement(context, {
+				clipId: drumClip.id,
+				trackId: drumTrack.id,
+				startTicks: 0,
+				durationTicks: TICKS_PER_BAR,
+			}),
+			createPlacement(context, {
+				clipId: bassClip.id,
+				trackId: samplerTrack.id,
+				startTicks: 0,
+				durationTicks: TICKS_PER_BAR,
+			}),
+			createPlacement(context, {
+				clipId: loopClip.id,
+				trackId: audioTrack.id,
+				startTicks: 0,
+				durationTicks: TICKS_PER_BAR * 2,
+			}),
+		],
+		automation,
+	};
+
+	return assertProject({
+		metadata: createProjectMetadata(context, {
+			ownerId: "user_owner",
+			name: "Rich Project",
+			template: "starter",
+			genre: "house",
+			packDependencies: derivePackDependencies(song),
+		}),
+		song,
+		clips: [drumClip, bassClip, loopClip],
+	});
+}
+
+describe("duplicateProject", () => {
+	it("produces a valid schema-v1 project", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+		expect(() => assertProject(duplicate)).not.toThrow();
+	});
+
+	it("assigns a fresh project id, resets revision, and stamps fresh timestamps", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source, { now: 1_800_000_000_000 });
+
+		expect(duplicate.metadata.id).not.toBe(source.metadata.id);
+		expect(duplicate.metadata.revision).toBe(0);
+		expect(duplicate.metadata.createdAt).toBe(1_800_000_000_000);
+		expect(duplicate.metadata.modifiedAt).toBe(1_800_000_000_000);
+	});
+
+	it("defaults the name to a 'copy' suffix and the owner to the source owner", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		expect(duplicate.metadata.name).toBe("Rich Project copy");
+		expect(duplicate.metadata.ownerId).toBe(source.metadata.ownerId);
+	});
+
+	it("accepts an explicit name and owner override", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source, {
+			name: "My Copy",
+			ownerId: "user_other",
+		});
+
+		expect(duplicate.metadata.name).toBe("My Copy");
+		expect(duplicate.metadata.ownerId).toBe("user_other");
+	});
+
+	it("carries template and genre over unchanged", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		expect(duplicate.metadata.template).toBe(source.metadata.template);
+		expect(duplicate.metadata.genre).toBe(source.metadata.genre);
+	});
+
+	it("mints independent IDs for every track, device, return, section, clip, event, placement, automation lane, and asset", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		const sourceIds = collectAllIds(source);
+		const duplicateIds = collectAllIds(duplicate);
+
+		for (const id of duplicateIds) {
+			expect(sourceIds.has(id)).toBe(false);
+		}
+		// Same *count* of each kind of entity, just none of the same identities.
+		expect(duplicate.song.tracks).toHaveLength(source.song.tracks.length);
+		expect(duplicate.song.returns).toHaveLength(source.song.returns.length);
+		expect(duplicate.song.sections).toHaveLength(source.song.sections.length);
+		expect(duplicate.song.placements).toHaveLength(
+			source.song.placements.length,
+		);
+		expect(duplicate.song.automation).toHaveLength(
+			source.song.automation.length,
+		);
+		expect(duplicate.song.assets).toHaveLength(source.song.assets.length);
+		expect(duplicate.clips).toHaveLength(source.clips.length);
+	});
+
+	it("keeps pack references (packId/packVersion) unchanged on duplicated assets", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		const sourcePacks = source.song.assets.map((a) => [
+			a.packId,
+			a.packVersion,
+		]);
+		const duplicatePacks = duplicate.song.assets.map((a) => [
+			a.packId,
+			a.packVersion,
+		]);
+		expect(duplicatePacks).toEqual(sourcePacks);
+		expect(duplicate.metadata.packDependencies).toEqual(
+			source.metadata.packDependencies,
+		);
+	});
+
+	it("remaps the sampler instrument's asset reference to the duplicated asset", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		const sourceSampler = source.song.tracks.find(
+			(t) => t.instrument?.kind === "sampler",
+		);
+		const duplicateSampler = duplicate.song.tracks.find(
+			(t) => t.instrument?.kind === "sampler",
+		);
+		expect(sourceSampler?.instrument?.kind).toBe("sampler");
+		expect(duplicateSampler?.instrument?.kind).toBe("sampler");
+		if (
+			sourceSampler?.instrument?.kind === "sampler" &&
+			duplicateSampler?.instrument?.kind === "sampler"
+		) {
+			const sourceAssetId = sourceSampler.instrument.assetId;
+			const duplicateAssetId = duplicateSampler.instrument.assetId;
+			expect(duplicateAssetId).not.toBe(sourceAssetId);
+			expect(duplicate.song.assets.some((a) => a.id === duplicateAssetId)).toBe(
+				true,
+			);
+		}
+	});
+
+	it("remaps drum pad triggers on note events to the duplicated pad", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		const sourceDrumTrack = source.song.tracks.find(
+			(t) => t.instrument?.kind === "drumMachine",
+		);
+		const duplicateDrumTrack = duplicate.song.tracks.find(
+			(t) => t.instrument?.kind === "drumMachine",
+		);
+		if (
+			sourceDrumTrack?.instrument?.kind !== "drumMachine" ||
+			duplicateDrumTrack?.instrument?.kind !== "drumMachine"
+		) {
+			throw new Error("expected drum machine tracks in both projects");
+		}
+		const sourcePadId = sourceDrumTrack.instrument.pads[0].id;
+		const duplicatePadId = duplicateDrumTrack.instrument.pads[0].id;
+		expect(duplicatePadId).not.toBe(sourcePadId);
+
+		const duplicateDrumClip = duplicate.clips.find(
+			(c) => c.trackId === duplicateDrumTrack.id,
+		);
+		if (duplicateDrumClip?.content.kind !== "notes") {
+			throw new Error("expected a notes clip on the duplicated drum track");
+		}
+		for (const event of duplicateDrumClip.content.events) {
+			expect(event.trigger).toEqual({ kind: "pad", padId: duplicatePadId });
+		}
+	});
+
+	it("remaps the audio-loop clip's asset reference", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		const sourceLoopClip = source.clips.find(
+			(c) => c.content.kind === "audioLoop",
+		);
+		const duplicateLoopClip = duplicate.clips.find(
+			(c) => c.content.kind === "audioLoop",
+		);
+		if (
+			sourceLoopClip?.content.kind !== "audioLoop" ||
+			duplicateLoopClip?.content.kind !== "audioLoop"
+		) {
+			throw new Error("expected an audio loop clip in both projects");
+		}
+		const sourceAssetId = sourceLoopClip.content.assetId;
+		const duplicateAssetId = duplicateLoopClip.content.assetId;
+		expect(duplicateAssetId).not.toBe(sourceAssetId);
+		expect(duplicate.song.assets.some((a) => a.id === duplicateAssetId)).toBe(
+			true,
+		);
+	});
+
+	it("remaps every automation target scope (track, trackDevice, send, return, master)", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		const sourceScopes = source.song.automation.map(
+			(lane) => lane.target.scope,
+		);
+		const duplicateScopes = duplicate.song.automation.map(
+			(lane) => lane.target.scope,
+		);
+		expect(duplicateScopes).toEqual(sourceScopes);
+
+		for (const lane of duplicate.song.automation) {
+			const target = lane.target;
+			if (
+				target.scope === "track" ||
+				target.scope === "trackDevice" ||
+				target.scope === "send"
+			) {
+				expect(duplicate.song.tracks.some((t) => t.id === target.trackId)).toBe(
+					true,
+				);
+			}
+			if (target.scope === "trackDevice") {
+				const track = duplicate.song.tracks.find(
+					(t) => t.id === target.trackId,
+				);
+				expect(track?.devices.some((d) => d.id === target.deviceId)).toBe(true);
+			}
+			if (target.scope === "send" || target.scope === "return") {
+				expect(
+					duplicate.song.returns.some((r) => r.id === target.returnId),
+				).toBe(true);
+			}
+		}
+	});
+
+	it("remaps the track send's return reference", () => {
+		const source = buildRichProject();
+		const duplicate = duplicateProject(source);
+
+		const sourceTrack = source.song.tracks.find((t) => t.sendConfig.length > 0);
+		const duplicateTrack = duplicate.song.tracks.find(
+			(t) => t.sendConfig.length > 0,
+		);
+		expect(sourceTrack).toBeDefined();
+		expect(duplicateTrack).toBeDefined();
+		expect(duplicateTrack?.sendConfig[0].returnId).not.toBe(
+			sourceTrack?.sendConfig[0].returnId,
+		);
+		expect(
+			duplicate.song.returns.some(
+				(r) => r.id === duplicateTrack?.sendConfig[0].returnId,
+			),
+		).toBe(true);
+	});
+
+	it("does not mutate the source project", () => {
+		const source = buildRichProject();
+		const before = JSON.parse(JSON.stringify(source));
+		duplicateProject(source);
+		expect(source).toEqual(before);
+	});
+
+	it("builds independent duplicates on each call", () => {
+		const source = buildRichProject();
+		const a = duplicateProject(source);
+		const b = duplicateProject(source);
+		expect(a.metadata.id).not.toBe(b.metadata.id);
+		expect(a.song.tracks[0].id).not.toBe(b.song.tracks[0].id);
+	});
+});
+
+/** Every ID-bearing field across a project, for cross-project collision checks. */
+function collectAllIds(project: Project): Set<string> {
+	const ids = new Set<string>();
+	ids.add(project.metadata.id);
+	for (const track of project.song.tracks) {
+		ids.add(track.id);
+		for (const device of track.devices) ids.add(device.id);
+		if (track.instrument?.kind === "drumMachine") {
+			for (const pad of track.instrument.pads) ids.add(pad.id);
+		}
+	}
+	for (const returnBus of project.song.returns) {
+		ids.add(returnBus.id);
+		for (const device of returnBus.devices) ids.add(device.id);
+	}
+	for (const device of project.song.master.devices) ids.add(device.id);
+	for (const section of project.song.sections) ids.add(section.id);
+	for (const placement of project.song.placements) ids.add(placement.id);
+	for (const lane of project.song.automation) ids.add(lane.id);
+	for (const asset of project.song.assets) ids.add(asset.id);
+	for (const clip of project.clips) {
+		ids.add(clip.id);
+		if (clip.content.kind === "notes") {
+			for (const event of clip.content.events) ids.add(event.id);
+		}
+	}
+	return ids;
+}

--- a/src/domain/duplicateProject.ts
+++ b/src/domain/duplicateProject.ts
@@ -1,0 +1,257 @@
+import type {
+	Asset,
+	AutomationLane,
+	AutomationTarget,
+	Clip,
+	ClipContent,
+	Device,
+	Instrument,
+	NoteTrigger,
+	Placement,
+	Project,
+	ReturnBus,
+	Section,
+	Song,
+	Track,
+} from "./entities";
+import { type Clock, createFactoryContext } from "./factories";
+import type {
+	AssetId,
+	ClipId,
+	DeviceId,
+	IdFactory,
+	PadId,
+	ReturnId,
+	SectionId,
+	TrackId,
+} from "./ids";
+import { derivePackDependencies } from "./packs";
+import { assertProject } from "./parse";
+
+/**
+ * Independent deep duplication of a whole project (PRD `PRJ-02`: "A duplicate
+ * receives independent IDs for all mutable entities").
+ *
+ * Every entity that owns a persistent ID — tracks, devices, drum pads, return
+ * buses, sections, placements, clips, note events, automation lanes, and asset
+ * references — gets a freshly minted one, and every reference to those IDs
+ * (sends, automation targets, clip/track/asset links, pad triggers) is rewritten
+ * to match. `assertProject` is run on the result, so a missed reference fails
+ * loudly here rather than silently producing a project with dangling links.
+ *
+ * Packs themselves are never duplicated: `packId`/`packVersion` name library
+ * content the duplicate still resolves from, so they are copied unchanged onto
+ * the fresh asset rows, and `derivePackDependencies` recomputes the metadata
+ * tier's dependency list from those unchanged pack references.
+ */
+export interface DuplicateProjectOptions {
+	/** Defaults to the source project's owner. */
+	ownerId?: string;
+	/** Defaults to a "<name> copy" derived name. */
+	name?: string;
+	ids?: IdFactory;
+	now?: number | Clock;
+}
+
+export function duplicateProject(
+	source: Project,
+	options: DuplicateProjectOptions = {},
+): Project {
+	const context = createFactoryContext({ ids: options.ids, now: options.now });
+
+	const assetIds = new Map<AssetId, AssetId>();
+	const returnIds = new Map<ReturnId, ReturnId>();
+	const trackIds = new Map<TrackId, TrackId>();
+	const deviceIds = new Map<DeviceId, DeviceId>();
+	const padIds = new Map<PadId, PadId>();
+	const clipIds = new Map<ClipId, ClipId>();
+	const sectionIds = new Map<SectionId, SectionId>();
+
+	function remapped<K>(map: Map<K, K>, key: K): K {
+		const next = map.get(key);
+		if (next === undefined) {
+			throw new Error(
+				"duplicateProject: reference resolved before its owner was remapped",
+			);
+		}
+		return next;
+	}
+
+	function remapDevices(devices: readonly Device[]): Device[] {
+		return devices.map((device) => {
+			const id = context.ids("device");
+			deviceIds.set(device.id, id);
+			return { ...device, id };
+		});
+	}
+
+	// Assets first: nothing they reference (pack fields are copied verbatim),
+	// and everything else (instruments, drum pads, audio-loop clips) references
+	// them.
+	const assets: Asset[] = source.song.assets.map((asset) => {
+		const id = context.ids("asset");
+		assetIds.set(asset.id, id);
+		return { ...asset, id };
+	});
+
+	// Returns before tracks: a track's `sendConfig` names a return bus.
+	const returns: ReturnBus[] = source.song.returns.map((returnBus) => {
+		const id = context.ids("return");
+		returnIds.set(returnBus.id, id);
+		return { ...returnBus, id, devices: remapDevices(returnBus.devices) };
+	});
+
+	function remapInstrument(instrument: Instrument | null): Instrument | null {
+		if (!instrument) return null;
+		if (instrument.kind === "synth") {
+			return { ...instrument };
+		}
+		if (instrument.kind === "sampler") {
+			return {
+				...instrument,
+				assetId: instrument.assetId
+					? remapped(assetIds, instrument.assetId)
+					: null,
+			};
+		}
+		return {
+			...instrument,
+			pads: instrument.pads.map((pad) => {
+				const id = context.ids("pad");
+				padIds.set(pad.id, id);
+				return {
+					...pad,
+					id,
+					assetId: pad.assetId ? remapped(assetIds, pad.assetId) : null,
+				};
+			}),
+		};
+	}
+
+	const tracks: Track[] = source.song.tracks.map((track) => {
+		const id = context.ids("track");
+		trackIds.set(track.id, id);
+		return {
+			...track,
+			id,
+			instrument: remapInstrument(track.instrument),
+			devices: remapDevices(track.devices),
+			sendConfig: track.sendConfig.map((send) => ({
+				...send,
+				returnId: remapped(returnIds, send.returnId),
+			})),
+		};
+	});
+
+	const master = {
+		...source.song.master,
+		devices: remapDevices(source.song.master.devices),
+	};
+
+	const sections: Section[] = source.song.sections.map((section) => {
+		const id = context.ids("section");
+		sectionIds.set(section.id, id);
+		return { ...section, id };
+	});
+
+	function remapClipContent(content: ClipContent): ClipContent {
+		if (content.kind === "audioLoop") {
+			return { ...content, assetId: remapped(assetIds, content.assetId) };
+		}
+		return {
+			...content,
+			events: content.events.map((event) => ({
+				...event,
+				id: context.ids("event"),
+				trigger: remapTrigger(event.trigger),
+			})),
+		};
+	}
+
+	function remapTrigger(trigger: NoteTrigger): NoteTrigger {
+		if (trigger.kind === "pad") {
+			return { ...trigger, padId: remapped(padIds, trigger.padId) };
+		}
+		return { ...trigger };
+	}
+
+	const clips: Clip[] = source.clips.map((clip) => {
+		const id = context.ids("clip");
+		clipIds.set(clip.id, id);
+		return {
+			...clip,
+			id,
+			trackId: remapped(trackIds, clip.trackId),
+			content: remapClipContent(clip.content),
+		};
+	});
+
+	const placements: Placement[] = source.song.placements.map((placement) => ({
+		...placement,
+		id: context.ids("placement"),
+		clipId: remapped(clipIds, placement.clipId),
+		trackId: remapped(trackIds, placement.trackId),
+	}));
+
+	function remapAutomationTarget(target: AutomationTarget): AutomationTarget {
+		switch (target.scope) {
+			case "track":
+				return { ...target, trackId: remapped(trackIds, target.trackId) };
+			case "trackDevice":
+				return {
+					...target,
+					trackId: remapped(trackIds, target.trackId),
+					deviceId: remapped(deviceIds, target.deviceId),
+				};
+			case "send":
+				return {
+					...target,
+					trackId: remapped(trackIds, target.trackId),
+					returnId: remapped(returnIds, target.returnId),
+				};
+			case "return":
+				return { ...target, returnId: remapped(returnIds, target.returnId) };
+			case "master":
+				return { ...target };
+		}
+	}
+
+	const automation: AutomationLane[] = source.song.automation.map((lane) => ({
+		...lane,
+		id: context.ids("automation"),
+		target: remapAutomationTarget(lane.target),
+		points: lane.points.map((point) => ({ ...point })),
+	}));
+
+	const song: Song = {
+		...source.song,
+		tracks,
+		returns,
+		master,
+		sections,
+		placements,
+		automation,
+		assets,
+	};
+
+	const timestamp = context.now();
+	return assertProject({
+		metadata: {
+			...source.metadata,
+			id: context.ids("project"),
+			revision: 0,
+			name: options.name ?? duplicateName(source.metadata.name),
+			ownerId: options.ownerId ?? source.metadata.ownerId,
+			collaboratorIds: [],
+			createdAt: timestamp,
+			modifiedAt: timestamp,
+			packDependencies: derivePackDependencies(song),
+		},
+		song,
+		clips,
+	});
+}
+
+function duplicateName(name: string): string {
+	return `${name} copy`;
+}

--- a/src/editor/EditorSession.test.ts
+++ b/src/editor/EditorSession.test.ts
@@ -12,7 +12,7 @@ import { createManualClock } from "../shared/clock";
 import { memoryStorage } from "../testing/storage";
 import { EditorSession } from "./EditorSession";
 
-async function setUp() {
+async function setUp(options: { deviceStorage?: Storage } = {}) {
 	const repository = createInMemoryProjectRepository();
 	const project = createSliceFixtureProject();
 	const created = await repository.createProject(project);
@@ -28,9 +28,25 @@ async function setUp() {
 	analytics.setAccountType("anonymous");
 
 	const clock = createManualClock(1_000);
-	const session = new EditorSession({ repository, project, clock, analytics });
+	const deviceStorage = options.deviceStorage ?? memoryStorage();
+	const session = new EditorSession({
+		repository,
+		project,
+		clock,
+		analytics,
+		deviceStorage,
+	});
 	const clipId = project.clips[0].id as ClipId;
-	return { repository, project, session, analytics, transport, clock, clipId };
+	return {
+		repository,
+		project,
+		session,
+		analytics,
+		transport,
+		clock,
+		clipId,
+		deviceStorage,
+	};
 }
 
 describe("EditorSession", () => {
@@ -165,6 +181,67 @@ describe("EditorSession", () => {
 		);
 		expect(firstEditEvents).toHaveLength(1);
 		expect(firstEditEvents[0]?.params.command_id).toBe("note.update");
+	});
+
+	it("logs project_opened exactly once when the session is constructed", () => {
+		const { transport } = ctx;
+
+		const opened = transport.named("project_opened");
+		expect(opened).toHaveLength(1);
+		expect(opened[0]?.params).toMatchObject({
+			project_age_bucket: "same_day",
+			track_count_bucket: "1_2",
+			is_first_open: true,
+		});
+	});
+
+	it("reports is_first_open: false on a second open of the same project on the same device", async () => {
+		const { repository, project, deviceStorage } = ctx;
+		const transport2 = createRecordingTransport();
+		const analytics2 = new Analytics({
+			transport: transport2,
+			consent: new ConsentStore(memoryStorage()),
+			storage: memoryStorage(),
+		});
+		analytics2.setAccountType("anonymous");
+
+		const secondSession = new EditorSession({
+			repository,
+			project,
+			clock: createManualClock(2_000),
+			analytics: analytics2,
+			deviceStorage,
+		});
+
+		const opened = transport2.named("project_opened");
+		expect(opened).toHaveLength(1);
+		expect(opened[0]?.params.is_first_open).toBe(false);
+
+		secondSession.dispose();
+	});
+
+	it("reports is_first_open: true again on a different device (isolated storage)", () => {
+		const { repository, project } = ctx;
+		const transport2 = createRecordingTransport();
+		const analytics2 = new Analytics({
+			transport: transport2,
+			consent: new ConsentStore(memoryStorage()),
+			storage: memoryStorage(),
+		});
+		analytics2.setAccountType("anonymous");
+
+		const otherDeviceSession = new EditorSession({
+			repository,
+			project,
+			clock: createManualClock(2_000),
+			analytics: analytics2,
+			deviceStorage: memoryStorage(),
+		});
+
+		const opened = transport2.named("project_opened");
+		expect(opened[0]?.params.is_first_open).toBe(true);
+
+		otherDeviceSession.dispose();
 	});
 
 	it("dispose stops the repository watch subscription", async () => {

--- a/src/editor/EditorSession.ts
+++ b/src/editor/EditorSession.ts
@@ -2,7 +2,7 @@ import {
 	type Analytics,
 	analytics as defaultAnalytics,
 } from "../analytics/analytics";
-import { bucketOf } from "../analytics/buckets";
+import { bucketOf, projectAgeBucket } from "../analytics/buckets";
 import { COMMAND_IDS, type CommandId } from "../analytics/catalog";
 import {
 	CommandHistory,
@@ -20,6 +20,7 @@ import {
 import type { ProjectRepository } from "../persistence/projectRepository";
 import { type Clock, systemClock } from "../shared/clock";
 import type { Scheduler } from "../shared/scheduler";
+import { markProjectOpened } from "./deviceProjectRecord";
 
 export interface EditorSessionOptions {
 	readonly repository: ProjectRepository;
@@ -30,6 +31,11 @@ export interface EditorSessionOptions {
 	/** Forwarded to `ProjectAutosave`; tests inject a manual scheduler. */
 	readonly scheduler?: Scheduler;
 	readonly coalesceMs?: number;
+	/**
+	 * Where the `project_opened` first-open marker is recorded (PRD `OPS-02`).
+	 * Tests inject an isolated store; defaults to `localStorage`.
+	 */
+	readonly deviceStorage?: Storage | null;
 }
 
 function isCommandId(value: string): value is CommandId {
@@ -89,6 +95,7 @@ export class EditorSession {
 		this.unwatch = options.repository.watchProject(this.projectId, (event) =>
 			this.autosave.applyRemote(event),
 		);
+		this.logProjectOpened(options.project, options.deviceStorage);
 	}
 
 	get project(): Project {
@@ -132,6 +139,24 @@ export class EditorSession {
 		this.unwatch();
 		this.autosave.dispose();
 		this.history.dispose();
+	}
+
+	/**
+	 * `project_opened` (PRD `OPS-02`), fired once per `EditorSession` — i.e.
+	 * once per actual open, not once per project like `first_edit`. Its
+	 * parameters are not optional: they are what makes the section 11 1- and
+	 * 7-day reopen measure computable.
+	 */
+	private logProjectOpened(
+		project: Project,
+		deviceStorage: Storage | null | undefined,
+	): void {
+		const ageMs = Math.max(0, this.clock.now() - project.metadata.createdAt);
+		this.analytics.log("project_opened", {
+			project_age_bucket: projectAgeBucket(ageMs),
+			track_count_bucket: bucketOf("track_count", project.song.tracks.length),
+			is_first_open: markProjectOpened(this.projectId, deviceStorage),
+		});
 	}
 
 	private logFirstEdit(result: TransactionSuccess): void {

--- a/src/editor/deviceProjectRecord.test.ts
+++ b/src/editor/deviceProjectRecord.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { memoryStorage } from "../testing/storage";
+import { clearProjectOpened, markProjectOpened } from "./deviceProjectRecord";
+
+describe("markProjectOpened", () => {
+	it("reports the first open as true and every later one as false", () => {
+		const storage = memoryStorage();
+
+		expect(markProjectOpened("prj_a", storage)).toBe(true);
+		expect(markProjectOpened("prj_a", storage)).toBe(false);
+		expect(markProjectOpened("prj_a", storage)).toBe(false);
+	});
+
+	it("tracks each project id independently", () => {
+		const storage = memoryStorage();
+
+		expect(markProjectOpened("prj_a", storage)).toBe(true);
+		expect(markProjectOpened("prj_b", storage)).toBe(true);
+		expect(markProjectOpened("prj_a", storage)).toBe(false);
+		expect(markProjectOpened("prj_b", storage)).toBe(false);
+	});
+
+	it("fails open (reports first open) when storage is unavailable", () => {
+		expect(markProjectOpened("prj_a", null)).toBe(true);
+		expect(markProjectOpened("prj_a", null)).toBe(true);
+	});
+
+	it("fails open when storage throws", () => {
+		const hostile: Storage = {
+			getItem: () => {
+				throw new Error("nope");
+			},
+			setItem: () => {
+				throw new Error("nope");
+			},
+			removeItem: () => {
+				throw new Error("nope");
+			},
+			clear: () => {
+				throw new Error("nope");
+			},
+			key: () => {
+				throw new Error("nope");
+			},
+			length: 0,
+		};
+		expect(markProjectOpened("prj_a", hostile)).toBe(true);
+	});
+
+	it("clearProjectOpened lets a later open report as first again", () => {
+		const storage = memoryStorage();
+
+		expect(markProjectOpened("prj_a", storage)).toBe(true);
+		expect(markProjectOpened("prj_a", storage)).toBe(false);
+
+		clearProjectOpened("prj_a", storage);
+
+		expect(markProjectOpened("prj_a", storage)).toBe(true);
+	});
+
+	it("clearProjectOpened on an unavailable store does not throw", () => {
+		expect(() => clearProjectOpened("prj_a", null)).not.toThrow();
+	});
+});

--- a/src/editor/deviceProjectRecord.ts
+++ b/src/editor/deviceProjectRecord.ts
@@ -1,0 +1,68 @@
+// Device-local "has this project been opened before" bookkeeping.
+//
+// PRD `OPS-02`: `project_opened`'s `is_first_open` parameter is what makes the
+// section 11 1- and 7-day reopen measure computable. Whether *this* open is the
+// project's first is not knowable from the project document alone — a project
+// created and immediately opened must still report `is_first_open: true` for
+// that first open, and `false` for every one after, including across a page
+// reload. That is a client-only signal with no server round trip, so it is
+// recorded in this browser's storage rather than in the domain model.
+//
+// This also anchors the `LOOP-001`/`DEC-001` requirement that "each device
+// records ... which anonymous projects were created or edited there": recording
+// an open here is the same act. The fuller pairing flow that *offers* to
+// attach those device-local projects to a newly authenticated account is not
+// implemented yet — see the `LOOP-001` PR discussion for why it is deferred —
+// but the storage this module owns is exactly what that flow would read.
+
+/** One entry per project this device has opened at least once. */
+const OPENED_STORAGE_PREFIX = "sg_device_opened:";
+
+function safeStorage(): Storage | null {
+	try {
+		return typeof localStorage === "undefined" ? null : localStorage;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Records that `projectId` was opened on this device and reports whether this
+ * is the first time this device has recorded an open for it.
+ *
+ * Fails open: if storage is unavailable (private browsing, a full quota, a
+ * non-browser test environment with no injected storage), every open reports
+ * as a first open rather than throwing — the same fail-open posture PRD
+ * `OPS-02` requires of analytics generally.
+ */
+export function markProjectOpened(
+	projectId: string,
+	storage?: Storage | null,
+): boolean {
+	const store = storage === undefined ? safeStorage() : storage;
+	if (!store) return true;
+	const key = OPENED_STORAGE_PREFIX + projectId;
+	try {
+		if (store.getItem(key) !== null) return false;
+		store.setItem(key, "1");
+		return true;
+	} catch {
+		return true;
+	}
+}
+
+/** Removes the device-local marker. Used when a project is deleted. */
+export function clearProjectOpened(
+	projectId: string,
+	storage?: Storage | null,
+): void {
+	const store = storage === undefined ? safeStorage() : storage;
+	if (!store) return;
+	try {
+		store.removeItem(OPENED_STORAGE_PREFIX + projectId);
+	} catch {
+		// Best-effort cleanup; a leaked marker just costs one stale "not first
+		// open" read if the project id is ever reused, which prefixed IDs make
+		// practically impossible.
+	}
+}

--- a/src/editor/starterProject.ts
+++ b/src/editor/starterProject.ts
@@ -81,7 +81,7 @@ export function createStarterProject(ownerId: string): Project {
 		metadata: createProjectMetadata(context, {
 			ownerId,
 			name: "Untitled Project",
-			template: "blank",
+			template: "starter",
 			packDependencies: derivePackDependencies(song),
 		}),
 		song,

--- a/src/routes/dashboard.css
+++ b/src/routes/dashboard.css
@@ -33,7 +33,8 @@
 }
 
 .upgrade-prompt button,
-.dashboard-actions .new-project {
+.dashboard-actions .new-project,
+.dashboard-actions .blank-project {
 	display: inline-flex;
 	align-items: center;
 	gap: 8px;
@@ -43,7 +44,8 @@
 }
 
 .upgrade-prompt button:disabled,
-.dashboard-actions .new-project:disabled {
+.dashboard-actions .new-project:disabled,
+.dashboard-actions .blank-project:disabled {
 	opacity: 0.6;
 	cursor: default;
 }
@@ -53,9 +55,14 @@
 	flex-direction: column;
 	align-items: flex-end;
 	gap: 8px;
-	/* Pull the button up so it aligns with the "Projects" header row. */
+	/* Pull the buttons up so they align with the "Projects" header row. */
 	margin-top: -68px;
 	margin-bottom: 28px;
+}
+
+.dashboard-actions .action-row {
+	display: flex;
+	gap: 8px;
 }
 
 .dashboard-actions .create-error {
@@ -182,4 +189,63 @@
 	padding: 10px 16px;
 	border-radius: 8px;
 	cursor: pointer;
+}
+
+/* The card title's stretched link (`.project-title a::after`) covers the
+   whole card, so the row actions below need their own stacking context to
+   stay clickable above it. */
+.project-card-actions,
+.project-rename-form {
+	position: relative;
+	z-index: 1;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.project-card-actions .project-action {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 10px;
+	border-radius: 6px;
+	font-size: var(--font-size-small);
+	background: rgba(255, 255, 255, 0.06);
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	color: var(--color-text);
+	cursor: pointer;
+}
+
+.project-card-actions .project-action:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+
+.project-card-actions .project-action-destructive {
+	color: #ff9a9a;
+}
+
+.project-rename-form .project-rename-input {
+	flex: 1;
+	min-width: 0;
+	padding: 6px 8px;
+	border-radius: 6px;
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	background: var(--color-background);
+	color: var(--color-text);
+}
+
+.project-rename-form button {
+	padding: 6px 10px;
+	border-radius: 6px;
+	cursor: pointer;
+}
+
+.project-row-error {
+	position: relative;
+	z-index: 1;
+	margin: 0;
+	font-size: var(--font-size-small);
+	color: #ff8a8a;
 }


### PR DESCRIPTION
Implements the PRJ-01/PRJ-02 dashboard creation, rename, duplicate, and confirmed-delete flows against the schema-v1 repository, plus the OPS-02 events LOOP-001 owns.

## What's here

- A new **Blank Project** creation path (the domain's existing `createBlankProject`) alongside the FND-009 audible starter, both wired to `project_created` with the right `source`.
- `src/domain/duplicateProject.ts` — independent deep duplication that mints a fresh ID for every mutable entity (tracks, devices, drum pads, returns, sections, placements, clips, note events, automation lanes, asset references) and rewrites every reference to match. Verified against a fixture exercising every automation-target scope.
- **Dashboard/ProjectList** — inline rename, duplicate, delete-with-confirmation (new `ConfirmDialog`), last-modified time, and template/genre badges per card.
- **Analytics** — `anon_session_created` (only on a genuinely new anonymous identity), `account_upgraded`, `project_opened` (with a device-local "opened before" marker for `is_first_open`), and `project_deleted`. Each is proven to fire exactly once by an automated test.
- `UpgradeAccountPrompt` now states the 180-day anonymous retention window alongside the upgrade promise (`DEC-001`).

## Verification

Run on the rebased head, not just the original branch:

| Check | Result |
| --- | --- |
| `bun run typecheck` | pass |
| `bun run test` | pass — 92 files, 1203 tests |
| `bun run check:ci` | pass (exit 0; the one warning is pre-existing on `main`, in `scripts/starter-library/acquire/generateCandidates.mjs`, untouched here) |
| `bun run test:emulator` | pass |
| `bun run build` | pass |
| `bun run test:browser` | **not executed** |
| `bun run test:browser:emulator` | **not executed** |

**The browser suites could not run.** Playwright's binaries can't be downloaded in the sandbox this was built in (the proxy returns 403 for `cdn.playwright.dev`). The specs are written and pass typecheck and lint, but have never been executed:

- `e2e-emulator/dashboard.spec.ts` — two-anonymous-identity access control, and destructive confirmation persisting across a reload
- `e2e/smoke.spec.ts` — Blank Project, plus rename/duplicate/delete against the mock backend

This bears directly on the issue's "Dashboard browser tests cover access control and destructive confirmation" criterion, so please treat that box as unproven until someone runs both suites. CI will exercise them on this PR.

## Acceptance criteria not met

The backlog's device-pairing bullet (in `docs/backlog.md`, not copied into the issue's shortened checklist) — *"each device locally records which anonymous projects were created or edited there; authenticating offers to pair those local records to the account"* — is **half-built**. The device-local bookkeeping exists (`src/editor/deviceProjectRecord.ts`), but the pairing/reattachment UI and backend do not: Firestore's rules forbid client-side `ownerId` reassignment, so real pairing needs a privileged Cloud Function or a rules change. That was reported rather than guessed at.

## Out of scope, suggested follow-ups

- **Cross-device pairing as a backend capability** — a privileged Cloud Function or a controlled `ownerId`/`collaboratorId` transfer in rules. Probably its own task, or `HARD-003` (the anonymous-retention deletion job), which already needs to know whether a project has been paired.
- **LOOP-015's six genre starter templates** (`DEC-002`-gated) — `project_created`'s `template_id`/`genre` stay unset from this task's two creation paths, since `template_id` is declared as an empty/UNCLAIMED enum in the analytics catalog specifically for LOOP-015 to fill in.

## Note for whoever merges

This and the LOOP-002 PR both touch `src/editor/EditorSession.ts` and its test. Whichever lands second will need a rebase.

This branch was rebased onto current `main` before opening. The original branch carried a duplicate of the `BASE_BRANCH` commit that landed in #94; that commit was dropped, since its content is byte-identical to what `main` already has.

Refs #40

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wggjodt38yCcRb5tnTvjDv)_