### PR TITLE
LOOP-004 - Synth and one-shot sampler

### DIFF
--- a/src/analytics/catalog.ts
+++ b/src/analytics/catalog.ts
@@ -182,6 +182,8 @@ export const COMMAND_IDS = [
 	"placement.delete",
 	"placement.update",
 	"parameter.set",
+	"instrument.change",
+	"instrument.setSample",
 ] as const;
 export type CommandId = (typeof COMMAND_IDS)[number];
 

--- a/src/audio/InstrumentGraph.test.ts
+++ b/src/audio/InstrumentGraph.test.ts
@@ -3,8 +3,13 @@ import type { DrumPad, Instrument } from "../domain/entities";
 import { packVersion } from "../domain/entities";
 import type { AssetId, PadId } from "../domain/ids";
 import { createSeededIdFactory } from "../domain/ids";
+import {
+	SAMPLER_PITCH,
+	SYNTH_FILTER_CUTOFF,
+	SYNTH_WAVEFORM,
+} from "../domain/parameters";
 import type { AudioAssetProjection } from "../projection/audioProjection";
-import { installWebAudioGlobals } from "./testAudioContext";
+import { hfEnergy, installWebAudioGlobals, rms } from "./testAudioContext";
 
 installWebAudioGlobals();
 
@@ -357,5 +362,248 @@ describe("playOneShot", () => {
 			destination.dispose();
 			buffer.dispose();
 		}
+	});
+});
+
+// --- LOOP-004: synth/sampler DSP and lifecycle -----------------------------
+
+const SYNTH_WAVEFORM_KEY = SYNTH_WAVEFORM.id.split(".")[1];
+const SYNTH_CUTOFF_KEY = SYNTH_FILTER_CUTOFF.id.split(".")[1];
+const SAMPLER_PITCH_KEY = SAMPLER_PITCH.id.split(".")[1];
+
+function bareContext() {
+	const runtime = new AudioRuntimeModule.AudioRuntime();
+	const scope = runtime.openProjectScope("p");
+	const { context } = makeContext(scope);
+	return { runtime, context };
+}
+
+describe("synth voice (PRD INS-01)", () => {
+	it("its resonant low-pass cutoff changes the rendered high-frequency energy", async () => {
+		const Tone = await import("tone");
+
+		async function renderAtCutoff(cutoff: number): Promise<Float32Array> {
+			const buffer = await Tone.Offline(
+				async ({ destination }) => {
+					const runtime = new AudioRuntimeModule.AudioRuntime();
+					const scope = runtime.openProjectScope("p");
+					const { context } = makeContext(scope);
+					const node = InstrumentGraphModule.createInstrumentNode(
+						{
+							kind: "synth",
+							parameters: {
+								[SYNTH_WAVEFORM_KEY]: 2, // sawtooth: rich in harmonics
+								[SYNTH_CUTOFF_KEY]: cutoff,
+								ampAttack: 0.001,
+								ampRelease: 0.05,
+							},
+						},
+						context,
+					);
+					node.output.connect(destination);
+					node.trigger({ kind: "pitch", pitch: 45 }, 0, 0.3, 0.9);
+				},
+				0.35,
+				1,
+			);
+			return Float32Array.from(buffer.getChannelData(0));
+		}
+
+		const dark = await renderAtCutoff(300);
+		const bright = await renderAtCutoff(16_000);
+		// A brighter cutoff passes more of the sawtooth's harmonics, so its
+		// high-frequency energy (discrete derivative RMS) is higher.
+		expect(hfEnergy(bright)).toBeGreaterThan(hfEnergy(dark));
+		expect(rms(bright)).toBeGreaterThan(0);
+	});
+
+	it("updates parameters in place without replacing the synth node", async () => {
+		const { runtime, context } = bareContext();
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "synth", parameters: {} },
+			context,
+		);
+		const before = runtime.diagnostics().resources.total;
+		// A cutoff sweep and a waveform change both go through update().
+		node.update({
+			kind: "synth",
+			parameters: { [SYNTH_CUTOFF_KEY]: 900, [SYNTH_WAVEFORM_KEY]: 1 },
+		});
+		node.update({
+			kind: "synth",
+			parameters: { [SYNTH_CUTOFF_KEY]: 4000, [SYNTH_WAVEFORM_KEY]: 3 },
+		});
+		expect(runtime.diagnostics().resources.total).toBe(before);
+		node.dispose();
+		await runtime.close();
+	});
+
+	it("survives parameter extremes and repeated triggers without throwing", async () => {
+		const { runtime, context } = bareContext();
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{
+				kind: "synth",
+				parameters: {
+					[SYNTH_CUTOFF_KEY]: SYNTH_FILTER_CUTOFF.max,
+					filterResonance: 20,
+					ampAttack: 0,
+					ampRelease: 0,
+					ampSustain: 0,
+				},
+			},
+			context,
+		);
+		expect(() => {
+			for (let i = 0; i < 64; i += 1) {
+				node.trigger(
+					{ kind: "pitch", pitch: 36 + (i % 48) },
+					i * 0.01,
+					0.05,
+					1,
+				);
+			}
+		}).not.toThrow();
+		node.dispose();
+		await runtime.close();
+	});
+});
+
+describe("one-shot sampler (PRD INS-01)", () => {
+	/** A ramp buffer, so a windowed slice sounds different from the whole file. */
+	async function rampBuffer(): Promise<import("tone").ToneAudioBuffer> {
+		const Tone = await import("tone");
+		const data = new Float32Array(4096);
+		for (let i = 0; i < data.length; i += 1) {
+			data[i] = Math.sin((i / data.length) * Math.PI * 8) * (i / data.length);
+		}
+		return Tone.ToneAudioBuffer.fromArray(data);
+	}
+
+	/** A context whose cache resolves one real ToneAudioBuffer for any asset. */
+	function realBufferContext(buffer: import("tone").ToneAudioBuffer) {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const assetsById = new Map<AssetId, AudioAssetProjection>();
+		const loader = {
+			async load() {
+				return buffer;
+			},
+		};
+		const bufferCache = new AudioBufferCacheModule.AudioBufferCache(
+			loader as unknown as import("./AudioBufferCache").AssetBufferLoader<
+				import("tone").ToneAudioBuffer
+			>,
+		);
+		return { runtime, context: { scope, assetsById, bufferCache } };
+	}
+
+	it("applies pitch as a playback-rate change and windows to start/end", async () => {
+		const Tone = await import("tone");
+		const buffer = await rampBuffer();
+		const { runtime, context } = realBufferContext(buffer);
+		const assetId = ids("asset");
+		context.assetsById.set(assetId, asset(assetId));
+
+		const starts: { rate: number; offset: number; duration: number }[] = [];
+		const startSpy = vi
+			.spyOn(Tone.Player.prototype, "start")
+			.mockImplementation(function mocked(
+				this: { playbackRate: number },
+				_time?: unknown,
+				offset?: unknown,
+				duration?: unknown,
+			) {
+				starts.push({
+					rate: this.playbackRate,
+					offset: Number(offset),
+					duration: Number(duration),
+				});
+				return this as never;
+			});
+
+		try {
+			const node = InstrumentGraphModule.createInstrumentNode(
+				{
+					kind: "sampler",
+					assetId,
+					parameters: {
+						[SAMPLER_PITCH_KEY]: 12, // +1 octave -> 2x rate
+						sampleStart: 0.25,
+						sampleEnd: 0.75,
+					},
+				},
+				context,
+			);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			node.trigger({ kind: "pitch", pitch: 60 }, 0, "192i", 1);
+			expect(starts).toHaveLength(1);
+			expect(starts[0].rate).toBeCloseTo(2, 5);
+			// Start offset is 25% into the buffer; the window is the middle 50%.
+			expect(starts[0].offset).toBeCloseTo(buffer.duration * 0.25, 3);
+			expect(starts[0].duration).toBeCloseTo(buffer.duration * 0.5, 3);
+
+			node.dispose();
+		} finally {
+			startSpy.mockRestore();
+			buffer.dispose();
+			await runtime.close();
+		}
+	});
+
+	it("swapping the sample cancels the old subscription (cache ownership)", async () => {
+		const { runtime, context } = bareContext();
+		const assetA = ids("asset");
+		const assetB = ids("asset");
+		context.assetsById.set(assetA, asset(assetA));
+		context.assetsById.set(assetB, asset(assetB));
+
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "sampler", assetId: assetA, parameters: {} },
+			context,
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(context.bufferCache.diagnostics().cachedAssets).toBe(1);
+
+		node.update({ kind: "sampler", assetId: assetB, parameters: {} });
+		await Promise.resolve();
+		await Promise.resolve();
+		// Old asset released, new one attached — one cached asset, not two.
+		expect(context.bufferCache.diagnostics().cachedAssets).toBe(1);
+
+		node.dispose();
+		await Promise.resolve();
+		expect(runtime.diagnostics().resources.total).toBe(0);
+		await runtime.close();
+	});
+
+	it("a parameter edit keeps the same subscription and disposes cleanly", async () => {
+		const { runtime, context } = bareContext();
+		const assetId = ids("asset");
+		context.assetsById.set(assetId, asset(assetId));
+		const node = InstrumentGraphModule.createInstrumentNode(
+			{ kind: "sampler", assetId, parameters: {} },
+			context,
+		);
+		await Promise.resolve();
+		await Promise.resolve();
+		const subscriptions = runtime.diagnostics().resources.byType.subscription;
+
+		node.update({
+			kind: "sampler",
+			assetId,
+			parameters: { [SAMPLER_PITCH_KEY]: 7, sampleStart: 0.2, sampleEnd: 0.9 },
+		});
+		// A non-asset edit must not resubscribe.
+		expect(runtime.diagnostics().resources.byType.subscription).toBe(
+			subscriptions,
+		);
+
+		node.dispose();
+		await Promise.resolve();
+		expect(runtime.diagnostics().resources.total).toBe(0);
+		await runtime.close();
 	});
 });

--- a/src/audio/InstrumentGraph.ts
+++ b/src/audio/InstrumentGraph.ts
@@ -1,9 +1,31 @@
 import * as Tone from "tone";
 import type { DrumPad, Instrument, NoteTrigger } from "../domain/entities";
 import type { AssetId, PadId } from "../domain/ids";
+import {
+	readInstrumentParameter,
+	SAMPLER_AMP_ATTACK,
+	SAMPLER_AMP_DECAY,
+	SAMPLER_AMP_RELEASE,
+	SAMPLER_AMP_SUSTAIN,
+	SAMPLER_PITCH,
+	SAMPLER_SAMPLE_END,
+	SAMPLER_SAMPLE_START,
+	SYNTH_AMP_ATTACK,
+	SYNTH_AMP_DECAY,
+	SYNTH_AMP_RELEASE,
+	SYNTH_AMP_SUSTAIN,
+	SYNTH_FILTER_CUTOFF,
+	SYNTH_FILTER_RESONANCE,
+	SYNTH_WAVEFORM,
+	synthWaveform,
+} from "../domain/parameters";
 import type { AudioAssetProjection } from "../projection/audioProjection";
 import type { AudioBufferCache, BufferSubscription } from "./AudioBufferCache";
 import type { AudioProjectScope } from "./AudioRuntime";
