### PR TITLE
DEC-007: record direct .als serialization as the exporter route

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -902,7 +902,7 @@ These tasks are intentionally brief until `REL-003` is `done`. Before claiming o
 `Status: parked | Owner: unassigned | Dependencies: REL-003, DEC-007`<br>
 `PRD: SHR-02 | Evidence: pending`
 
-Determine the oldest correctly supported Live version, serialization route, legal/technical constraints, supported editable mappings, fallback policy, and fixture test matrix.
+The exporter builds and maintains its own `.als` serializer rather than a partner/integration route (`DEC-007`). Survey existing open-source `.als` parsing/writing libraries and adopt one where its schema coverage and licence are adequate, to minimize the maintenance burden of an unofficial, reverse-engineered format; otherwise write the serializer from scratch. Determine the oldest correctly supported Live version, remaining legal/technical constraints, supported editable mappings, fallback policy, and fixture test matrix.
 
 ### P1-002 - Self-contained Ableton Live export
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1480,6 +1480,7 @@ A feature is done only when:
 - Stereo and stem exports preserve project gain exactly rather than applying a peak/loudness normalization policy. Final output level stays under the producer's control; no export library may change it implicitly (`DEC-004`).
 - A self-contained Ableton Live Set is the first native project-format handoff target after the private alpha.
 - Ableton export targets the oldest Live version that can correctly support the implemented handoff; an exporter compatibility spike establishes and documents that minimum version.
+- Native Live Set generation is built and maintained directly as our own `.als` serializer rather than through a supported partner/integration route: Ableton publishes no partner API or SDK that can produce a native Live Set on our behalf, so that route cannot meet `SHR-02`'s self-contained-file acceptance criteria and would in practice degrade to shipping MIDI and stems for manual reassembly. `P1-001` surveys existing open-source `.als` parsing/writing libraries across Live versions and builds on one where its schema coverage and licence are adequate, to minimize the maintenance burden of an unofficial, reverse-engineered file format (`DEC-007`).
 - Real-time collaboration follows validation of the single-user creation workflow.
 - SolidStart/SolidJS/TypeScript, Tone.js over Web Audio, and Firebase Auth/Firestore/Storage/Functions are committed alpha technologies.
 - One long-lived real-time Tone/Web Audio context per document and stable, incrementally reconciled audio graphs are hard alpha architecture decisions.
@@ -1493,7 +1494,6 @@ A feature is done only when:
 - For the later pack marketplace (LIB-05): who may publish a pack, what rights and revenue-sharing terms apply to a creator, what moderation and takedown process governs published content, and what happens to a project that uses a pack after that pack is withdrawn or the user's access to it ends? (Post-alpha; unscheduled.)
 - Which sample/preset sources have acceptable commercial licensing and attribution terms?
 - Which AI provider, model budget, usage limit, and data-retention policy are acceptable for the alpha?
-- Should native Live Set generation be maintained directly or delivered through a supported partner/integration route?
 - Who are the first 8-20 target testers, and what existing tools/genres should the cohort represent?
 - What consent, retention, and regional policy applies to product analytics and error reports — is analytics on by default with an opt-out, how long is event and error data retained, and does the Sentry data region satisfy any regional constraint, or does that constraint reopen self-hosting? (`DEC-009`.)
 - When does the alpha stop deploying only to production: what triggers adding a separate staging or preview environment, and does it happen before the cohort grows or before public launch?


### PR DESCRIPTION
Records the DEC-007 decision: Solid Groove builds and maintains its own .als serializer rather than a partner/integration route, since Ableton has no partner API/SDK that can produce a native Live Set. Updates `docs/prd.md` section 16 (moves the open question into "Decisions made for implementation") and directs `P1-001` to survey existing open-source `.als` libraries first, falling back to a from-scratch serializer only if none has adequate schema coverage/licence.

Closes #36.

Generated with [Claude Code](https://claude.ai/code)