### PR TITLE
LOOP-002: autosave recovery UX, navigation flush, and undo/save analytics

### DIFF
--- a/src/editor/EditorSession.test.ts
+++ b/src/editor/EditorSession.test.ts
@@ -167,6 +167,40 @@ describe("EditorSession", () => {
 		expect(firstEditEvents[0]?.params.command_id).toBe("note.update");
 	});
 
+	it("logs undo_used with direction and actor on undo and redo, once per invocation", () => {
+		const { session, transport, clipId } = ctx;
+		const factoryContext = createFactoryContext();
+		const note = createNoteEvent(factoryContext, {
+			startTicks: 1 * TICKS_PER_SIXTEENTH,
+			durationTicks: TICKS_PER_SIXTEENTH,
+			pitch: 36,
+		});
+		session.dispatch(addNotes(clipId, [note]));
+
+		session.undo();
+		session.redo();
+
+		const undoUsedEvents = transport.named("undo_used");
+		expect(undoUsedEvents).toHaveLength(2);
+		expect(undoUsedEvents[0]?.params).toMatchObject({
+			direction: "undo",
+			actor: "user",
+		});
+		expect(undoUsedEvents[1]?.params).toMatchObject({
+			direction: "redo",
+			actor: "user",
+		});
+	});
+
+	it("does not log undo_used when there is nothing to undo or redo", () => {
+		const { session, transport } = ctx;
+
+		expect(session.undo()).toBeNull();
+		expect(session.redo()).toBeNull();
+
+		expect(transport.named("undo_used")).toHaveLength(0);
+	});
+
 	it("dispose stops the repository watch subscription", async () => {
 		const { session, repository, project } = ctx;
 		session.dispose();

--- a/src/editor/EditorSession.ts
+++ b/src/editor/EditorSession.ts
@@ -111,17 +111,27 @@ export class EditorSession {
 		return result;
 	}
 
-	undo(): TransactionResult | null {
+	/**
+	 * `actor` is who invoked the undo, not who authored the entry being undone
+	 * (`history.undo()` already replays the entry's own actor for that). Only
+	 * `"user"` is reachable today — an assistant-invoked undo is `AI-003`'s
+	 * `assistant_proposal_undone`, a distinct catalog event, not this one.
+	 */
+	undo(actor: "user" | "assistant" = "user"): TransactionResult | null {
 		const result = this.history.undo();
-		if (result?.ok) this.queueAutosave(result);
+		if (result?.ok) {
+			this.queueAutosave(result);
+			this.analytics.log("undo_used", { direction: "undo", actor });
+		}
 		return result;
 	}
 
-	redo(): TransactionResult | null {
+	redo(actor: "user" | "assistant" = "user"): TransactionResult | null {
 		const result = this.history.redo();
 		if (result?.ok) {
 			this.logFirstEdit(result);
 			this.queueAutosave(result);
+			this.analytics.log("undo_used", { direction: "redo", actor });
 		}
 		return result;
 	}

--- a/src/editor/EditorView.css
+++ b/src/editor/EditorView.css
@@ -75,6 +75,12 @@
 	opacity: 0.75;
 }
 
+.editor-header .save-status-group {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
 .editor-header .save-status {
 	font-size: var(--font-size-small);
 	color: var(--color-text-secondary);
@@ -84,6 +90,28 @@
 
 .editor-header .save-status[data-state="failed"] {
 	color: #e08a87;
+}
+
+.editor-header .save-recovery {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: var(--font-size-small);
+	color: #e08a87;
+}
+
+.editor-header .save-retry-button {
+	font-size: var(--font-size-small);
+	color: inherit;
+	background: none;
+	border: 1px solid currentColor;
+	border-radius: 3px;
+	padding: 2px 8px;
+	cursor: pointer;
+}
+
+.editor-header .save-retry-button:hover {
+	opacity: 0.75;
 }
 
 .workspace {

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -8,11 +8,13 @@ installWebAudioGlobals();
 
 let AudioRuntimeModule: typeof import("../audio/AudioRuntime");
 let inMemoryModule: typeof import("../persistence/inMemoryProjectRepository");
+let documentsModule: typeof import("../persistence/documents");
 let EditorViewModule: typeof import("./EditorView");
 
 beforeAll(async () => {
 	AudioRuntimeModule = await import("../audio/AudioRuntime");
 	inMemoryModule = await import("../persistence/inMemoryProjectRepository");
+	documentsModule = await import("../persistence/documents");
 	EditorViewModule = await import("./EditorView");
 });
 
@@ -158,5 +160,70 @@ describe("EditorView", () => {
 		if (clip.content.kind !== "notes") throw new Error("expected a note clip");
 		// The undone note stayed undone in the persisted document too.
 		expect(clip.content.events).toHaveLength(4);
+	});
+
+	it("shows an actionable Save failed state with an explicit retry, and recovers", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+
+		repository.failNextWrites({ count: 1 });
+		renderEditor(project.metadata.id);
+		await screen.findByRole("group", { name: "16-step sequence" });
+
+		fireEvent.click(screen.getByRole("button", { name: "Step 2, off" }));
+
+		await screen.findByText("Save failed", {}, { timeout: 3_000 });
+		expect(screen.getByText("Check your connection.")).toBeInTheDocument();
+		const retryButton = await screen.findByRole("button", { name: "Retry" });
+
+		fireEvent.click(retryButton);
+
+		await screen.findByText("Saved", {}, { timeout: 3_000 });
+		expect(screen.queryByText("Save failed")).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Retry" }),
+		).not.toBeInTheDocument();
+
+		const loaded = await repository.loadProject(project.metadata.id);
+		if (!loaded.ok) throw new Error("expected the project to load");
+		const clip = loaded.value.clips[0];
+		if (clip.content.kind !== "notes") throw new Error("expected a note clip");
+		expect(clip.content.events).toHaveLength(5);
+	});
+
+	it("does not offer a retry button for a non-retryable failure", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+
+		renderEditor(project.metadata.id);
+		await screen.findByRole("group", { name: "16-step sequence" });
+
+		// Another client's write lands in the store directly, without going
+		// through `saveMetadata` (which would notify this session's own
+		// `watchProject` listener and let it adopt the newer revision before the
+		// edit below ever conflicts). That models the real race the revision
+		// check exists for: the remote write reaches the server before this
+		// tab's watcher has delivered word of it.
+		const path = documentsModule.projectDocumentPath(project.metadata.id);
+		const stored = repository.readDocument(path);
+		if (!stored) throw new Error("expected the metadata document to exist");
+		repository.writeDocument(path, {
+			...stored,
+			revision: (stored.revision as number) + 1,
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Step 2, off" }));
+
+		await screen.findByText("Save failed", {}, { timeout: 3_000 });
+		expect(
+			screen.getByText("This project changed in another tab or session."),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Retry" }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -15,6 +15,7 @@ import {
 import { usePlaybackHotkey } from "../audio/usePlaybackHotkey";
 import ProjectNotFound from "../components/ProjectNotFound";
 import TapeLoader from "../components/TapeLoader";
+import type { SaveFailureReason } from "../persistence/projectRepository";
 import { getProjectRepository } from "../projectRepositoryClient";
 import StepGrid from "./StepGrid";
 import { useEditorSession } from "./useEditorSession";
@@ -31,6 +32,23 @@ const SAVE_STATUS_LABEL: Record<string, string> = {
 	saving: "Saving…",
 	saved: "Saved",
 	failed: "Save failed",
+};
+
+/**
+ * Actionable text for the PRD `PRJ-03` "actionable Save failed" state. Never
+ * the repository's raw `SaveFailure.message` — that can carry backend error
+ * text not meant for a user-facing surface — and never the reason string
+ * itself, which is an internal, unlocalized identifier.
+ */
+const SAVE_FAILURE_REASON_LABEL: Record<SaveFailureReason, string> = {
+	unavailable: "Check your connection.",
+	revision_conflict: "This project changed in another tab or session.",
+	not_found: "This project no longer exists.",
+	already_exists: "A save conflict occurred.",
+	unsupported_schema_version:
+		"This project needs a newer version of Solid Groove.",
+	invalid_document: "Something about this save wasn't valid.",
+	document_too_large: "This project is too large to save further changes.",
 };
 
 /**
@@ -69,6 +87,11 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	const saveStatusLabel = createMemo(
 		() => SAVE_STATUS_LABEL[session.state.saveStatus?.state ?? "idle"],
 	);
+	const saveFailure = createMemo(() => session.state.saveStatus?.failure);
+	const saveFailureMessage = createMemo(() => {
+		const failure = saveFailure();
+		return failure ? SAVE_FAILURE_REASON_LABEL[failure.reason] : null;
+	});
 
 	return (
 		<main class="editor">
@@ -148,13 +171,31 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 										</Show>
 									</button>
 								</div>
-								<div
-									class="save-status"
-									data-state={session.state.saveStatus?.state}
-									data-revision={session.state.saveStatus?.revision}
-									title={`Revision ${session.state.saveStatus?.revision ?? 0}`}
-								>
-									{saveStatusLabel()}
+								<div class="save-status-group">
+									<div
+										class="save-status"
+										data-state={session.state.saveStatus?.state}
+										data-revision={session.state.saveStatus?.revision}
+										title={`Revision ${session.state.saveStatus?.revision ?? 0}`}
+									>
+										{saveStatusLabel()}
+									</div>
+									<Show when={saveFailure()}>
+										<div class="save-recovery" role="alert">
+											<span class="save-recovery-message">
+												{saveFailureMessage()}
+											</span>
+											<Show when={saveFailure()?.retryable}>
+												<button
+													type="button"
+													class="save-retry-button"
+													onClick={() => void session.retry()}
+												>
+													Retry
+												</button>
+											</Show>
+										</div>
+									</Show>
 								</div>
 							</header>
 							<div class="workspace">

--- a/src/editor/useEditorSession.test.ts
+++ b/src/editor/useEditorSession.test.ts
@@ -1,0 +1,128 @@
+import { cleanup, renderHook } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { removeNotes } from "../commands";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import type { ClipId } from "../domain/ids";
+import { createInMemoryProjectRepository } from "../persistence/inMemoryProjectRepository";
+import { useEditorSession } from "./useEditorSession";
+
+afterEach(() => {
+	cleanup();
+});
+
+/**
+ * The PRD `PRJ-03` navigation-flush half of `LOOP-002`: a queued-but-not-yet-
+ * written edit must reach the repository when the browser signals the page
+ * might not run again, not only when the in-app router tears the session
+ * down (that half is `useEditorSession`'s existing `onCleanup`, exercised by
+ * the "changing projects" test below).
+ */
+describe("useEditorSession navigation flush", () => {
+	it("flushes a queued edit on pagehide, before the coalescing window elapses", async () => {
+		const repository = createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+		repository.clearWrites();
+
+		const clip = project.clips[0];
+		if (clip.content.kind !== "notes") throw new Error("expected a note clip");
+		const clipId = clip.id as ClipId;
+		const eventId = clip.content.events[0].id;
+
+		const { result } = renderHook(
+			() =>
+				useEditorSession(
+					() => project.metadata.id,
+					() => repository,
+				),
+			{},
+		);
+
+		await vi.waitFor(() => expect(result.state.loading).toBe(false));
+
+		result.dispatch(removeNotes(clipId, [eventId]));
+		expect(result.state.saveStatus?.pending).toBe(1);
+		// Nothing has reached the repository yet — the default coalescing
+		// window (400ms) has not elapsed and no real time has passed in this
+		// test.
+		expect(repository.writes).toHaveLength(0);
+
+		window.dispatchEvent(new Event("pagehide"));
+		// `flush()` writes are async even once started; let the promise chain it
+		// kicked off actually settle.
+		await vi.waitFor(() => expect(repository.writes.length).toBeGreaterThan(0));
+
+		const loaded = await repository.loadProject(project.metadata.id);
+		if (!loaded.ok) throw new Error("expected the project to load");
+		const savedClip = loaded.value.clips.find((c) => c.id === clipId);
+		if (savedClip?.content.kind !== "notes") throw new Error("expected notes");
+		expect(savedClip.content.events.some((event) => event.id === eventId)).toBe(
+			false,
+		);
+	});
+
+	it("flushes a queued edit on visibilitychange to hidden", async () => {
+		const repository = createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+		repository.clearWrites();
+
+		const clip = project.clips[0];
+		if (clip.content.kind !== "notes") throw new Error("expected a note clip");
+		const clipId = clip.id as ClipId;
+		const eventId = clip.content.events[0].id;
+
+		const { result } = renderHook(
+			() =>
+				useEditorSession(
+					() => project.metadata.id,
+					() => repository,
+				),
+			{},
+		);
+
+		await vi.waitFor(() => expect(result.state.loading).toBe(false));
+
+		result.dispatch(removeNotes(clipId, [eventId]));
+		expect(repository.writes).toHaveLength(0);
+
+		vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+		document.dispatchEvent(new Event("visibilitychange"));
+
+		await vi.waitFor(() => expect(repository.writes.length).toBeGreaterThan(0));
+		vi.restoreAllMocks();
+	});
+
+	it("still flushes on unmount (in-app navigation away from the project)", async () => {
+		const repository = createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+		repository.clearWrites();
+
+		const clip = project.clips[0];
+		if (clip.content.kind !== "notes") throw new Error("expected a note clip");
+		const clipId = clip.id as ClipId;
+		const eventId = clip.content.events[0].id;
+
+		const { result, cleanup: cleanupHook } = renderHook(
+			() =>
+				useEditorSession(
+					() => project.metadata.id,
+					() => repository,
+				),
+			{},
+		);
+
+		await vi.waitFor(() => expect(result.state.loading).toBe(false));
+
+		result.dispatch(removeNotes(clipId, [eventId]));
+		expect(repository.writes).toHaveLength(0);
+
+		cleanupHook();
+
+		await vi.waitFor(() => expect(repository.writes.length).toBeGreaterThan(0));
+	});
+});

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -11,6 +11,47 @@ import type { SaveStatus } from "../persistence/autosave";
 import type { ProjectRepository } from "../persistence/projectRepository";
 import { EditorSession } from "./EditorSession";
 
+/**
+ * Attaches the PRD `PRJ-03` navigation-flush behavior for one session: a
+ * queued-but-not-yet-written edit is flushed as soon as the browser signals
+ * the page might not get another chance to run, not only when this Solid
+ * effect tears down (in-app route changes already get that from `onCleanup`
+ * below).
+ *
+ * `visibilitychange` to `"hidden"` is the reliable signal across desktop and
+ * mobile browsers (a background tab, an app switch, a real close all fire
+ * it); `pagehide` covers the same-tab navigation/close cases some browsers
+ * fire without a visibility change first. Neither can guarantee the write
+ * completes before the page actually goes away — that is what "where the
+ * browser permits a flush" in the PRD acknowledges — but both start it as
+ * early as this code can detect the moment.
+ */
+function watchNavigationFlush(getSession: () => EditorSession | null): void {
+	if (typeof window === "undefined") return;
+
+	function flush(): void {
+		getSession()
+			?.autosave.flush()
+			.catch(() => {
+				// `flush()` only rejects if the repository call itself throws
+				// synchronously into the promise chain; a failed write already
+				// surfaces through `SaveStatus.state === "failed"`, so there is
+				// nothing further to do with the rejection here.
+			});
+	}
+
+	function handleVisibilityChange(): void {
+		if (document.visibilityState === "hidden") flush();
+	}
+
+	document.addEventListener("visibilitychange", handleVisibilityChange);
+	window.addEventListener("pagehide", flush);
+	onCleanup(() => {
+		document.removeEventListener("visibilitychange", handleVisibilityChange);
+		window.removeEventListener("pagehide", flush);
+	});
+}
+
 export interface EditorSessionState {
 	readonly loading: boolean;
 	readonly notFound: boolean;
@@ -30,6 +71,8 @@ export interface UseEditorSessionResult {
 	): TransactionResult | undefined;
 	undo(): TransactionResult | null | undefined;
 	redo(): TransactionResult | null | undefined;
+	/** The explicit retry affordance PRD `PRJ-03` requires for a failed save. */
+	retry(): Promise<SaveStatus> | undefined;
 }
 
 const INITIAL_STATE: EditorSessionState = {
@@ -62,6 +105,7 @@ export function useEditorSession(
 		...INITIAL_STATE,
 	});
 	let session: EditorSession | null = null;
+	watchNavigationFlush(() => session);
 
 	createEffect(() => {
 		const id = projectId();
@@ -134,5 +178,6 @@ export function useEditorSession(
 		dispatch: (commands) => session?.dispatch(commands),
 		undo: () => session?.undo(),
 		redo: () => session?.redo(),
+		retry: () => session?.autosave.retry(),
 	};
 }

--- a/src/persistence/autosave.test.ts
+++ b/src/persistence/autosave.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import {
+	createRecordingTransport,
+	type RecordingTransport,
+} from "../analytics/transport";
 import type { Project } from "../domain/entities";
 import { createSliceFixtureProject } from "../domain/fixtures";
 import { createManualClock } from "../shared/clock";
@@ -6,10 +12,25 @@ import {
 	createManualScheduler,
 	type ManualScheduler,
 } from "../shared/scheduler";
+import { memoryStorage } from "../testing/storage";
 import { ProjectAutosave, type SaveStatus } from "./autosave";
 import { clipDocumentPath, songDocumentPath } from "./documents";
 import { InMemoryProjectRepository } from "./inMemoryProjectRepository";
 import type { ProjectRepository } from "./projectRepository";
+
+function createTestAnalytics(): {
+	analytics: Analytics;
+	transport: RecordingTransport;
+} {
+	const transport = createRecordingTransport();
+	const analytics = new Analytics({
+		transport,
+		consent: new ConsentStore(memoryStorage()),
+		storage: memoryStorage(),
+	});
+	analytics.setAccountType("anonymous");
+	return { analytics, transport };
+}
 
 /**
  * Wraps a repository so the first `saveSong` blocks until the test releases it.
@@ -372,5 +393,123 @@ describe("ProjectAutosave", () => {
 
 		expect(scheduler.pending).toBe(0);
 		expect(repository.writes).toHaveLength(0);
+	});
+
+	describe("analytics (PRD OPS-02)", () => {
+		it("logs save_failed once per failing write, with the error code and retry count", async () => {
+			const { analytics, transport } = createTestAnalytics();
+			const controller = new ProjectAutosave({
+				repository,
+				projectId: project.metadata.id,
+				revision: project.metadata.revision,
+				scheduler,
+				analytics,
+			});
+			repository.failNextWrites({ count: 1 });
+
+			controller.queueSong(renamedSong(150));
+			await controller.flush();
+
+			expect(transport.named("save_failed")).toHaveLength(1);
+			expect(transport.named("save_failed")[0]?.params).toMatchObject({
+				error_code: "unavailable",
+				retry_count: 0,
+			});
+		});
+
+		it("does not log save_failed again for the same in-flight retry racing itself", async () => {
+			// Mirrors "does not report a conflict against a write it just made
+			// itself" above: several flushes park on one drain, so this asserts
+			// the coalescing guarantee — one event per failure episode, not one
+			// per attempt — holds for the analytics event too.
+			const { analytics, transport } = createTestAnalytics();
+			const controller = new ProjectAutosave({
+				repository,
+				projectId: project.metadata.id,
+				revision: project.metadata.revision,
+				scheduler,
+				analytics,
+			});
+			repository.failNextWrites({ count: 1 });
+			controller.queueSong(renamedSong(151));
+
+			await Promise.all([
+				controller.flush(),
+				controller.flush(),
+				controller.flush(),
+			]);
+
+			expect(transport.named("save_failed")).toHaveLength(1);
+		});
+
+		it("logs save_recovered exactly once when a retry after a failure succeeds", async () => {
+			const { analytics, transport } = createTestAnalytics();
+			const controller = new ProjectAutosave({
+				repository,
+				projectId: project.metadata.id,
+				revision: project.metadata.revision,
+				scheduler,
+				analytics,
+			});
+			repository.failNextWrites({ count: 1 });
+			controller.queueSong(renamedSong(152));
+
+			await controller.flush();
+			expect(controller.status.state).toBe("failed");
+			expect(transport.named("save_recovered")).toHaveLength(0);
+
+			await controller.retry();
+
+			expect(controller.status.state).toBe("saved");
+			expect(transport.named("save_recovered")).toHaveLength(1);
+			expect(transport.named("save_recovered")[0]?.params).toMatchObject({
+				retry_count: 1,
+			});
+		});
+
+		it("does not log save_recovered for an ordinary save with no prior failure", async () => {
+			const { analytics, transport } = createTestAnalytics();
+			const controller = new ProjectAutosave({
+				repository,
+				projectId: project.metadata.id,
+				revision: project.metadata.revision,
+				scheduler,
+				analytics,
+			});
+
+			controller.queueSong(renamedSong(153));
+			await controller.flush();
+
+			expect(controller.status.state).toBe("saved");
+			expect(transport.named("save_recovered")).toHaveLength(0);
+		});
+
+		it("counts every failed attempt in the episode's retry_count, and reports exactly one recovery", async () => {
+			const { analytics, transport } = createTestAnalytics();
+			const controller = new ProjectAutosave({
+				repository,
+				projectId: project.metadata.id,
+				revision: project.metadata.revision,
+				scheduler,
+				analytics,
+			});
+			repository.failNextWrites({ count: 2 });
+			controller.queueSong(renamedSong(154));
+
+			await controller.flush();
+			await controller.retry();
+			expect(controller.status.state).toBe("failed");
+			await controller.retry();
+
+			expect(controller.status.state).toBe("saved");
+			expect(transport.named("save_failed")).toHaveLength(2);
+			expect(
+				transport.named("save_failed").map((e) => e.params.retry_count),
+			).toEqual([0, 1]);
+			expect(transport.named("save_recovered")).toHaveLength(1);
+			expect(transport.named("save_recovered")[0]?.params).toMatchObject({
+				retry_count: 2,
+			});
+		});
 	});
 });

--- a/src/persistence/autosave.ts
+++ b/src/persistence/autosave.ts
@@ -261,6 +261,12 @@ export class ProjectAutosave {
 		this.failure = null;
 		this.publish();
 
+		// Captured before the loop can reset it: a drain that starts having
+		// already failed at least once is a retry of a failure episode, and
+		// `save_recovered` (below) reports how many attempts that episode cost —
+		// one event per episode, not one per attempt, matching `save_failed`.
+		const retryCountIfRecovered = this.consecutiveFailures;
+
 		while (this.queue.size > 0 && !this.disposed) {
 			const [key, entry] = [...this.queue.entries()][0];
 			const result = await this.write(entry);
@@ -293,9 +299,14 @@ export class ProjectAutosave {
 		}
 
 		if (!this.disposed) {
-			// A clean drain ends the failure streak. `save_recovered` — the event
-			// that pairs with this — belongs to `LOOP-002`, which owns the retry
-			// UX that makes recovery observable to the user.
+			// A clean drain ends the failure streak. `save_recovered` fires only
+			// when this drain actually recovered one — an ordinary drain with no
+			// prior failure is not a "recovery" and stays silent.
+			if (retryCountIfRecovered > 0) {
+				this.analytics.log("save_recovered", {
+					retry_count: retryCountIfRecovered,
+				});
+			}
 			this.consecutiveFailures = 0;
 			this.state = "saved";
 			this.publish();


### PR DESCRIPTION
Builds the PRJ-03 autosave and recovery UX on top of the existing FND-009 `ProjectAutosave`/`EditorSession`/`EditorView` slice.

## What's here

- **`ProjectAutosave`** logs `save_recovered` once per failure episode — never for an ordinary save with no prior failure — pairing with the existing `save_failed` event.
- **`EditorSession`** logs `undo_used` (direction plus invoking actor) whenever undo or redo actually replays an entry.
- **`useEditorSession`** flushes any queued-but-unwritten edit on `pagehide` and on `visibilitychange` to hidden, in addition to the existing flush-on-unmount for in-app navigation, and exposes an explicit `retry()`.
- **`EditorView`** shows an actionable, reason-specific message for a failed save plus an explicit Retry action, gated on `SaveFailure.retryable` so a genuine optimistic conflict doesn't offer a retry that cannot succeed.

Tests: fake-timer/repository coverage for the new analytics in `autosave.test.ts` and `EditorSession.test.ts`, a new `useEditorSession.test.ts` covering the pagehide/visibilitychange/unmount flush paths, and `EditorView` component tests for the failed/retry UI and the non-retryable conflict path.

## Verification

Run on the rebased head, not just the original branch:

| Check | Result |
| --- | --- |
| `bun run typecheck` | pass |
| `bun run test` | pass — 88 files, 1164 tests |
| `bun run check:ci` | pass (exit 0; the one warning is pre-existing on `main`, in `scripts/starter-library/acquire/generateCandidates.mjs`, untouched here) |
| `bun run test:browser` | **not executed** |
| `bun run test:browser:emulator` | **not executed** |

**The browser suites could not run** — Playwright's binaries can't be downloaded in the sandbox this was built in (the proxy returns 403 for `cdn.playwright.dev`). The behaviour is otherwise covered by the Vitest suite, including a jsdom-rendered `EditorView` test of the new failed/retry UI, so the gap here is narrower than on the LOOP-001 PR: no new browser specs were added by this task. CI will exercise the existing suites on this PR.

Worth a reviewer's attention specifically: `pagehide`/`visibilitychange` flush behaviour is asserted in jsdom, which is not the same as proving it in a real browser under an actual tab close. If you want that proven, it needs a browser test rather than a unit test.

## Note for whoever merges

This and #96 (LOOP-001) both touch `src/editor/EditorSession.ts` and its test. Whichever lands second will need a rebase.

This branch was rebased onto current `main` before opening. The original branch carried a duplicate of the `BASE_BRANCH` commit that landed in #94; that commit was dropped, since its content is byte-identical to what `main` already has.

Closes #42

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wggjodt38yCcRb5tnTvjDv)_