+
+/** Continuous parameter edits ramp over this window rather than stepping, so a
+ * cutoff sweep or a filter-Q change never clicks (AUD "safe smoothing"). */
+const SMOOTHING_SECONDS = 0.02;
 
 /** Schema v1 models `Instrument` as one discriminated union rather than
  * exporting each variant separately; these local aliases narrow it by `kind`
@@ -120,6 +142,87 @@ function releaseAssetVoice(voice: AssetVoice, scope: AudioProjectScope): void {
 
 // --- Sampler -----------------------------------------------------------
 
+/** The sampler's playback + envelope settings, resolved from its parameters. */
+interface SamplerSettings {
+	pitch: number;
+	sampleStart: number;
+	sampleEnd: number;
+	attack: number;
+	decay: number;
+	sustain: number;
+	release: number;
+}
+
+function readSamplerSettings(instrument: SamplerInstrument): SamplerSettings {
+	const p = instrument.parameters;
+	return {
+		pitch: readInstrumentParameter(SAMPLER_PITCH, p),
+		sampleStart: readInstrumentParameter(SAMPLER_SAMPLE_START, p),
+		sampleEnd: readInstrumentParameter(SAMPLER_SAMPLE_END, p),
+		attack: readInstrumentParameter(SAMPLER_AMP_ATTACK, p),
+		decay: readInstrumentParameter(SAMPLER_AMP_DECAY, p),
+		sustain: readInstrumentParameter(SAMPLER_AMP_SUSTAIN, p),
+		release: readInstrumentParameter(SAMPLER_AMP_RELEASE, p),
+	};
+}
+
+/**
+ * Plays `buffer` once, pitched and windowed to the sampler's settings, through
+ * a per-trigger amplitude envelope that self-disposes when the note is done —
+ * the short-lived voice AUD-08 permits, as long as it leaves nothing scheduled
+ * behind it. Voices carry no reference to the instrument, so a settings edit
+ * mid-note never mutates a note already sounding.
+ */
+function playSampledVoice(
+	buffer: Tone.ToneAudioBuffer,
+	destination: Tone.ToneAudioNode,
+	settings: SamplerSettings,
+	time: Tone.Unit.Time,
+	duration: Tone.Unit.Time,
+	velocity: number,
+): void {
+	const bufferSeconds = buffer.duration;
+	const offset = clampUnit(settings.sampleStart) * bufferSeconds;
+	const end = clampUnit(settings.sampleEnd) * bufferSeconds;
+	const windowSeconds = Math.max(0, end - offset);
+	if (windowSeconds <= 0) return;
+
+	const envelope = new Tone.AmplitudeEnvelope({
+		attack: settings.attack,
+		decay: settings.decay,
+		sustain: settings.sustain,
+		release: settings.release,
+	}).connect(destination);
+	// Velocity scales the peak so a soft hit is quieter, without touching the
+	// envelope's own shape.
+	const gain = new Tone.Gain(velocity).connect(envelope);
+	const player = new Tone.Player(buffer).connect(gain);
+	player.playbackRate = 2 ** (settings.pitch / 12);
+
+	// The audible slice is the sample window, but the amp envelope's release
+	// tail is what actually ends the voice; hold the player through both.
+	const holdSeconds = Math.min(
+		windowSeconds / player.playbackRate,
+		Tone.Time(duration).toSeconds(),
+	);
+	envelope.triggerAttackRelease(holdSeconds, time, velocity);
+	player.start(time, offset, windowSeconds);
+	player.onstop = () => {
+		player.dispose();
+		gain.dispose();
+		// The envelope's release runs past the player's stop, so let it ring out
+		// before disposal rather than cutting the tail.
+		const releaseMs = (settings.release + 0.05) * 1000;
+		setTimeout(() => envelope.dispose(), releaseMs);
+	};
+}
+
+/** Folds a stored 0..1 position into range, guarding a bad projected value. */
+function clampUnit(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.min(1, Math.max(0, value));
+}
+
 function createSamplerInstrumentNode(
 	instrument: SamplerInstrument,
 	context: InstrumentGraphContext,
@@ -127,23 +230,34 @@ function createSamplerInstrumentNode(
 	const output = new Tone.Gain(1);
 	const voice = createAssetVoice();
 	attachAssetVoice(voice, context, instrument.assetId);
+	let settings = readSamplerSettings(instrument);
 
 	return {
 		kind: "sampler",
 		output,
-		trigger(trigger, time, duration) {
-			// Per-pitch playback rate and round-robin are Alpha Milestone 1 sampler-device
-			// concerns; the v1 scaffold plays the loaded one-shot at normal rate
-			// on any pitch trigger so the note-scheduling contract is provable
-			// ahead of that DSP.
+		trigger(trigger, time, duration, velocity) {
 			if (trigger.kind !== "pitch" || !voice.buffer) return;
-			playOneShot(voice.buffer, output, time, duration);
+			playSampledVoice(
+				voice.buffer,
+				output,
+				settings,
+				time,
+				duration,
+				velocity,
+			);
 		},
 		update(next) {
 			if (next.kind !== "sampler") return;
 			if (next.assetId !== voice.assetId) {
+				// A new asset id abandons the old subscription; `AudioBufferCache`
+				// generation tracking cancels any in-flight decode of the old sample
+				// so a stale load can never reconnect.
 				attachAssetVoice(voice, context, next.assetId);
 			}
+			// Playback and envelope settings are read on the *next* trigger; there is
+			// no persistent node to smooth, so this is a plain assignment. Notes
+			// already sounding keep the settings they were triggered with.
+			settings = readSamplerSettings(next);
 		},
 		dispose() {
 			releaseAssetVoice(voice, context.scope);
@@ -154,13 +268,67 @@ function createSamplerInstrumentNode(
 
 // --- Synth ---------------------------------------------------------------
 
+interface SynthSettings {
+	waveform: ReturnType<typeof synthWaveform>;
+	attack: number;
+	decay: number;
+	sustain: number;
+	release: number;
+	cutoff: number;
+	resonance: number;
+}
+
+function readSynthSettings(instrument: SynthInstrument): SynthSettings {
+	const p = instrument.parameters;
+	return {
+		waveform: synthWaveform(readInstrumentParameter(SYNTH_WAVEFORM, p)),
+		attack: readInstrumentParameter(SYNTH_AMP_ATTACK, p),
+		decay: readInstrumentParameter(SYNTH_AMP_DECAY, p),
+		sustain: readInstrumentParameter(SYNTH_AMP_SUSTAIN, p),
+		release: readInstrumentParameter(SYNTH_AMP_RELEASE, p),
+		cutoff: readInstrumentParameter(SYNTH_FILTER_CUTOFF, p),
+		resonance: readInstrumentParameter(SYNTH_FILTER_RESONANCE, p),
+	};
+}
+
+/**
+ * A polyphonic subtractive synth voice: oscillator + amp envelope (`PolySynth`
+ * over `Tone.Synth`) into one shared resonant low-pass `Tone.Filter`.
+ *
+ * `update()` reuses every node. Oscillator waveform and envelope stages are set
+ * on the poly synth's voice defaults, so they apply to the *next* note without
+ * disturbing notes already sounding. Filter cutoff and Q — the two continuous,
+ * automatable controls — ramp over `SMOOTHING_SECONDS` so a live sweep never
+ * clicks. The node is only ever replaced when the instrument `kind` changes,
+ * never for a parameter edit.
+ */
 function createSynthInstrumentNode(
-	_instrument: SynthInstrument,
+	instrument: SynthInstrument,
 	_context: InstrumentGraphContext,
 ): InstrumentNode {
+	const settings = readSynthSettings(instrument);
 	const synth = new Tone.PolySynth(Tone.Synth);
+	const filter = new Tone.Filter({
+		type: "lowpass",
+		frequency: settings.cutoff,
+		Q: settings.resonance,
+	});
 	const output = new Tone.Gain(1);
-	synth.connect(output);
+	synth.connect(filter);
+	filter.connect(output);
+
+	function applyVoiceDefaults(next: SynthSettings): void {
+		synth.set({
+			oscillator: { type: next.waveform },
+			envelope: {
+				attack: next.attack,
+				decay: next.decay,
+				sustain: next.sustain,
+				release: next.release,
+			},
+		});
+	}
+	applyVoiceDefaults(settings);
 
 	return {
 		kind: "synth",
@@ -172,12 +340,16 @@ function createSynthInstrumentNode(
 		},
 		update(next) {
 			if (next.kind !== "synth") return;
-			// Schema v1 defines no synth parameters yet — Alpha Milestone 1 authors them
-			// with the synth device (PRD section 9.5 invariant 10). `parameters`
-			// is carried through for forward compatibility only.
+			const resolved = readSynthSettings(next);
+			applyVoiceDefaults(resolved);
+			// The filter is a live, always-connected node — ramp it rather than
+			// jumping, so automating cutoff/resonance during playback is smooth.
+			filter.frequency.rampTo(resolved.cutoff, SMOOTHING_SECONDS);
+			filter.Q.rampTo(resolved.resonance, SMOOTHING_SECONDS);
 		},
 		dispose() {
 			synth.dispose();
+			filter.dispose();
 			output.dispose();
 		},
 	};

--- a/src/audio/ProjectAudioGraph.test.ts
+++ b/src/audio/ProjectAudioGraph.test.ts
@@ -173,6 +173,38 @@ describe("ProjectAudioGraph", () => {
 		await runtime.close();
 	});
 
+	it("auditionTrack triggers the target track's instrument once", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+		const project = createSliceFixtureProject();
+		graph.reconcile(buildAudioProjection(project));
+
+		const trackId = project.song.tracks[0].id;
+		const trackGraph = graph.trackGraphs.get(trackId);
+		if (!trackGraph) throw new Error("no track graph");
+		const trigger = vi.spyOn(trackGraph, "trigger");
+
+		graph.auditionTrack(trackId, { kind: "pitch", pitch: 60 }, 192, 0.9);
+		expect(trigger).toHaveBeenCalledTimes(1);
+		expect(trigger.mock.calls[0][0]).toEqual({ kind: "pitch", pitch: 60 });
+
+		// An unknown track is a silent no-op, not a throw.
+		expect(() =>
+			graph.auditionTrack(
+				"trk_missing" as never,
+				{ kind: "pitch", pitch: 60 },
+				192,
+				0.9,
+			),
+		).not.toThrow();
+
+		trigger.mockRestore();
+		await graph.dispose();
+		await runtime.close();
+	});
+
 	it("editing one track's mixer does not touch other tracks' graphs", async () => {
 		const project = createReferenceProject({
 			trackCount: 4,

--- a/src/audio/ProjectAudioGraph.ts
+++ b/src/audio/ProjectAudioGraph.ts
@@ -1,4 +1,5 @@
 import * as Tone from "tone";
+import type { NoteTrigger } from "../domain/entities";
 import type { AssetId, PlacementId, ReturnId, TrackId } from "../domain/ids";
 import type {
 	AudioAssetProjection,
@@ -181,6 +182,25 @@ export class ProjectAudioGraph {
 
 	get returnGraphs(): ReadonlyMap<ReturnId, ReturnAudioGraph> {
 		return this.returns;
+	}
+
+	/**
+	 * Plays one note through a track's instrument right now, for auditioning a
+	 * sound while editing it (PRD INS-01). It routes through the track's own
+	 * device chain and channel strip, so what a user hears is what the track
+	 * sounds like — it is not a bypassed preview. A no-op for an unknown track or
+	 * one with nothing loaded. The caller resumes the shared context first (the
+	 * audition button is a user gesture); this only schedules the trigger.
+	 */
+	auditionTrack(
+		trackId: TrackId,
+		trigger: NoteTrigger,
+		durationTicks: number,
+		velocity: number,
+	): void {
+		this.tracks
+			.get(trackId)
+			?.trigger(trigger, this.now(), ticksToToneTime(durationTicks), velocity);
 	}
 
 	diagnostics(): {

--- a/src/audio/testAudioContext.ts
+++ b/src/audio/testAudioContext.ts
@@ -1,4 +1,5 @@
 import * as nwaa from "node-web-audio-api";
+import { installWebAudioTeardownGuard } from "./testAudioTeardown";
 
 /**
  * jsdom has no Web Audio API, so Tone.js cannot render. `node-web-audio-api`
@@ -9,6 +10,11 @@ import * as nwaa from "node-web-audio-api";
  * Call this once, before importing Tone, to enable offline rendering.
  */
 export function installWebAudioGlobals(): void {
+	// Native `ended` events from `node-web-audio-api` can fire after jsdom is
+	// torn down; guard against that one teardown-race artifact. See
+	// `testAudioTeardown.ts`.
+	installWebAudioTeardownGuard();
+
 	const classes = [
 		"AudioContext",
 		"OfflineAudioContext",

--- a/src/audio/testAudioTeardown.test.ts
+++ b/src/audio/testAudioTeardown.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { installWebAudioGlobals } from "./testAudioContext";
+import { installWebAudioTeardownGuard } from "./testAudioTeardown";
+
+installWebAudioGlobals();
+
+describe("web audio teardown guard", () => {
+	it("swallows the stale-Event dispatch TypeError from a node-web-audio-api node", async () => {
+		installWebAudioTeardownGuard();
+		const nwaa = await import("node-web-audio-api");
+		const ctx = new nwaa.AudioContext();
+		try {
+			const node = new nwaa.ConstantSourceNode(ctx);
+			// A jsdom Event whose realm no longer matches the bound dispatchEvent
+			// is the shape of the post-teardown collision. We provoke the exact
+			// thrown TypeError by dispatching a non-Event value: the inherited
+			// (jsdom) dispatchEvent rejects it, and the guard must swallow *that*
+			// specific failure rather than let it escape as an unhandled error.
+			const dispatch = node.dispatchEvent as (e: unknown) => boolean;
+			expect(dispatch.call(node, { type: "ended" })).toBe(false);
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	it("is transparent for a well-formed event (happy path still dispatches)", async () => {
+		installWebAudioTeardownGuard();
+		const nwaa = await import("node-web-audio-api");
+		const ctx = new nwaa.AudioContext();
+		try {
+			const node = new nwaa.ConstantSourceNode(ctx);
+			let heard = false;
+			node.addEventListener("custom", () => {
+				heard = true;
+			});
+			// A real, in-realm jsdom Event must pass straight through the guard.
+			node.dispatchEvent(new Event("custom"));
+			expect(heard).toBe(true);
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/src/audio/testAudioTeardown.ts
+++ b/src/audio/testAudioTeardown.ts
@@ -1,11 +1,13 @@
+import * as nwaa from "node-web-audio-api";
+
 /**
- * Swallows the one teardown-race artifact that `node-web-audio-api` produces
+ * Neutralises the one teardown-race artifact that `node-web-audio-api` produces
  * under jsdom, and nothing else.
  *
  * `node-web-audio-api` fires a scheduled source's `ended` event from a *native*
- * callback (see `AudioScheduledSourceNode.js`), on the host event loop rather
- * than a JS microtask we can await. When a test schedules a note whose stop
- * time is still in the future and then disposes/closes the context, that native
+ * callback (see its `AudioScheduledSourceNode.js`), on the host event loop
+ * rather than a JS microtask we can await. When a test schedules a note whose
+ * stop time is still in the future and then disposes/closes the context, that
  * callback can fire *after* the whole Vitest run has finished and jsdom has been
  * torn down. Its `propagateEvent` then calls `dispatchEvent(new Event(...))`,
  * but the freshly-constructed `Event` no longer matches the (now stale) jsdom
@@ -14,32 +16,31 @@
  *   TypeError: Failed to execute 'dispatchEvent' on 'EventTarget':
  *   parameter 1 is not of type 'Event'.
  *
- * Vitest reports that as an unhandled error and fails an otherwise-green run.
- * It is an environment artifact, not a test failure: it can only happen *after*
- * teardown (a live dispatch during a test uses the matching jsdom `Event` and
- * succeeds), so ignoring it cannot mask a real in-test assertion or throw.
+ * Vitest installs its own `uncaughtException` listener and records that as an
+ * unhandled error, failing an otherwise-green run — a peer `uncaughtException`
+ * listener can't prevent Vitest's from also recording it, so the fix has to stop
+ * the throw at its source.
  *
- * The match is deliberately narrow — the exact jsdom message AND a
- * `node-web-audio-api` `propagateEvent` frame in the stack — so any other
- * unhandled `dispatchEvent` error still surfaces normally.
+ * We do that by giving `node-web-audio-api`'s own `AudioNode.prototype` a
+ * `dispatchEvent` that swallows *only* this exact failure and otherwise defers
+ * to the inherited (jsdom) implementation. It is an environment artifact, not a
+ * test failure: it can only happen *after* teardown (a live dispatch during a
+ * test uses the matching jsdom `Event` and succeeds), so ignoring it cannot mask
+ * a real in-test assertion or throw. The match is deliberately narrow — the
+ * exact jsdom / native "not an Event" dispatch type error — so any other error
+ * from an event handler still propagates normally.
  */
-function isNwaaTeardownDispatchArtifact(error: unknown): boolean {
-	if (!(error instanceof Error)) return false;
-	// The strong discriminator: it must have originated in node-web-audio-api's
-	// native `ended` propagation (`propagateEvent` in `lib/events.js`). Any
-	// error a test itself throws lacks this frame.
-	const fromNwaaPropagateEvent = /node-web-audio-api[\\/].*events\.js/.test(
-		error.stack ?? "",
-	);
-	if (!fromNwaaPropagateEvent) return false;
-	// ...and it must be the `dispatchEvent` type mismatch itself — jsdom words it
-	// "parameter 1 is not of type 'Event'"; Node's native EventTarget words the
-	// same failure "must be an instance of Event". Both are the stale-`Event`
-	// teardown collision, never a real test assertion.
+function isStaleEventDispatchTypeError(error: unknown): boolean {
+	// jsdom throws from its own realm, so a cross-realm `instanceof Error` is
+	// unreliable here — match structurally on `name`/`message` instead.
+	if (typeof error !== "object" || error === null) return false;
+	const { name, message } = error as { name?: unknown; message?: unknown };
+	if (name !== "TypeError" || typeof message !== "string") return false;
+	// jsdom words it "...parameter 1 is not of type 'Event'."; Node's native
+	// EventTarget words the same failure "...must be an instance of Event".
 	return (
-		error.name === "TypeError" &&
-		(/dispatchEvent/.test(error.message) ||
-			/instance of Event/.test(error.message))
+		(/dispatchEvent/.test(message) && /not of type 'Event'/.test(message)) ||
+		/must be an instance of Event/.test(message)
 	);
 }
 
@@ -47,24 +48,32 @@ let installed = false;
 
 /**
  * Install the guard once per worker. Idempotent: any Tone-touching suite may
- * call it (it is wired through `installWebAudioGlobals`), and repeated calls add
- * no extra listeners.
- *
- * The listener only ever *swallows* the artifact above. For any other uncaught
- * exception it re-emits on the next tick with itself detached, so Vitest's own
- * `uncaughtException` handling still sees and reports the error — we suppress
- * the one benign event, never the rest.
+ * call it (it is wired through `installWebAudioGlobals`), and repeated calls
+ * leave the single wrapper in place.
  */
 export function installWebAudioTeardownGuard(): void {
 	if (installed) return;
-	installed = true;
-	const handler = (error: Error): void => {
-		if (isNwaaTeardownDispatchArtifact(error)) return;
-		process.removeListener("uncaughtException", handler);
-		installed = false;
-		process.nextTick(() => {
-			throw error;
-		});
+	const audioNode = (nwaa as unknown as { AudioNode?: { prototype: object } })
+		.AudioNode;
+	if (!audioNode?.prototype) return;
+	const proto = audioNode.prototype as {
+		dispatchEvent?: (event: Event) => boolean;
 	};
-	process.on("uncaughtException", handler);
+	// The inherited (jsdom / native EventTarget) implementation.
+	const inherited = proto.dispatchEvent;
+	if (typeof inherited !== "function") return;
+	installed = true;
+	// An OWN property on node-web-audio-api's AudioNode.prototype, so the wrap is
+	// scoped to its nodes and never touches the global EventTarget itself.
+	proto.dispatchEvent = function guardedDispatchEvent(
+		this: object,
+		event: Event,
+	): boolean {
+		try {
+			return inherited.call(this, event);
+		} catch (error) {
+			if (isStaleEventDispatchTypeError(error)) return false;
+			throw error;
+		}
+	};
 }

--- a/src/audio/testAudioTeardown.ts
+++ b/src/audio/testAudioTeardown.ts
@@ -1,0 +1,70 @@
+/**
+ * Swallows the one teardown-race artifact that `node-web-audio-api` produces
+ * under jsdom, and nothing else.
+ *
+ * `node-web-audio-api` fires a scheduled source's `ended` event from a *native*
+ * callback (see `AudioScheduledSourceNode.js`), on the host event loop rather
+ * than a JS microtask we can await. When a test schedules a note whose stop
+ * time is still in the future and then disposes/closes the context, that native
+ * callback can fire *after* the whole Vitest run has finished and jsdom has been
+ * torn down. Its `propagateEvent` then calls `dispatchEvent(new Event(...))`,
+ * but the freshly-constructed `Event` no longer matches the (now stale) jsdom
+ * `EventTarget.prototype.dispatchEvent` still bound to the node, so jsdom throws
+ *
+ *   TypeError: Failed to execute 'dispatchEvent' on 'EventTarget':
+ *   parameter 1 is not of type 'Event'.
+ *
+ * Vitest reports that as an unhandled error and fails an otherwise-green run.
+ * It is an environment artifact, not a test failure: it can only happen *after*
+ * teardown (a live dispatch during a test uses the matching jsdom `Event` and
+ * succeeds), so ignoring it cannot mask a real in-test assertion or throw.
+ *
+ * The match is deliberately narrow — the exact jsdom message AND a
+ * `node-web-audio-api` `propagateEvent` frame in the stack — so any other
+ * unhandled `dispatchEvent` error still surfaces normally.
+ */
+function isNwaaTeardownDispatchArtifact(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	// The strong discriminator: it must have originated in node-web-audio-api's
+	// native `ended` propagation (`propagateEvent` in `lib/events.js`). Any
+	// error a test itself throws lacks this frame.
+	const fromNwaaPropagateEvent = /node-web-audio-api[\\/].*events\.js/.test(
+		error.stack ?? "",
+	);
+	if (!fromNwaaPropagateEvent) return false;
+	// ...and it must be the `dispatchEvent` type mismatch itself — jsdom words it
+	// "parameter 1 is not of type 'Event'"; Node's native EventTarget words the
+	// same failure "must be an instance of Event". Both are the stale-`Event`
+	// teardown collision, never a real test assertion.
+	return (
+		error.name === "TypeError" &&
+		(/dispatchEvent/.test(error.message) ||
+			/instance of Event/.test(error.message))
+	);
+}
+
+let installed = false;
+
+/**
+ * Install the guard once per worker. Idempotent: any Tone-touching suite may
+ * call it (it is wired through `installWebAudioGlobals`), and repeated calls add
+ * no extra listeners.
+ *
+ * The listener only ever *swallows* the artifact above. For any other uncaught
+ * exception it re-emits on the next tick with itself detached, so Vitest's own
+ * `uncaughtException` handling still sees and reports the error — we suppress
+ * the one benign event, never the rest.
+ */
+export function installWebAudioTeardownGuard(): void {
+	if (installed) return;
+	installed = true;
+	const handler = (error: Error): void => {
+		if (isNwaaTeardownDispatchArtifact(error)) return;
+		process.removeListener("uncaughtException", handler);
+		installed = false;
+		process.nextTick(() => {
+			throw error;
+		});
+	};
+	process.on("uncaughtException", handler);
+}

--- a/src/commands/definitions/instruments.ts
+++ b/src/commands/definitions/instruments.ts
@@ -1,0 +1,154 @@
+import { z } from "zod";
+import { type Instrument, instrumentSchema } from "../../domain/entities";
+import {
+	type AssetId,
+	assetIdSchema,
+	type TrackId,
+	trackIdSchema,
+} from "../../domain/ids";
+import { findTrack, replaceTrack, trackLabel } from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+
+/**
+ * Instrument lifecycle commands (LOOP-004, PRD INS-01).
+ *
+ * A track's instrument is *structure*, not a per-value edit, so replacing it or
+ * its sample is its own command rather than a `parameter.set`. Two guarantees
+ * matter here and both fall out of the command kernel:
+ *
+ * - **Clip data survives.** Clips live outside the track (invariant 3): swapping
+ *   a sampler for a synth, or one sample for another, only rewrites
+ *   `track.instrument` and never touches a clip's notes. A note clip authored
+ *   against one instrument replays against the next.
+ * - **Undo restores exactly.** Each command's `invert` captures the previous
+ *   instrument (or sample) verbatim, so redo/undo round-trips are byte-for-byte,
+ *   including any parameters the replaced instrument carried.
+ *
+ * Sample *load* cancellation lives in the audio graph (`AudioBufferCache`
+ * generation tracking): the command records intent, and reconciling the new
+ * projection is what abandons the stale decode.
+ */
+
+export const instrumentChangePayloadSchema = z.strictObject({
+	trackId: trackIdSchema,
+	/** The instrument to install, or `null` to clear the track's instrument. */
+	instrument: instrumentSchema.nullable(),
+});
+export type InstrumentChangePayload = z.infer<
+	typeof instrumentChangePayloadSchema
+>;
+
+export const instrumentSetSamplePayloadSchema = z.strictObject({
+	trackId: trackIdSchema,
+	/** The asset the sampler should play, or `null` to clear it. */
+	assetId: assetIdSchema.nullable(),
+});
+export type InstrumentSetSamplePayload = z.infer<
+	typeof instrumentSetSamplePayloadSchema
+>;
+
+function describeInstrument(instrument: Instrument | null): string {
+	if (!instrument) return "no instrument";
+	switch (instrument.kind) {
+		case "sampler":
+			return "sampler";
+		case "synth":
+			return "synth";
+		case "drumMachine":
+			return "drum machine";
+	}
+}
+
+export const instrumentChangeCommand = defineCommand<InstrumentChangePayload>({
+	type: "instrument.change",
+	version: 1,
+	schema: instrumentChangePayloadSchema,
+	summarize: (payload, project) =>
+		`Change ${trackLabel(project, payload.trackId)} to ${describeInstrument(payload.instrument)}`,
+	apply(project, payload) {
+		const track = findTrack(project, payload.trackId);
+		if (!track) {
+			return rejected(`Track ${payload.trackId} does not exist`);
+		}
+		return applied(
+			replaceTrack(project, { ...track, instrument: payload.instrument }),
+		);
+	},
+	invert(payload, before) {
+		const track = findTrack(before, payload.trackId);
+		return track ? [changeInstrument(payload.trackId, track.instrument)] : [];
+	},
+});
+
+export const instrumentSetSampleCommand =
+	defineCommand<InstrumentSetSamplePayload>({
+		type: "instrument.setSample",
+		version: 1,
+		schema: instrumentSetSamplePayloadSchema,
+		summarize: (payload, project) =>
+			payload.assetId
+				? `Replace sample on ${trackLabel(project, payload.trackId)}`
+				: `Clear sample on ${trackLabel(project, payload.trackId)}`,
+		apply(project, payload) {
+			const track = findTrack(project, payload.trackId);
+			if (!track) {
+				return rejected(`Track ${payload.trackId} does not exist`);
+			}
+			if (track.instrument?.kind !== "sampler") {
+				return rejected(
+					`Track ${track.id} has no sampler to load a sample into`,
+				);
+			}
+			return applied(
+				replaceTrack(project, {
+					...track,
+					// Only the asset changes: pitch, start/end, and envelope carry
+					// through unchanged, which is the "compatible clip data preserved"
+					// guarantee at the instrument level.
+					instrument: { ...track.instrument, assetId: payload.assetId },
+				}),
+			);
+		},
+		invert(payload, before) {
+			const track = findTrack(before, payload.trackId);
+			if (track?.instrument?.kind !== "sampler") {
+				return [];
+			}
+			return [setSample(payload.trackId, track.instrument.assetId)];
+		},
+	});
+
+// --- Typed builders -------------------------------------------------------
+
+export function changeInstrument(
+	trackId: TrackId,
+	instrument: Instrument | null,
+): CommandInput<InstrumentChangePayload> {
+	return {
+		type: instrumentChangeCommand.type,
+		payload: { trackId, instrument },
+	};
+}
+
+export function setSample(
+	trackId: TrackId,
+	assetId: AssetId | null,
+): CommandInput<InstrumentSetSamplePayload> {
+	return {
+		type: instrumentSetSampleCommand.type,
+		payload: { trackId, assetId },
+	};
+}
+
+/** Registered, payload-erased commands from this module. */
+export const instrumentCommands: readonly RegisteredCommand[] = [
+	eraseCommand(instrumentChangeCommand),
+	eraseCommand(instrumentSetSampleCommand),
+];

--- a/src/commands/definitions/parameters.ts
+++ b/src/commands/definitions/parameters.ts
@@ -48,6 +48,11 @@ export const parameterTargetSchema = z.discriminatedUnion("scope", [
 		parameterId: z.string().min(1),
 	}),
 	z.strictObject({
+		scope: z.literal("instrument"),
+		trackId: trackIdSchema,
+		parameterId: z.string().min(1),
+	}),
+	z.strictObject({
 		scope: z.literal("trackDevice"),
 		trackId: trackIdSchema,
 		deviceId: deviceIdSchema,
@@ -147,6 +152,42 @@ function resolveParameter(
 						}),
 				}),
 			);
+		}
+		case "instrument": {
+			const track = findTrack(project, target.trackId);
+			if (!track) {
+				return { error: `Track ${target.trackId} does not exist` };
+			}
+			const instrument = track.instrument;
+			if (!instrument) {
+				return { error: `Track ${track.id} has no instrument` };
+			}
+			// Instrument parameters are namespaced by instrument kind, matching how
+			// the domain validates a stored instrument parameter value.
+			const definition = getParameterDefinition(
+				`${instrument.kind}.${target.parameterId}`,
+			);
+			if (!definition) {
+				return {
+					error: `Instrument ${instrument.kind} has no registered parameter "${target.parameterId}"`,
+				};
+			}
+			return {
+				definition,
+				current:
+					instrument.parameters[target.parameterId] ?? definition.defaultValue,
+				write: (value) =>
+					replaceTrack(project, {
+						...track,
+						instrument: {
+							...instrument,
+							parameters: {
+								...instrument.parameters,
+								[target.parameterId]: value,
+							},
+						},
+					}),
+			};
 		}
 		case "send": {
 			const track = findTrack(project, target.trackId);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@
  */
 
 export * from "./definitions/clips";
+export * from "./definitions/instruments";
 export * from "./definitions/notes";
 export * from "./definitions/parameters";
 export * from "./definitions/placements";

--- a/src/commands/instruments.test.ts
+++ b/src/commands/instruments.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	createSynthInstrument,
+	createTrack,
+	type Project,
+	SAMPLER_PITCH,
+} from "../domain";
+import { addTrack, changeInstrument, setParameter, setSample } from ".";
+import { executeCommand } from "./execute";
+import { CommandHistory } from "./history";
+import { findTrack } from "./projectEdits";
+import {
+	ABSENT_IDS,
+	type CommandTestProject,
+	createCommandTestProject,
+	createTestFactoryContext,
+} from "./testProjects";
+
+function apply(
+	project: Project,
+	command: Parameters<typeof executeCommand>[1],
+): Project {
+	const result = executeCommand(project, command);
+	if (!result.ok) {
+		throw new Error(`Expected success: ${result.issues[0].message}`);
+	}
+	return result.project;
+}
+
+describe("instrument parameter scope (parameter.set)", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	it("sets a sampler instrument parameter, coerced by its definition", () => {
+		const next = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "instrument",
+					trackId: fixture.trackAId,
+					parameterId: "pitch",
+				},
+				7,
+			),
+		);
+		const track = findTrack(next, fixture.trackAId);
+		expect(track?.instrument?.parameters.pitch).toBe(7);
+	});
+
+	it("clamps a sampler pitch above its range rather than storing it raw", () => {
+		const next = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "instrument",
+					trackId: fixture.trackAId,
+					parameterId: "pitch",
+				},
+				999,
+			),
+		);
+		const track = findTrack(next, fixture.trackAId);
+		expect(track?.instrument?.parameters.pitch).toBe(SAMPLER_PITCH.max);
+	});
+
+	it("rejects a parameter the instrument kind does not own", () => {
+		const result = executeCommand(
+			fixture.project,
+			// filterCutoff is a synth parameter; trackA is a sampler.
+			setParameter(
+				{
+					scope: "instrument",
+					trackId: fixture.trackAId,
+					parameterId: "filterCutoff",
+				},
+				800,
+			),
+		);
+		expect(result.ok).toBe(false);
+	});
+
+	it("rejects setting an instrument parameter on a track with no instrument", () => {
+		// A fresh track with no instrument at all.
+		const bare = createTrack(createTestFactoryContext("bare-track"), {
+			name: "Bare",
+			order: 2,
+		});
+		const withBare = apply(fixture.project, addTrack(bare));
+		const result = executeCommand(
+			withBare,
+			setParameter(
+				{ scope: "instrument", trackId: bare.id, parameterId: "pitch" },
+				2,
+			),
+		);
+		expect(result.ok).toBe(false);
+	});
+
+	it("rejects an unknown track", () => {
+		const result = executeCommand(
+			fixture.project,
+			setParameter(
+				{
+					scope: "instrument",
+					trackId: ABSENT_IDS.track,
+					parameterId: "pitch",
+				},
+				2,
+			),
+		);
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("instrument.change", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	it("replaces a track's instrument and preserves its clips", () => {
+		const clipsBefore = fixture.project.clips.filter(
+			(clip) => clip.trackId === fixture.trackAId,
+		);
+		const next = apply(
+			fixture.project,
+			changeInstrument(fixture.trackAId, createSynthInstrument()),
+		);
+		const track = findTrack(next, fixture.trackAId);
+		expect(track?.instrument?.kind).toBe("synth");
+		// Clips are separate from the track (invariant 3): swapping the instrument
+		// leaves the note clips authored against it untouched.
+		expect(
+			next.clips.filter((clip) => clip.trackId === fixture.trackAId),
+		).toEqual(clipsBefore);
+	});
+
+	it("round-trips through undo/redo, restoring the exact previous instrument", () => {
+		const history = new CommandHistory(fixture.project);
+		const before = findTrack(history.project, fixture.trackAId)?.instrument;
+
+		history.execute(
+			changeInstrument(fixture.trackAId, createSynthInstrument()),
+		);
+		expect(findTrack(history.project, fixture.trackAId)?.instrument?.kind).toBe(
+			"synth",
+		);
+
+		history.undo();
+		expect(findTrack(history.project, fixture.trackAId)?.instrument).toEqual(
+			before,
+		);
+
+		history.redo();
+		expect(findTrack(history.project, fixture.trackAId)?.instrument?.kind).toBe(
+			"synth",
+		);
+	});
+});
+
+describe("instrument.setSample", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	function samplerAssetId(project: Project): string | null {
+		const instrument = findTrack(project, fixture.trackAId)?.instrument;
+		if (instrument?.kind !== "sampler") throw new Error("expected a sampler");
+		return instrument.assetId;
+	}
+
+	it("replaces the sampler's asset while keeping its other settings", () => {
+		// Give the sampler a distinctive parameter first, so we can prove the swap
+		// preserves it (the "compatible clip data preserved" guarantee).
+		const withPitch = apply(
+			fixture.project,
+			setParameter(
+				{
+					scope: "instrument",
+					trackId: fixture.trackAId,
+					parameterId: "pitch",
+				},
+				5,
+			),
+		);
+		const currentAssetId = samplerAssetId(withPitch);
+		const otherAsset = withPitch.song.assets.find(
+			(asset) => asset.id !== currentAssetId,
+		);
+		expect(otherAsset).toBeDefined();
+
+		const next = apply(
+			withPitch,
+			setSample(fixture.trackAId, otherAsset?.id ?? null),
+		);
+		const instrument = findTrack(next, fixture.trackAId)?.instrument;
+		expect(instrument?.kind).toBe("sampler");
+		if (instrument?.kind === "sampler") {
+			expect(instrument.assetId).toBe(otherAsset?.id ?? null);
+			expect(instrument.parameters.pitch).toBe(5);
+		}
+	});
+
+	it("undo restores the previously loaded sample", () => {
+		const history = new CommandHistory(fixture.project);
+		const originalAsset = samplerAssetId(history.project);
+
+		history.execute(setSample(fixture.trackAId, null));
+		expect(samplerAssetId(history.project)).toBeNull();
+
+		history.undo();
+		expect(samplerAssetId(history.project)).toBe(originalAsset);
+	});
+
+	it("rejects loading a sample into a non-sampler instrument", () => {
+		// trackB is a drum machine.
+		const result = executeCommand(
+			fixture.project,
+			setSample(fixture.trackBId, null),
+		);
+		expect(result.ok).toBe(false);
+	});
+});

--- a/src/commands/inverse.test.ts
+++ b/src/commands/inverse.test.ts
@@ -5,6 +5,7 @@ import {
 	createNoteEvent,
 	createPlacement,
 	createSeededIdFactory,
+	createSynthInstrument,
 	createTrack as createTrackEntity,
 	TICKS_PER_BAR,
 	TICKS_PER_SIXTEENTH,
@@ -16,6 +17,7 @@ import {
 	addNotes,
 	addPlacement,
 	addTrack,
+	changeInstrument,
 	clearNotes,
 	duplicateNotes,
 	quantizeNotes,
@@ -26,6 +28,7 @@ import {
 	reorderTrack,
 	scaleNoteVelocity,
 	setParameter,
+	setSample,
 	setTrackFlag,
 	transposeNotes,
 	updateClip,
@@ -203,6 +206,17 @@ const cases: InverseCase[] = [
 				},
 				-11,
 			),
+	},
+	{
+		type: "instrument.change",
+		// trackA is a sampler; swap it for a synth so the inverse must restore the
+		// full previous sampler instrument, assetId and all.
+		build: (fixture) =>
+			changeInstrument(fixture.trackAId, createSynthInstrument()),
+	},
+	{
+		type: "instrument.setSample",
+		build: (fixture) => setSample(fixture.trackAId, null),
 	},
 ];
 

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -36,6 +36,8 @@ const EXPECTED_COMMANDS = [
 	"placement.delete",
 	"placement.update",
 	"parameter.set",
+	"instrument.change",
+	"instrument.setSample",
 ];
 
 describe("command registry", () => {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,4 +1,5 @@
 import { clipCommands } from "./definitions/clips";
+import { instrumentCommands } from "./definitions/instruments";
 import { noteCommands } from "./definitions/notes";
 import { parameterCommands } from "./definitions/parameters";
 import { placementCommands } from "./definitions/placements";
@@ -26,6 +27,7 @@ const ALL_DEFINITIONS: readonly RegisteredCommand[] = [
 	...trackCommands,
 	...placementCommands,
 	...parameterCommands,
+	...instrumentCommands,
 ];
 
 function buildRegistry(

--- a/src/domain/factories.ts
+++ b/src/domain/factories.ts
@@ -174,6 +174,10 @@ export function createSamplerInstrument(
 	return { kind: "sampler", assetId, parameters: {} };
 }
 
+export function createSynthInstrument(): Instrument {
+	return { kind: "synth", parameters: {} };
+}
+
 export function createDrumPad(
 	context: DomainFactoryContext,
 	options: {

--- a/src/domain/parameters.test.ts
+++ b/src/domain/parameters.test.ts
@@ -1,17 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+	bareParameterId,
 	clampParameterValue,
 	coerceParameterValue,
 	defineParameter,
 	getParameterDefinition,
+	instrumentParameters,
 	isAutomatable,
 	isParameterValueInRange,
 	MASTER_VOLUME,
 	NOTE_VELOCITY,
 	parameterDefinitions,
 	parameterSchemaFor,
+	readInstrumentParameter,
 	requireParameterDefinition,
 	SONG_TEMPO,
+	SYNTH_FILTER_CUTOFF,
+	SYNTH_FILTER_RESONANCE,
+	synthWaveform,
 	TRACK_PAN,
 	TRACK_VOLUME,
 } from "./parameters";
@@ -33,14 +39,28 @@ describe("parameter definitions", () => {
 		expect(MASTER_VOLUME.automatable).toBe(true);
 	});
 
-	it("keeps the registry to the parameters the foundation slice needs", () => {
+	it("registers the foundation slice and LOOP-004 instrument parameters", () => {
 		expect([...parameterDefinitions().keys()].sort()).toEqual([
 			"master.volume",
 			"note.probability",
 			"note.velocity",
 			"return.pan",
 			"return.volume",
+			"sampler.ampAttack",
+			"sampler.ampDecay",
+			"sampler.ampRelease",
+			"sampler.ampSustain",
+			"sampler.pitch",
+			"sampler.sampleEnd",
+			"sampler.sampleStart",
 			"song.tempo",
+			"synth.ampAttack",
+			"synth.ampDecay",
+			"synth.ampRelease",
+			"synth.ampSustain",
+			"synth.filterCutoff",
+			"synth.filterResonance",
+			"synth.waveform",
 			"track.pan",
 			"track.sendLevel",
 			"track.volume",
@@ -164,5 +184,51 @@ describe("parameter definitions", () => {
 		expect(schema.safeParse(0.5).success).toBe(true);
 		expect(schema.safeParse(1.5).success).toBe(false);
 		expect(schema.safeParse(Number.POSITIVE_INFINITY).success).toBe(false);
+	});
+});
+
+describe("instrument parameters (LOOP-004)", () => {
+	it("maps a waveform index onto its oscillator type, clamped in range", () => {
+		expect(synthWaveform(0)).toBe("sine");
+		expect(synthWaveform(2)).toBe("sawtooth");
+		expect(synthWaveform(3)).toBe("triangle");
+		// Out-of-range or fractional indices clamp/round rather than throw.
+		expect(synthWaveform(-1)).toBe("sine");
+		expect(synthWaveform(99)).toBe("triangle");
+		expect(synthWaveform(1.4)).toBe("square");
+	});
+
+	it("reads a stored parameter or falls back to the definition default", () => {
+		expect(readInstrumentParameter(SYNTH_FILTER_CUTOFF, {})).toBe(
+			SYNTH_FILTER_CUTOFF.defaultValue,
+		);
+		expect(
+			readInstrumentParameter(SYNTH_FILTER_CUTOFF, { filterCutoff: 800 }),
+		).toBe(800);
+	});
+
+	it("lists the parameters each instrument kind owns", () => {
+		expect(instrumentParameters("synth").map((p) => p.id)).toContain(
+			"synth.filterResonance",
+		);
+		expect(instrumentParameters("sampler").map((p) => p.id)).toContain(
+			"sampler.sampleEnd",
+		);
+		expect(instrumentParameters("drumMachine")).toEqual([]);
+	});
+
+	it("strips the instrument namespace from a definition id", () => {
+		expect(bareParameterId("synth.filterCutoff")).toBe("filterCutoff");
+		expect(bareParameterId("sampler.pitch")).toBe("pitch");
+		expect(bareParameterId("bare")).toBe("bare");
+	});
+
+	it("declares a resonant filter and a full amp envelope for the synth", () => {
+		expect(SYNTH_FILTER_CUTOFF.unit).toBe("hertz");
+		expect(SYNTH_FILTER_CUTOFF.automatable).toBe(true);
+		expect(SYNTH_FILTER_RESONANCE.automatable).toBe(true);
+		for (const stage of instrumentParameters("synth")) {
+			expect(isParameterValueInRange(stage, stage.defaultValue)).toBe(true);
+		}
 	});
 });

--- a/src/domain/parameters.ts
+++ b/src/domain/parameters.ts
@@ -197,6 +197,250 @@ export const NOTE_PROBABILITY = register({
 	automatable: false,
 });
 
+// --- Instrument parameters (LOOP-004, PRD INS-01) --------------------------
+//
+// Synth and one-shot sampler parameters. Registered here (not repeated at the
+// UI, command, or audio layers) so a control, its validation, and the audio
+// engine all read one definition. Namespaced by instrument kind — `synth.*`
+// and `sampler.*` — the same way device parameters are namespaced by device
+// type, so `parse.ts` and the `parameter.set` command look them up by
+// `${instrument.kind}.${parameterId}`.
+//
+// The fuller instrument in the design mocks (sub-oscillator, pulse-width,
+// multi-mode filter, key tracking, fine tune, gain/pan, envelope hold, a
+// per-sampler filter) is the INS-01 *deferred* set (P1/P2) and is not
+// registered here.
+
+/**
+ * Oscillator waveform, stored as a small integer index rather than a string so
+ * it fits the numeric-only parameter model. `SYNTH_WAVEFORMS` maps the index to
+ * the Tone oscillator type; the option group in the UI reads the same list.
+ */
+export const SYNTH_WAVEFORMS = [
+	"sine",
+	"square",
+	"sawtooth",
+	"triangle",
+] as const;
+export type SynthWaveform = (typeof SYNTH_WAVEFORMS)[number];
+
+export const SYNTH_WAVEFORM = register({
+	id: "synth.waveform",
+	label: "Waveform",
+	unit: "normalized",
+	min: 0,
+	max: SYNTH_WAVEFORMS.length - 1,
+	defaultValue: 2, // sawtooth
+	step: 1,
+	clampPolicy: "reject",
+	automatable: false,
+});
+
+/** Maps a stored waveform index onto its oscillator type, clamped in range. */
+export function synthWaveform(index: number): SynthWaveform {
+	const clamped = Math.min(
+		SYNTH_WAVEFORMS.length - 1,
+		Math.max(0, Math.round(index)),
+	);
+	return SYNTH_WAVEFORMS[clamped];
+}
+
+/** Amp-envelope attack/decay/release share one range across synth and sampler. */
+const ENVELOPE_TIME = {
+	unit: "seconds",
+	min: 0,
+	max: 4,
+	scale: "logarithmic",
+	automatable: false,
+} as const;
+
+export const SYNTH_AMP_ATTACK = register({
+	id: "synth.ampAttack",
+	label: "Attack",
+	...ENVELOPE_TIME,
+	defaultValue: 0.005,
+});
+
+export const SYNTH_AMP_DECAY = register({
+	id: "synth.ampDecay",
+	label: "Decay",
+	...ENVELOPE_TIME,
+	defaultValue: 0.18,
+});
+
+export const SYNTH_AMP_SUSTAIN = register({
+	id: "synth.ampSustain",
+	label: "Sustain",
+	unit: "normalized",
+	min: 0,
+	max: 1,
+	defaultValue: 0.6,
+	automatable: false,
+});
+
+export const SYNTH_AMP_RELEASE = register({
+	id: "synth.ampRelease",
+	label: "Release",
+	...ENVELOPE_TIME,
+	defaultValue: 0.22,
+});
+
+export const SYNTH_FILTER_CUTOFF = register({
+	id: "synth.filterCutoff",
+	label: "Cutoff",
+	unit: "hertz",
+	min: 20,
+	max: 20_000,
+	defaultValue: 12_000,
+	scale: "logarithmic",
+	automatable: true,
+});
+
+/**
+ * Resonant low-pass filter Q. The upper bound is finite but deliberately
+ * generous so the classic self-resonant sweep is reachable (AUD/INS "extreme
+ * but finite" ranges).
+ */
+export const SYNTH_FILTER_RESONANCE = register({
+	id: "synth.filterResonance",
+	label: "Resonance",
+	unit: "normalized",
+	min: 0,
+	max: 20,
+	defaultValue: 1,
+	automatable: true,
+});
+
+export const SAMPLER_PITCH = register({
+	id: "sampler.pitch",
+	label: "Pitch",
+	unit: "semitones",
+	min: -24,
+	max: 24,
+	defaultValue: 0,
+	step: 1,
+	automatable: false,
+});
+
+/**
+ * Sample start and end as a normalized position in the buffer (0..1). The end
+ * defaults to 1 (the whole sample); the audio engine reads the material between
+ * them and the domain rejects an end that is not strictly after the start.
+ */
+export const SAMPLER_SAMPLE_START = register({
+	id: "sampler.sampleStart",
+	label: "Start",
+	unit: "normalized",
+	min: 0,
+	max: 1,
+	defaultValue: 0,
+	automatable: false,
+});
+
+export const SAMPLER_SAMPLE_END = register({
+	id: "sampler.sampleEnd",
+	label: "End",
+	unit: "normalized",
+	min: 0,
+	max: 1,
+	defaultValue: 1,
+	automatable: false,
+});
+
+export const SAMPLER_AMP_ATTACK = register({
+	id: "sampler.ampAttack",
+	label: "Attack",
+	...ENVELOPE_TIME,
+	defaultValue: 0.001,
+});
+
+export const SAMPLER_AMP_DECAY = register({
+	id: "sampler.ampDecay",
+	label: "Decay",
+	...ENVELOPE_TIME,
+	defaultValue: 0.1,
+});
+
+export const SAMPLER_AMP_SUSTAIN = register({
+	id: "sampler.ampSustain",
+	label: "Sustain",
+	unit: "normalized",
+	min: 0,
+	max: 1,
+	defaultValue: 1,
+	automatable: false,
+});
+
+export const SAMPLER_AMP_RELEASE = register({
+	id: "sampler.ampRelease",
+	label: "Release",
+	...ENVELOPE_TIME,
+	defaultValue: 0.2,
+});
+
+/** Every synth parameter, in panel order. Keyed by its full `synth.*` id. */
+export const SYNTH_PARAMETERS: readonly ParameterDefinition[] = [
+	SYNTH_WAVEFORM,
+	SYNTH_AMP_ATTACK,
+	SYNTH_AMP_DECAY,
+	SYNTH_AMP_SUSTAIN,
+	SYNTH_AMP_RELEASE,
+	SYNTH_FILTER_CUTOFF,
+	SYNTH_FILTER_RESONANCE,
+];
+
+/** Every sampler parameter, in panel order. Keyed by its full `sampler.*` id. */
+export const SAMPLER_PARAMETERS: readonly ParameterDefinition[] = [
+	SAMPLER_PITCH,
+	SAMPLER_SAMPLE_START,
+	SAMPLER_SAMPLE_END,
+	SAMPLER_AMP_ATTACK,
+	SAMPLER_AMP_DECAY,
+	SAMPLER_AMP_SUSTAIN,
+	SAMPLER_AMP_RELEASE,
+];
+
+/**
+ * The registered parameter definitions an instrument of `kind` owns. The
+ * `parameter.set` command and `parse.ts` both use this to reject a parameter a
+ * given instrument does not own without repeating the list.
+ */
+export function instrumentParameters(
+	kind: "synth" | "sampler" | "drumMachine",
+): readonly ParameterDefinition[] {
+	switch (kind) {
+		case "synth":
+			return SYNTH_PARAMETERS;
+		case "sampler":
+			return SAMPLER_PARAMETERS;
+		case "drumMachine":
+			// Per-pad drum parameters are authored by LOOP-005; the machine itself
+			// exposes none at this layer yet.
+			return [];
+	}
+}
+
+/**
+ * Reads one instrument parameter's stored value, falling back to the
+ * definition's default when the sparse parameter map omits it. Parameter ids
+ * here are the bare `attack`/`cutoff`-style keys stored in `parameters`, not the
+ * namespaced definition id.
+ */
+export function readInstrumentParameter(
+	definition: ParameterDefinition,
+	parameters: Readonly<Record<string, number>>,
+): number {
+	const key = bareParameterId(definition.id);
+	const stored = parameters[key];
+	return stored === undefined ? definition.defaultValue : stored;
+}
+
+/** Strips the `synth.`/`sampler.` namespace from a definition id. */
+export function bareParameterId(id: string): string {
+	const dot = id.indexOf(".");
+	return dot === -1 ? id : id.slice(dot + 1);
+}
+
 /** Every parameter registered so far, keyed by parameter ID. */
 export function parameterDefinitions(): ReadonlyMap<
 	string,

--- a/src/domain/parse.test.ts
+++ b/src/domain/parse.test.ts
@@ -54,8 +54,10 @@ interface MutableTrack extends JsonRecord {
 	sendConfig: (JsonRecord & { returnId: string })[];
 	instrument:
 		| (JsonRecord & {
+				kind?: string;
 				assetId?: string | null;
 				pads?: MutableDrumPad[];
+				parameters?: Record<string, number>;
 		  })
 		| null;
 	mixer: JsonRecord & { volume: number };
@@ -380,6 +382,42 @@ describe("parseProject", () => {
 		outOfRangeLane.points = [{ tick: 0, value: 40 }];
 		outOfRange.song.automation = [outOfRangeLane];
 		expectIssue(parseProject(outOfRange), "invalid_parameter");
+	});
+
+	it("rejects an instrument parameter outside its declared range", () => {
+		const input = baseProject();
+		const sampler = input.song.tracks.find(
+			(track) => track.instrument?.kind === "sampler",
+		);
+		if (!sampler?.instrument) throw new Error("fixture has no sampler track");
+		// SAMPLER_PITCH is -24..24 semitones; 99 is out of range.
+		sampler.instrument.parameters = { pitch: 99 };
+		expectIssue(parseProject(input), "invalid_parameter");
+	});
+
+	it("accepts in-range instrument parameters", () => {
+		const input = baseProject();
+		const sampler = input.song.tracks.find(
+			(track) => track.instrument?.kind === "sampler",
+		);
+		if (!sampler?.instrument) throw new Error("fixture has no sampler track");
+		sampler.instrument.parameters = {
+			pitch: 5,
+			sampleStart: 0.1,
+			sampleEnd: 0.8,
+			ampAttack: 0.01,
+		};
+		expect(parseProject(input).ok).toBe(true);
+	});
+
+	it("rejects a sample window whose end is not after its start", () => {
+		const input = baseProject();
+		const sampler = input.song.tracks.find(
+			(track) => track.instrument?.kind === "sampler",
+		);
+		if (!sampler?.instrument) throw new Error("fixture has no sampler track");
+		sampler.instrument.parameters = { sampleStart: 0.6, sampleEnd: 0.6 };
+		expectIssue(parseProject(input), "invalid_parameter");
 	});
 
 	it("rejects inconsistent project metadata", () => {

--- a/src/domain/parse.ts
+++ b/src/domain/parse.ts
@@ -12,7 +12,13 @@ import {
 	songSchema,
 	type Track,
 } from "./entities";
-import { getParameterDefinition, isParameterValueInRange } from "./parameters";
+import {
+	bareParameterId,
+	getParameterDefinition,
+	isParameterValueInRange,
+	SAMPLER_SAMPLE_END,
+	SAMPLER_SAMPLE_START,
+} from "./parameters";
 
 /**
  * Parsing and cross-entity integrity (PRD section 9.5).
@@ -516,13 +522,37 @@ function checkInstrument(
 	if (!instrument) {
 		return issues;
 	}
-	if (instrument.kind === "sampler" && instrument.assetId !== null) {
-		if (!assetIds.has(instrument.assetId)) {
+	// Every stored instrument parameter is validated against its registered
+	// definition (invariant 10), the same way device parameters are — namespaced
+	// by instrument kind, `${kind}.${parameterId}`.
+	issues.push(
+		...checkInstrumentParameters(instrument.kind, instrument.parameters, [
+			...path,
+			"instrument",
+			"parameters",
+		]),
+	);
+	if (instrument.kind === "sampler") {
+		if (instrument.assetId !== null && !assetIds.has(instrument.assetId)) {
 			issues.push(
 				issue(
 					"dangling_reference",
 					[...path, "instrument", "assetId"],
 					`Track ${track.id} references missing asset ${instrument.assetId}`,
+				),
+			);
+		}
+		// A sample window collapses to silence — or plays backwards — unless its
+		// end is strictly after its start.
+		const start =
+			instrument.parameters[bareParameterId(SAMPLER_SAMPLE_START.id)];
+		const end = instrument.parameters[bareParameterId(SAMPLER_SAMPLE_END.id)];
+		if (start !== undefined && end !== undefined && end <= start) {
+			issues.push(
+				issue(
+					"invalid_parameter",
+					[...path, "instrument", "parameters", "sampleEnd"],
+					`Sample end ${end} must be greater than sample start ${start}`,
 				),
 			);
 		}
@@ -541,6 +571,28 @@ function checkInstrument(
 				);
 			}
 		});
+	}
+	return issues;
+}
+
+/** Validates a sparse instrument parameter map against its registered definitions. */
+function checkInstrumentParameters(
+	kind: NonNullable<Track["instrument"]>["kind"],
+	parameters: Readonly<Record<string, number>>,
+	path: ReadonlyArray<string | number>,
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	for (const [parameterId, value] of Object.entries(parameters)) {
+		const definition = getParameterDefinition(`${kind}.${parameterId}`);
+		if (definition && !isParameterValueInRange(definition, value)) {
+			issues.push(
+				issue(
+					"invalid_parameter",
+					[...path, parameterId],
+					`Value ${value} is outside the declared range ${definition.min}..${definition.max}`,
+				),
+			);
+		}
 	}
 	return issues;
 }

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -88,6 +88,26 @@ describe("EditorView", () => {
 		expect(screen.getByRole("button", { name: "Undo" })).toBeDisabled();
 	});
 
+	it("shows the sampler instrument panel for the slice's sampler track", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+
+		renderEditor(project.metadata.id);
+
+		expect(
+			await screen.findByRole("region", { name: "Sampler" }),
+		).toBeInTheDocument();
+		// The INS-01 sampler controls: pitch, sample start/end, amp envelope.
+		expect(screen.getByLabelText("Pitch")).toBeInTheDocument();
+		expect(screen.getByLabelText("Start")).toBeInTheDocument();
+		expect(screen.getByLabelText("End")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Audition" }),
+		).toBeInTheDocument();
+	});
+
 	it("toggling a step enables undo, and undo reverts it", async () => {
 		repository = inMemoryModule.createInMemoryProjectRepository();
 		const project = createSliceFixtureProject();

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -22,8 +22,11 @@ import { clampTempo, MAX_TEMPO_BPM, MIN_TEMPO_BPM } from "../audio/Transport";
 import { setParameter } from "../commands/definitions/parameters";
 import ProjectNotFound from "../components/ProjectNotFound";
 import TapeLoader from "../components/TapeLoader";
+import type { NoteTrigger } from "../domain/entities";
 import { SONG_TEMPO } from "../domain/parameters";
-import { formatBarsBeatsSixteenths } from "../domain/time";
+import { formatBarsBeatsSixteenths, TICKS_PER_QUARTER } from "../domain/time";
+import SamplerPanel, { type SampleChoice } from "../instrument/SamplerPanel";
+import SynthPanel from "../instrument/SynthPanel";
 import type { SaveFailureReason } from "../persistence/projectRepository";
 import { getProjectRepository } from "../projectRepositoryClient";
 import type { ShortcutContext, ShortcutHandlers } from "../shortcuts";
@@ -157,6 +160,52 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 			currentProject.clips.find((c) => c.trackId === currentTrack.id) ?? null
 		);
 	});
+
+	// The instrument of the slice's first track, and the audition note it plays.
+	const instrument = createMemo(() => track()?.instrument ?? null);
+	// The track id, only when it carries an instrument this slice renders a panel
+	// for (sampler or synth). The drum machine's panel lands with LOOP-005.
+	const instrumentPanelTrackId = createMemo(() => {
+		const kind = instrument()?.kind;
+		return kind === "sampler" || kind === "synth"
+			? (track()?.id ?? null)
+			: null;
+	});
+	const AUDITION_PITCH = 60; // Middle C
+	const AUDITION_DURATION_TICKS = TICKS_PER_QUARTER;
+	function auditionInstrument(): void {
+		const currentTrack = track();
+		const currentInstrument = instrument();
+		if (!currentTrack || !currentInstrument) return;
+		const trigger: NoteTrigger =
+			currentInstrument.kind === "drumMachine" &&
+			currentInstrument.pads.length > 0
+				? { kind: "pad", padId: currentInstrument.pads[0].id }
+				: { kind: "pitch", pitch: AUDITION_PITCH };
+		void audio.auditionTrack(
+			currentTrack.id,
+			trigger,
+			AUDITION_DURATION_TICKS,
+			0.9,
+		);
+	}
+
+	// Samples the sampler panel can swap to: every `sample`-kind asset the
+	// project already carries. A richer, genre-filtered browser lands with
+	// LOOP-013; here it is a straight list of the project's own samples.
+	const sampleName = createMemo(() => {
+		const current = instrument();
+		if (current?.kind !== "sampler" || !current.assetId) return null;
+		return (
+			project()?.song.assets.find((asset) => asset.id === current.assetId)
+				?.name ?? null
+		);
+	});
+	const replacementOptions = createMemo<readonly SampleChoice[]>(() =>
+		(project()?.song.assets ?? [])
+			.filter((asset) => asset.kind === "sample")
+			.map((asset) => ({ assetId: asset.id, name: asset.name })),
+	);
 
 	const packDependencyLabel = createMemo(() => {
 		const dependency = project()?.metadata.packDependencies[0];
@@ -383,6 +432,50 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 												clip={currentClip()}
 												dispatch={session.dispatch}
 											/>
+											<Show when={instrumentPanelTrackId()}>
+												{(trackId) => (
+													<Switch>
+														<Match
+															when={
+																instrument()?.kind === "sampler" &&
+																(instrument() as Extract<
+																	NonNullable<ReturnType<typeof instrument>>,
+																	{ kind: "sampler" }
+																>)
+															}
+														>
+															{(sampler) => (
+																<SamplerPanel
+																	trackId={trackId()}
+																	instrument={sampler()}
+																	sampleName={sampleName()}
+																	replacementOptions={replacementOptions()}
+																	dispatch={session.dispatch}
+																	audition={auditionInstrument}
+																/>
+															)}
+														</Match>
+														<Match
+															when={
+																instrument()?.kind === "synth" &&
+																(instrument() as Extract<
+																	NonNullable<ReturnType<typeof instrument>>,
+																	{ kind: "synth" }
+																>)
+															}
+														>
+															{(synth) => (
+																<SynthPanel
+																	trackId={trackId()}
+																	instrument={synth()}
+																	dispatch={session.dispatch}
+																	audition={auditionInstrument}
+																/>
+															)}
+														</Match>
+													</Switch>
+												)}
+											</Show>
 										</div>
 									)}
 								</Show>

--- a/src/editor/useProjectAudio.test.ts
+++ b/src/editor/useProjectAudio.test.ts
@@ -259,4 +259,56 @@ describe("useProjectAudio", () => {
 		expect(afterDispose.byType.schedule ?? 0).toBe(0);
 		expect(afterDispose.byType.subscription ?? 0).toBe(0);
 	});
+
+	it("auditionTrack unlocks the context and resolves true on a loaded project", async () => {
+		const { analytics } = fakeAnalytics();
+		let resumed = 0;
+		const runtime = unreachableAudioHost(() => {
+			resumed += 1;
+			return Promise.resolve();
+		});
+		const { result } = renderHook(
+			() =>
+				useProjectAudioModule.useProjectAudio(() => null, {
+					runtime,
+					analytics,
+				}),
+			{},
+		);
+
+		const played = await result.auditionTrack(
+			"trk_any" as never,
+			{ kind: "pitch", pitch: 60 },
+			192,
+			0.9,
+		);
+		// The audition is a user gesture: it resumes the shared context exactly once
+		// and reports success even when the graph has no such track (a no-op play).
+		expect(played).toBe(true);
+		expect(resumed).toBe(1);
+	});
+
+	it("auditionTrack reports audio_start_failed and resolves false when blocked", async () => {
+		const { analytics, transport } = fakeAnalytics();
+		const runtime = unreachableAudioHost(() =>
+			Promise.reject(new Error("NotAllowedError: blocked")),
+		);
+		const { result } = renderHook(
+			() =>
+				useProjectAudioModule.useProjectAudio(() => null, {
+					runtime,
+					analytics,
+				}),
+			{},
+		);
+
+		const played = await result.auditionTrack(
+			"trk_any" as never,
+			{ kind: "pitch", pitch: 60 },
+			192,
+			0.9,
+		);
+		expect(played).toBe(false);
+		expect(transport.named("audio_start_failed")).toHaveLength(1);
+	});
 });

--- a/src/editor/useProjectAudio.ts
+++ b/src/editor/useProjectAudio.ts
@@ -12,7 +12,8 @@ import {
 	TransportMetronome,
 } from "../audio/Transport";
 import { UnderrunMonitor } from "../audio/underrun";
-import type { Project } from "../domain/entities";
+import type { NoteTrigger, Project } from "../domain/entities";
+import type { TrackId } from "../domain/ids";
 import { TICKS_PER_BAR } from "../domain/time";
 import { CodedError, codeFor, reportError } from "../monitoring/errorReporting";
 import {
@@ -45,6 +46,19 @@ export interface ProjectAudioControls {
 	setLoop(startTicks: number, endTicks: number): void;
 	toggleLoop(): void;
 	toggleMetronome(): void;
+	/**
+	 * Plays one note through a track's instrument for auditioning (PRD INS-01).
+	 * Resumes the shared context behind the calling user gesture, then triggers
+	 * the sound through the track's own chain. Resolves whether a note was
+	 * triggered; a browser-blocked unlock reports `audio_start_failed` and
+	 * resolves `false`, like `play()`.
+	 */
+	auditionTrack(
+		trackId: TrackId,
+		trigger: NoteTrigger,
+		durationTicks: number,
+		velocity: number,
+	): Promise<boolean>;
 }
 
 export interface UseProjectAudioOptions {
@@ -339,6 +353,27 @@ export function useProjectAudio(
 		setMetronomeEnabled(transport?.metronomeEnabled ?? false);
 	}
 
+	async function auditionTrack(
+		trackId: TrackId,
+		trigger: NoteTrigger,
+		durationTicks: number,
+		velocity: number,
+	): Promise<boolean> {
+		try {
+			await resumeWithinTimeout();
+			graph?.auditionTrack(trackId, trigger, durationTicks, velocity);
+			return true;
+		} catch (error) {
+			const code = codeFor(error);
+			analytics.log("audio_start_failed", {
+				error_code: code,
+				was_browser_blocked: code === "autoplay_blocked",
+			});
+			reportError(error, { area: "audio", fatal: false, code });
+			return false;
+		}
+	}
+
 	return {
 		isPlaying,
 		positionTicks,
@@ -354,5 +389,6 @@ export function useProjectAudio(
 		setLoop: setLoopRange,
 		toggleLoop,
 		toggleMetronome,
+		auditionTrack,
 	};
 }

--- a/src/instrument/FillSlider.css
+++ b/src/instrument/FillSlider.css
@@ -1,0 +1,102 @@
+/* The vertical fill-slider from design mock 06c-slider: label above, live
+   value below, a thumbless accent fill track between. Fixed 48px width; sliders
+   sequence horizontally and never stack. */
+
+.fill-slider {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	width: 48px;
+	gap: 6px;
+}
+
+.fill-slider-label {
+	font-size: var(--font-size-tiny);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-foreground);
+	white-space: nowrap;
+}
+
+.fill-slider-track {
+	position: relative;
+	width: 22px;
+	height: 120px;
+	background-color: var(--color-background);
+	overflow: hidden;
+}
+
+/* The filled portion IS the value, growing from the bottom. Resting sliders use
+   the muted accent; the touched (focused/hovered) one uses the bright accent. */
+.fill-slider-fill {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: color-mix(
+		in srgb,
+		var(--color-accent, #20c8e8) 55%,
+		#1b6b7a
+	);
+	pointer-events: none;
+}
+
+.fill-slider-track:hover .fill-slider-fill,
+.fill-slider-track:focus-within .fill-slider-fill {
+	background-color: var(--color-accent, #20c8e8);
+}
+
+/* The real range input, restyled to an invisible thumbless overlay so the fill
+   div reads the value visually while the input carries keyboard + a11y. */
+.fill-slider-input {
+	position: absolute;
+	inset: 0;
+	width: 120px;
+	height: 22px;
+	/* Rotate a horizontal range so up = more, keeping native arrow-key semantics
+	   (Up/Right increases). The track is 22x120; the rotated input fills it. */
+	transform: rotate(-90deg);
+	transform-origin: 60px 60px;
+	margin: 0;
+	background: transparent;
+	cursor: ns-resize;
+	appearance: none;
+	-webkit-appearance: none;
+}
+
+.fill-slider-input:focus-visible {
+	outline: 2px solid var(--color-accent, #20c8e8);
+	outline-offset: 2px;
+}
+
+.fill-slider-input::-webkit-slider-thumb {
+	appearance: none;
+	-webkit-appearance: none;
+	width: 22px;
+	height: 6px;
+	background: transparent;
+	cursor: ns-resize;
+}
+
+.fill-slider-input::-moz-range-thumb {
+	width: 22px;
+	height: 6px;
+	border: none;
+	background: transparent;
+	cursor: ns-resize;
+}
+
+.fill-slider-input::-webkit-slider-runnable-track {
+	background: transparent;
+}
+
+.fill-slider-input::-moz-range-track {
+	background: transparent;
+}
+
+.fill-slider-value {
+	font-size: var(--font-size-small);
+	color: var(--color-text);
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+}

--- a/src/instrument/FillSlider.tsx
+++ b/src/instrument/FillSlider.tsx
@@ -1,0 +1,83 @@
+import { createMemo, type JSX } from "solid-js";
+import {
+	clampParameterValue,
+	type ParameterDefinition,
+} from "../domain/parameters";
+import "./FillSlider.css";
+
+export interface FillSliderProps {
+	readonly definition: ParameterDefinition;
+	readonly value: number;
+	/** Formatted live value shown under the slider (e.g. "760 Hz"). */
+	readonly displayValue: string;
+	/** Called with a coerced, in-range value while dragging. */
+	onInput(value: number): void;
+	/** Called once when the drag/keyboard gesture commits. */
+	onCommit(value: number): void;
+}
+
+/**
+ * The one continuous control (design mock `06c-slider`): a thumbless vertical
+ * fill track with its label above and live value below. The filled portion *is*
+ * the value; dragging up/down maps directly onto the fill.
+ *
+ * It is a real `<input type="range">` underneath — so it is keyboard-operable
+ * and screen-reader labelled for free — visually restyled to a fill track. The
+ * range's own `step` follows the parameter definition, so a stepped parameter
+ * (pitch in semitones, waveform index) snaps and a continuous one (cutoff) does
+ * not.
+ *
+ * `onInput` fires per movement so the audio graph can follow live; `onCommit`
+ * fires once when the gesture ends, which is where the caller opens/closes a
+ * single history gesture so a drag is one undo step and emits nothing per tick.
+ */
+export default function FillSlider(props: FillSliderProps): JSX.Element {
+	const fillPercent = createMemo(() => {
+		const { min, max } = props.definition;
+		const span = max - min;
+		if (span <= 0) return 0;
+		return ((props.value - min) / span) * 100;
+	});
+
+	const coerce = (raw: number): number =>
+		clampParameterValue(props.definition, raw);
+
+	return (
+		<div class="fill-slider">
+			<label class="fill-slider-label" for={inputId(props.definition.id)}>
+				{props.definition.label}
+			</label>
+			<div class="fill-slider-track">
+				<div
+					class="fill-slider-fill"
+					style={{ height: `${fillPercent()}%` }}
+					aria-hidden="true"
+				/>
+				<input
+					id={inputId(props.definition.id)}
+					class="fill-slider-input"
+					type="range"
+					// A vertical orientation for pointer and arrow-key semantics.
+					aria-orientation="vertical"
+					min={props.definition.min}
+					max={props.definition.max}
+					step={props.definition.step ?? "any"}
+					value={props.value}
+					onInput={(event) =>
+						props.onInput(coerce(event.currentTarget.valueAsNumber))
+					}
+					onChange={(event) =>
+						props.onCommit(coerce(event.currentTarget.valueAsNumber))
+					}
+				/>
+			</div>
+			<output class="fill-slider-value" for={inputId(props.definition.id)}>
+				{props.displayValue}
+			</output>
+		</div>
+	);
+}
+
+function inputId(parameterId: string): string {
+	return `fill-slider-${parameterId.replace(/\./g, "-")}`;
+}

--- a/src/instrument/InstrumentPanel.css
+++ b/src/instrument/InstrumentPanel.css
@@ -1,0 +1,73 @@
+/* Synth and sampler panels (mocks 05a/05b). Flat, square, single cyan accent;
+   regions separate by elevation tint, not borders. */
+
+.instrument-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 12px;
+	background-color: var(--color-background-secondary);
+}
+
+.instrument-panel-groups {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	align-items: flex-start;
+}
+
+.instrument-panel-group {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 10px;
+	background-color: var(--color-background-highlight);
+	min-width: 0;
+}
+
+.instrument-panel-heading {
+	margin: 0;
+	font-size: var(--font-size-tiny);
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-foreground);
+	font-weight: 600;
+}
+
+.instrument-panel-slider-row {
+	display: flex;
+	gap: 10px;
+	align-items: flex-end;
+}
+
+.sampler-sample-name {
+	margin: 0;
+	font-size: var(--font-size-base);
+	color: var(--color-text);
+}
+
+.sampler-load-select,
+.instrument-panel-audition {
+	height: 30px;
+	padding: 0 12px;
+	background-color: var(--color-background-tertiary);
+	color: var(--color-text);
+	border: none;
+	font-size: var(--font-size-small);
+	cursor: pointer;
+}
+
+.sampler-load-select:hover,
+.instrument-panel-audition:hover {
+	background-color: var(--color-background-hover);
+}
+
+.instrument-panel-audition {
+	align-self: flex-start;
+	color: var(--color-accent, #20c8e8);
+}
+
+.instrument-panel-audition:hover {
+	background-color: var(--color-accent, #20c8e8);
+	color: var(--color-background);
+}

--- a/src/instrument/OptionGroup.css
+++ b/src/instrument/OptionGroup.css
@@ -1,0 +1,62 @@
+/* Labelled option group from mocks 05a/05b: stacked mutually-exclusive choices,
+   the active one carrying the cyan accent. Square corners, flat surfaces. */
+
+.option-group {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin: 0;
+	padding: 0;
+	border: none;
+	min-width: 0;
+}
+
+.option-group-option {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	height: 30px;
+	padding: 0 10px;
+	background-color: var(--color-background-tertiary);
+	color: var(--color-text-secondary);
+	cursor: pointer;
+	user-select: none;
+}
+
+.option-group-option:hover {
+	background-color: var(--color-background-hover);
+}
+
+.option-group-option.active {
+	background-color: var(--color-accent, #20c8e8);
+	color: var(--color-background);
+}
+
+/* The radio itself is a visually-hidden a11y/keyboard anchor; the label is the
+   control. Keep it focusable so arrow keys and focus rings still work. */
+.option-group-input {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.option-group-option:focus-within {
+	outline: 2px solid var(--color-accent, #20c8e8);
+	outline-offset: 1px;
+}
+
+.option-group-icon {
+	display: inline-flex;
+	align-items: center;
+}
+
+.option-group-text {
+	font-size: var(--font-size-small);
+	letter-spacing: 0.02em;
+}

--- a/src/instrument/OptionGroup.tsx
+++ b/src/instrument/OptionGroup.tsx
@@ -1,0 +1,56 @@
+import { For, type JSX } from "solid-js";
+import "./OptionGroup.css";
+
+export interface OptionGroupOption<V extends string | number> {
+	readonly value: V;
+	readonly label: string;
+	/** A small decorative glyph (e.g. a waveform icon) shown before the label. */
+	readonly icon?: JSX.Element;
+}
+
+export interface OptionGroupProps<V extends string | number> {
+	/** Accessible group name, e.g. "Waveform". */
+	readonly legend: string;
+	readonly options: readonly OptionGroupOption<V>[];
+	readonly value: V;
+	onSelect(value: V): void;
+}
+
+/**
+ * A labelled option group (design mocks `05a`/`05b`): a vertical list of
+ * mutually exclusive choices, the active one carrying the cyan accent. Built as
+ * a radio group so exactly one is selected and arrow keys move between options.
+ */
+export default function OptionGroup<V extends string | number>(
+	props: OptionGroupProps<V>,
+): JSX.Element {
+	return (
+		<fieldset class="option-group" aria-label={props.legend}>
+			<For each={props.options}>
+				{(option) => {
+					const selected = () => option.value === props.value;
+					return (
+						<label
+							class="option-group-option"
+							classList={{ active: selected() }}
+						>
+							<input
+								type="radio"
+								class="option-group-input"
+								name={`option-group-${props.legend}`}
+								checked={selected()}
+								onChange={() => props.onSelect(option.value)}
+							/>
+							{option.icon ? (
+								<span class="option-group-icon" aria-hidden="true">
+									{option.icon}
+								</span>
+							) : null}
+							<span class="option-group-text">{option.label}</span>
+						</label>
+					);
+				}}
+			</For>
+		</fieldset>
+	);
+}

--- a/src/instrument/SamplerPanel.test.tsx
+++ b/src/instrument/SamplerPanel.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import type { Instrument } from "../domain/entities";
+import type { AssetId, TrackId } from "../domain/ids";
+import { memoryStorage } from "../testing/storage";
+import SamplerPanel, { type SampleChoice } from "./SamplerPanel";
+
+afterEach(() => cleanup());
+
+const TRACK_ID = "trk_sampler" as TrackId;
+const ASSET_A = "ast_a" as AssetId;
+const ASSET_B = "ast_b" as AssetId;
+
+const OPTIONS: SampleChoice[] = [
+	{ assetId: ASSET_A, name: "Clap" },
+	{ assetId: ASSET_B, name: "Snare" },
+];
+
+function renderPanel(
+	instrument: Extract<Instrument, { kind: "sampler" }> = {
+		kind: "sampler",
+		assetId: ASSET_A,
+		parameters: {},
+	},
+) {
+	const dispatch = vi.fn<
+		(
+			commands: RawCommandInput | readonly RawCommandInput[],
+		) => TransactionResult | undefined
+	>(() => ({ ok: true }) as TransactionResult);
+	const audition = vi.fn();
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+	analytics.setAccountType("anonymous");
+	render(() => (
+		<SamplerPanel
+			trackId={TRACK_ID}
+			instrument={instrument}
+			sampleName="Clap"
+			replacementOptions={OPTIONS}
+			dispatch={dispatch}
+			audition={audition}
+			analytics={analytics}
+		/>
+	));
+	return { dispatch, audition, transport };
+}
+
+describe("SamplerPanel", () => {
+	it("renders the sample name, playback, and amp-envelope sliders", () => {
+		renderPanel();
+		expect(screen.getByText("Clap", { selector: "p" })).toBeInTheDocument();
+		expect(screen.getByLabelText("Pitch")).toBeInTheDocument();
+		expect(screen.getByLabelText("Start")).toBeInTheDocument();
+		expect(screen.getByLabelText("End")).toBeInTheDocument();
+		expect(screen.getByLabelText("Attack")).toBeInTheDocument();
+	});
+
+	it("dispatches an instrument parameter.set once when a slider commits", () => {
+		const { dispatch, transport } = renderPanel();
+		const pitch = screen.getByLabelText("Pitch") as HTMLInputElement;
+		fireEvent.input(pitch, { target: { value: "5" } });
+		fireEvent.change(pitch, { target: { value: "5" } });
+
+		expect(dispatch).toHaveBeenCalledTimes(1);
+		const command = dispatch.mock.calls[0][0] as {
+			type: string;
+			payload: { target: { scope: string; parameterId: string } };
+		};
+		expect(command.type).toBe("parameter.set");
+		expect(command.payload.target.scope).toBe("instrument");
+		expect(command.payload.target.parameterId).toBe("pitch");
+		// No instrument_changed for a plain parameter edit.
+		expect(transport.named("instrument_changed")).toHaveLength(0);
+	});
+
+	it("replacing the sample dispatches instrument.setSample and emits instrument_changed once", () => {
+		const { dispatch, transport } = renderPanel();
+		const select = screen.getByRole("combobox") as HTMLSelectElement;
+		fireEvent.change(select, { target: { value: ASSET_B } });
+
+		const command = dispatch.mock.calls.at(-1)?.[0] as {
+			type: string;
+			payload: { assetId: string };
+		};
+		expect(command.type).toBe("instrument.setSample");
+		expect(command.payload.assetId).toBe(ASSET_B);
+
+		const changed = transport.named("instrument_changed");
+		expect(changed).toHaveLength(1);
+		expect(changed[0].params.instrument_type).toBe("sampler");
+		expect(
+			transport
+				.named("feature_first_use")
+				.filter((e) => e.params.feature === "sampler"),
+		).toHaveLength(1);
+	});
+
+	it("does not emit instrument_changed when the sample swap is rejected", () => {
+		const dispatch = vi.fn<
+			(
+				commands: RawCommandInput | readonly RawCommandInput[],
+			) => TransactionResult | undefined
+		>(() => ({ ok: false, issues: [] }) as unknown as TransactionResult);
+		const transport = createRecordingTransport();
+		const consent = new ConsentStore(memoryStorage());
+		const analytics = new Analytics({
+			transport,
+			consent,
+			storage: memoryStorage(),
+		});
+		analytics.setAccountType("anonymous");
+		render(() => (
+			<SamplerPanel
+				trackId={TRACK_ID}
+				instrument={{ kind: "sampler", assetId: ASSET_A, parameters: {} }}
+				sampleName="Clap"
+				replacementOptions={OPTIONS}
+				dispatch={dispatch}
+				audition={vi.fn()}
+				analytics={analytics}
+			/>
+		));
+		fireEvent.change(screen.getByRole("combobox"), {
+			target: { value: ASSET_B },
+		});
+		expect(transport.named("instrument_changed")).toHaveLength(0);
+	});
+
+	it("emits nothing per input tick before a slider commits", () => {
+		const { dispatch, transport } = renderPanel();
+		const pitch = screen.getByLabelText("Pitch") as HTMLInputElement;
+		fireEvent.input(pitch, { target: { value: "1" } });
+		fireEvent.input(pitch, { target: { value: "2" } });
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(transport.events).toHaveLength(0);
+	});
+
+	it("auditions on the audition button", () => {
+		const { audition } = renderPanel();
+		fireEvent.click(screen.getByRole("button", { name: "Audition" }));
+		expect(audition).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/instrument/SamplerPanel.tsx
+++ b/src/instrument/SamplerPanel.tsx
@@ -1,0 +1,166 @@
+import { For, type JSX, Show } from "solid-js";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import { setParameter, setSample } from "../commands";
+import type { Instrument } from "../domain/entities";
+import type { AssetId, TrackId } from "../domain/ids";
+import {
+	bareParameterId,
+	readInstrumentParameter,
+	SAMPLER_AMP_ATTACK,
+	SAMPLER_AMP_DECAY,
+	SAMPLER_AMP_RELEASE,
+	SAMPLER_AMP_SUSTAIN,
+	SAMPLER_PITCH,
+	SAMPLER_SAMPLE_END,
+	SAMPLER_SAMPLE_START,
+} from "../domain/parameters";
+import FillSlider from "./FillSlider";
+import { formatInstrumentValue } from "./formatValue";
+import "./InstrumentPanel.css";
+
+/** A sample the user can load into the sampler (from the project's assets). */
+export interface SampleChoice {
+	readonly assetId: AssetId;
+	readonly name: string;
+}
+
+export interface SamplerPanelProps {
+	readonly trackId: TrackId;
+	readonly instrument: Extract<Instrument, { kind: "sampler" }>;
+	/** Display name of the currently loaded sample, or null when empty. */
+	readonly sampleName: string | null;
+	/** Samples the user can swap to (a real browser lands with LOOP-013). */
+	readonly replacementOptions: readonly SampleChoice[];
+	dispatch(
+		commands: RawCommandInput | readonly RawCommandInput[],
+	): TransactionResult | undefined;
+	audition(): void;
+	readonly analytics?: Analytics;
+}
+
+const PLAYBACK_SLIDERS = [
+	SAMPLER_PITCH,
+	SAMPLER_SAMPLE_START,
+	SAMPLER_SAMPLE_END,
+];
+
+const ENVELOPE_SLIDERS = [
+	SAMPLER_AMP_ATTACK,
+	SAMPLER_AMP_DECAY,
+	SAMPLER_AMP_SUSTAIN,
+	SAMPLER_AMP_RELEASE,
+];
+
+/**
+ * The reusable one-shot sampler panel (PRD INS-01, mock `05b-sampler`): sample
+ * selection + audition, and fill-sliders for pitch, sample start/end, and the
+ * amp envelope (ADSR).
+ *
+ * Parameter edits dispatch a validated `parameter.set` in the `instrument`
+ * scope; a sample swap dispatches `instrument.setSample`, whose inverse restores
+ * the previous asset so replacement is undoable and preserves the rest of the
+ * sampler's settings. Replacing the sample emits `instrument_changed`
+ * (`sampler`) and the `sampler` `feature_first_use` key. A continuous slider
+ * commits once per gesture, so a drag is one command and emits nothing per tick.
+ */
+export default function SamplerPanel(props: SamplerPanelProps): JSX.Element {
+	const analytics = () => props.analytics ?? defaultAnalytics;
+
+	function commit(parameterId: string, value: number): void {
+		props.dispatch(
+			setParameter(
+				{ scope: "instrument", trackId: props.trackId, parameterId },
+				value,
+			),
+		);
+		analytics().logFeatureFirstUse("sampler");
+	}
+
+	function replaceSample(assetId: AssetId): void {
+		if (assetId === props.instrument.assetId) return;
+		const result = props.dispatch(setSample(props.trackId, assetId));
+		if (!result?.ok) return;
+		analytics().log("instrument_changed", { instrument_type: "sampler" });
+		analytics().logFeatureFirstUse("sampler");
+	}
+
+	return (
+		<section class="instrument-panel sampler-panel" aria-label="Sampler">
+			<div class="instrument-panel-groups">
+				<div class="instrument-panel-group">
+					<h3 class="instrument-panel-heading">Sample</h3>
+					<p class="sampler-sample-name">
+						{props.sampleName ?? "No sample loaded"}
+					</p>
+					<Show when={props.replacementOptions.length > 0}>
+						<label class="sampler-load">
+							<span class="visually-hidden">Load sample</span>
+							<select
+								class="sampler-load-select"
+								value={props.instrument.assetId ?? ""}
+								onChange={(event) => {
+									const value = event.currentTarget.value;
+									if (value) replaceSample(value as AssetId);
+								}}
+							>
+								<option value="" disabled>
+									Load…
+								</option>
+								<For each={props.replacementOptions}>
+									{(choice) => (
+										<option value={choice.assetId}>{choice.name}</option>
+									)}
+								</For>
+							</select>
+						</label>
+					</Show>
+				</div>
+				<div class="instrument-panel-group instrument-panel-sliders">
+					<h3 class="instrument-panel-heading">Playback</h3>
+					<div class="instrument-panel-slider-row">
+						<For each={PLAYBACK_SLIDERS}>
+							{(definition) => sliderFor(definition)}
+						</For>
+					</div>
+				</div>
+				<div class="instrument-panel-group instrument-panel-sliders">
+					<h3 class="instrument-panel-heading">Amp Envelope</h3>
+					<div class="instrument-panel-slider-row">
+						<For each={ENVELOPE_SLIDERS}>
+							{(definition) => sliderFor(definition)}
+						</For>
+					</div>
+				</div>
+			</div>
+			<button
+				type="button"
+				class="instrument-panel-audition"
+				onClick={() => props.audition()}
+			>
+				Audition
+			</button>
+		</section>
+	);
+
+	function sliderFor(
+		definition: (typeof PLAYBACK_SLIDERS)[number],
+	): JSX.Element {
+		const value = () =>
+			readInstrumentParameter(definition, props.instrument.parameters);
+		return (
+			<FillSlider
+				definition={definition}
+				value={value()}
+				displayValue={formatInstrumentValue(definition, value())}
+				onInput={() => {
+					/* live audio follows on commit; nothing per tick */
+				}}
+				onCommit={(next) => commit(bareParameterId(definition.id), next)}
+			/>
+		);
+	}
+}

--- a/src/instrument/SynthPanel.test.tsx
+++ b/src/instrument/SynthPanel.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import type { Instrument } from "../domain/entities";
+import type { TrackId } from "../domain/ids";
+import { memoryStorage } from "../testing/storage";
+import SynthPanel from "./SynthPanel";
+
+afterEach(() => cleanup());
+
+const TRACK_ID = "trk_synth" as TrackId;
+
+function renderPanel(
+	instrument: Extract<Instrument, { kind: "synth" }> = {
+		kind: "synth",
+		parameters: {},
+	},
+) {
+	const dispatch = vi.fn<
+		(
+			commands: RawCommandInput | readonly RawCommandInput[],
+		) => TransactionResult | undefined
+	>(() => ({ ok: true }) as TransactionResult);
+	const audition = vi.fn();
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+	analytics.setAccountType("anonymous");
+	render(() => (
+		<SynthPanel
+			trackId={TRACK_ID}
+			instrument={instrument}
+			dispatch={dispatch}
+			audition={audition}
+			analytics={analytics}
+		/>
+	));
+	return { dispatch, audition, transport };
+}
+
+describe("SynthPanel", () => {
+	it("renders the oscillator waveforms and amp/filter sliders", () => {
+		renderPanel();
+		expect(screen.getByRole("group", { name: "Waveform" })).toBeInTheDocument();
+		// Amp ADSR + filter cutoff/resonance are the six fill-sliders.
+		expect(screen.getByLabelText("Attack")).toBeInTheDocument();
+		expect(screen.getByLabelText("Cutoff")).toBeInTheDocument();
+		expect(screen.getByLabelText("Resonance")).toBeInTheDocument();
+	});
+
+	it("dispatches a validated instrument parameter.set when a slider commits", () => {
+		const { dispatch } = renderPanel();
+		const cutoff = screen.getByLabelText("Cutoff") as HTMLInputElement;
+		fireEvent.input(cutoff, { target: { value: "5000" } });
+		fireEvent.change(cutoff, { target: { value: "5000" } });
+
+		// Exactly one command, on commit — not one per input tick.
+		expect(dispatch).toHaveBeenCalledTimes(1);
+		const command = dispatch.mock.calls[0][0] as {
+			type: string;
+			payload: {
+				target: { scope: string; parameterId: string };
+				value: number;
+			};
+		};
+		expect(command.type).toBe("parameter.set");
+		expect(command.payload.target.scope).toBe("instrument");
+		expect(command.payload.target.parameterId).toBe("filterCutoff");
+	});
+
+	it("selecting a waveform dispatches its index", () => {
+		const { dispatch } = renderPanel();
+		fireEvent.click(screen.getByRole("radio", { name: /Square/ }));
+		const command = dispatch.mock.calls.at(-1)?.[0] as {
+			payload: { target: { parameterId: string }; value: number };
+		};
+		expect(command.payload.target.parameterId).toBe("waveform");
+		expect(command.payload.value).toBe(1); // square is index 1
+	});
+
+	it("emits the synth feature_first_use exactly once across many edits", () => {
+		const { transport } = renderPanel();
+		const cutoff = screen.getByLabelText("Cutoff") as HTMLInputElement;
+		for (const value of ["2000", "3000", "4000"]) {
+			fireEvent.input(cutoff, { target: { value } });
+			fireEvent.change(cutoff, { target: { value } });
+		}
+		expect(
+			transport
+				.named("feature_first_use")
+				.filter((e) => e.params.feature === "synth"),
+		).toHaveLength(1);
+	});
+
+	it("emits nothing per input tick before the gesture commits", () => {
+		const { dispatch, transport } = renderPanel();
+		const cutoff = screen.getByLabelText("Cutoff") as HTMLInputElement;
+		// Three moves, no commit yet.
+		fireEvent.input(cutoff, { target: { value: "1000" } });
+		fireEvent.input(cutoff, { target: { value: "2000" } });
+		fireEvent.input(cutoff, { target: { value: "3000" } });
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(transport.events).toHaveLength(0);
+	});
+
+	it("auditions on the audition button", () => {
+		const { audition } = renderPanel();
+		fireEvent.click(screen.getByRole("button", { name: "Audition" }));
+		expect(audition).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/instrument/SynthPanel.tsx
+++ b/src/instrument/SynthPanel.tsx
@@ -1,0 +1,142 @@
+import { For, type JSX } from "solid-js";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import { setParameter } from "../commands";
+import type { Instrument } from "../domain/entities";
+import type { TrackId } from "../domain/ids";
+import {
+	bareParameterId,
+	readInstrumentParameter,
+	SYNTH_AMP_ATTACK,
+	SYNTH_AMP_DECAY,
+	SYNTH_AMP_RELEASE,
+	SYNTH_AMP_SUSTAIN,
+	SYNTH_FILTER_CUTOFF,
+	SYNTH_FILTER_RESONANCE,
+	SYNTH_WAVEFORM,
+	SYNTH_WAVEFORMS,
+	synthWaveform,
+} from "../domain/parameters";
+import FillSlider from "./FillSlider";
+import { formatInstrumentValue } from "./formatValue";
+import "./InstrumentPanel.css";
+import OptionGroup from "./OptionGroup";
+import { WaveformIcon } from "./waveformIcons";
+
+export interface SynthPanelProps {
+	readonly trackId: TrackId;
+	readonly instrument: Extract<Instrument, { kind: "synth" }>;
+	dispatch(
+		commands: RawCommandInput | readonly RawCommandInput[],
+	): TransactionResult | undefined;
+	/** Plays one preview note through the track. */
+	audition(): void;
+	/** Defaults to the application singleton; injectable for tests. */
+	readonly analytics?: Analytics;
+}
+
+const SLIDERS = [
+	SYNTH_AMP_ATTACK,
+	SYNTH_AMP_DECAY,
+	SYNTH_AMP_SUSTAIN,
+	SYNTH_AMP_RELEASE,
+	SYNTH_FILTER_CUTOFF,
+	SYNTH_FILTER_RESONANCE,
+];
+
+/**
+ * The reusable synth voice panel (PRD INS-01, mock `05a-synth-voice`): an
+ * oscillator waveform option group and vertical fill-sliders for the amp
+ * envelope (ADSR) and the resonant low-pass filter (cutoff, resonance).
+ *
+ * Every control dispatches a validated `parameter.set` command in the
+ * `instrument` scope — never a direct project mutation — so edits are
+ * revision-checked and undoable, and the audio graph reuses its nodes with
+ * smoothing. A continuous slider commits once per gesture (on release/blur), so
+ * a drag is one command, one history entry, and emits nothing per tick;
+ * `feature_first_use` for `synth` fires once, on the first edit, not per render.
+ */
+export default function SynthPanel(props: SynthPanelProps): JSX.Element {
+	const analytics = () => props.analytics ?? defaultAnalytics;
+
+	function commit(parameterId: string, value: number): void {
+		props.dispatch(
+			setParameter(
+				{ scope: "instrument", trackId: props.trackId, parameterId },
+				value,
+			),
+		);
+		analytics().logFeatureFirstUse("synth");
+	}
+
+	const currentWaveform = () =>
+		synthWaveform(
+			readInstrumentParameter(SYNTH_WAVEFORM, props.instrument.parameters),
+		);
+
+	return (
+		<section class="instrument-panel synth-panel" aria-label="Synth voice">
+			<div class="instrument-panel-groups">
+				<div class="instrument-panel-group">
+					<h3 class="instrument-panel-heading">Oscillator</h3>
+					<OptionGroup
+						legend="Waveform"
+						value={currentWaveform()}
+						options={SYNTH_WAVEFORMS.map((waveform) => ({
+							value: waveform,
+							label: capitalize(waveform),
+							icon: <WaveformIcon waveform={waveform} />,
+						}))}
+						onSelect={(waveform) =>
+							commit(
+								bareParameterId(SYNTH_WAVEFORM.id),
+								SYNTH_WAVEFORMS.indexOf(waveform),
+							)
+						}
+					/>
+				</div>
+				<div class="instrument-panel-group instrument-panel-sliders">
+					<h3 class="instrument-panel-heading">Amp &amp; Filter</h3>
+					<div class="instrument-panel-slider-row">
+						<For each={SLIDERS}>
+							{(definition) => {
+								const value = () =>
+									readInstrumentParameter(
+										definition,
+										props.instrument.parameters,
+									);
+								return (
+									<FillSlider
+										definition={definition}
+										value={value()}
+										displayValue={formatInstrumentValue(definition, value())}
+										onInput={() => {
+											/* live audio follows on commit; nothing per tick */
+										}}
+										onCommit={(next) =>
+											commit(bareParameterId(definition.id), next)
+										}
+									/>
+								);
+							}}
+						</For>
+					</div>
+				</div>
+			</div>
+			<button
+				type="button"
+				class="instrument-panel-audition"
+				onClick={() => props.audition()}
+			>
+				Audition
+			</button>
+		</section>
+	);
+}
+
+function capitalize(text: string): string {
+	return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/src/instrument/formatValue.test.ts
+++ b/src/instrument/formatValue.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	SAMPLER_PITCH,
+	SAMPLER_SAMPLE_START,
+	SYNTH_AMP_ATTACK,
+	SYNTH_AMP_SUSTAIN,
+	SYNTH_FILTER_CUTOFF,
+	SYNTH_WAVEFORM,
+} from "../domain/parameters";
+import { formatInstrumentValue } from "./formatValue";
+
+describe("formatInstrumentValue", () => {
+	it("reads a waveform index as its name", () => {
+		expect(formatInstrumentValue(SYNTH_WAVEFORM, 0)).toBe("Sine");
+		expect(formatInstrumentValue(SYNTH_WAVEFORM, 2)).toBe("Sawtooth");
+	});
+
+	it("shows frequency in Hz below 1k and kHz above", () => {
+		expect(formatInstrumentValue(SYNTH_FILTER_CUTOFF, 760)).toBe("760 Hz");
+		expect(formatInstrumentValue(SYNTH_FILTER_CUTOFF, 8400)).toBe("8.4 kHz");
+	});
+
+	it("shows small envelope times in ms", () => {
+		expect(formatInstrumentValue(SYNTH_AMP_ATTACK, 0.006)).toBe("6 ms");
+	});
+
+	it("shows a signed semitone pitch", () => {
+		expect(formatInstrumentValue(SAMPLER_PITCH, 7)).toBe("+7 st");
+		expect(formatInstrumentValue(SAMPLER_PITCH, -3)).toBe("-3 st");
+		expect(formatInstrumentValue(SAMPLER_PITCH, 0)).toBe("0 st");
+	});
+
+	it("shows a normalized 0..1 parameter as a percent", () => {
+		expect(formatInstrumentValue(SAMPLER_SAMPLE_START, 0.25)).toBe("25%");
+		expect(formatInstrumentValue(SYNTH_AMP_SUSTAIN, 0.6)).toBe("60%");
+	});
+});

--- a/src/instrument/formatValue.ts
+++ b/src/instrument/formatValue.ts
@@ -1,0 +1,51 @@
+import {
+	type ParameterDefinition,
+	SYNTH_WAVEFORM,
+	synthWaveform,
+} from "../domain/parameters";
+
+/**
+ * Human-readable value for one instrument parameter, in its own unit — the
+ * "live value below" line of a fill-slider (design mock `06c`). Small envelope
+ * times read in milliseconds, frequencies switch to kHz past 1000, the
+ * waveform index reads as its name, and semitone pitch carries a sign.
+ */
+export function formatInstrumentValue(
+	definition: ParameterDefinition,
+	value: number,
+): string {
+	if (definition.id === SYNTH_WAVEFORM.id) {
+		return capitalize(synthWaveform(value));
+	}
+	switch (definition.unit) {
+		case "hertz":
+			return value >= 1000
+				? `${trim(value / 1000, 1)} kHz`
+				: `${Math.round(value)} Hz`;
+		case "seconds":
+			return value < 1
+				? `${Math.round(value * 1000)} ms`
+				: `${trim(value, 2)} s`;
+		case "semitones": {
+			const rounded = Math.round(value);
+			return `${rounded > 0 ? "+" : ""}${rounded} st`;
+		}
+		case "decibels":
+			return `${trim(value, 1)} dB`;
+		case "normalized":
+			// Sustain and resonance are dimensionless; start/end read as a percent.
+			return definition.max <= 1
+				? `${Math.round(value * 100)}%`
+				: trim(value, 2);
+		default:
+			return trim(value, 2);
+	}
+}
+
+function trim(value: number, places: number): string {
+	return String(Number(value.toFixed(places)));
+}
+
+function capitalize(text: string): string {
+	return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/src/instrument/waveformIcons.tsx
+++ b/src/instrument/waveformIcons.tsx
@@ -1,0 +1,28 @@
+import type { JSX } from "solid-js";
+import type { SynthWaveform } from "../domain/parameters";
+
+/** Small decorative waveform glyphs for the oscillator option group (mock 05a). */
+export function WaveformIcon(props: { waveform: SynthWaveform }): JSX.Element {
+	const path = () => WAVEFORM_PATHS[props.waveform];
+	return (
+		<svg
+			width="24"
+			height="16"
+			viewBox="0 0 24 16"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.5"
+			aria-hidden="true"
+		>
+			<title>{props.waveform}</title>
+			<path d={path()} />
+		</svg>
+	);
+}
+
+const WAVEFORM_PATHS: Record<SynthWaveform, string> = {
+	sine: "M1 8 Q6 1 11 8 T21 8",
+	square: "M1 12 V4 H8 V12 H15 V4 H22",
+	sawtooth: "M1 12 L8 4 L8 12 L15 4 L15 12 L22 4",
+	triangle: "M1 12 L6 4 L12 12 L18 4 L23 12",
+};


### PR DESCRIPTION
## Summary

Implements the INS-01 alpha synth and one-shot sampler as reusable graph/UI slices — parameters, validated commands, real audio voices, and the panel UI, wired into the editor with audition.

- **Domain**: registers the synth (oscillator waveform, amp ADSR, resonant low-pass cutoff/resonance) and sampler (pitch, sample start/end, amp ADSR) parameters once in `src/domain/parameters.ts`, namespaced by instrument kind, and validates stored instrument parameters (plus a sample start<end invariant) in `parse.ts`.
- **Commands**: adds an `instrument` scope to `parameter.set`, plus two new registered commands — `instrument.change` and `instrument.setSample` — with generated inverses, so control edits and sample replacement are undoable and clip data survives instrument swaps.
- **Audio**: rebuilds the `InstrumentGraph` synth voice (PolySynth + resonant `Tone.Filter`) and sampler voice (playback-rate pitch, start/end windowing, per-trigger amp envelope). Parameter edits reuse nodes with click-free ramped smoothing; a sample swap cancels the stale decode via the buffer cache's generation tracking. Adds `ProjectAudioGraph.auditionTrack`, exposed through `useProjectAudio`.
- **UI**: reusable `FillSlider`, `OptionGroup`, `SynthPanel`, and `SamplerPanel` under `src/instrument`, following the design mocks' vertical fill-slider and labelled option-group language, wired into `EditorView` with audition.
- **Analytics**: emits `instrument_changed` (`instrument_type`) on sample replacement and the `synth`/`sampler` `feature_first_use` keys; continuous slider gestures commit once and emit nothing per tick. Pins the two new command ids in the analytics catalog.

## PRD requirements

Implements **INS-01 — Electronic instruments (P0)** ([`docs/prd.md`](../blob/main/docs/prd.md#L341)). The design-mock controls called out as post-alpha in the PRD note (sub-oscillator, pulse-width, multi-mode filter, filter envelope amount, key tracking, sampler fine tune/gain/pan/envelope hold/per-sampler filter) are explicitly out of scope for this alpha baseline and deferred to P1/P2 (tracked in `docs/backlog.md`).

## Acceptance criteria met

- [x] Controls dispatch validated commands and parameter changes reuse nodes with safe smoothing.
- [x] Sample replacement cancels stale loads and preserves compatible clip data through undo/redo.
- [x] Audio fixtures test parameter extremes, repeated triggers, cache ownership, export compatibility, and disposal.
- [x] Emits `instrument_changed` with `instrument_type` and the `synth` and `sampler` `feature_first_use` keys. Continuous parameter gestures emit nothing per tick.

This branch passed an Opus review round in the implementation workflow.

Closes #44

---
_Generated by [Claude Code](https://claude.ai/code)_
