### PR TITLE
LOOP-008 (2/4): device and routing command family

### DIFF
--- a/src/analytics/catalog.ts
+++ b/src/analytics/catalog.ts
@@ -193,6 +193,13 @@ export const COMMAND_IDS = [
 	"drum.reorderPad",
 	"instrument.change",
 	"instrument.setSample",
+	"device.add",
+	"device.remove",
+	"device.reorder",
+	"device.duplicate",
+	"device.setBypass",
+	"device.reset",
+	"device.restoreParameters",
 ] as const;
 export type CommandId = (typeof COMMAND_IDS)[number];
 

--- a/src/commands/definitions/deviceChains.ts
+++ b/src/commands/definitions/deviceChains.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import {
+	type ReturnId,
+	returnIdSchema,
+	type TrackId,
+	trackIdSchema,
+} from "../../domain/ids";
+
+/**
+ * Which insert chain a device command targets (PRD FX-01, LOOP-008).
+ *
+ * A device lives in exactly one of three kinds of chain — a track's inserts, a
+ * return bus's chain, or the master chain — and the `chain` discriminant maps
+ * one-to-one onto the `device_added` analytics `chain` parameter. It is shared
+ * by every device command so the chain a device belongs to is expressed once.
+ */
+export const chainTargetSchema = z.discriminatedUnion("chain", [
+	z.strictObject({ chain: z.literal("insert"), trackId: trackIdSchema }),
+	z.strictObject({ chain: z.literal("return"), returnId: returnIdSchema }),
+	z.strictObject({ chain: z.literal("master") }),
+]);
+export type DeviceChainTarget = z.infer<typeof chainTargetSchema>;
+
+export const insertChain = (trackId: TrackId): DeviceChainTarget => ({
+	chain: "insert",
+	trackId,
+});
+
+export const returnChain = (returnId: ReturnId): DeviceChainTarget => ({
+	chain: "return",
+	returnId,
+});
+
+export const masterChain: DeviceChainTarget = { chain: "master" };

--- a/src/commands/definitions/devices.ts
+++ b/src/commands/definitions/devices.ts
@@ -1,0 +1,463 @@
+import { z } from "zod";
+import { defaultDeviceParameters } from "../../domain/devices";
+import { type Device, deviceSchema, type Project } from "../../domain/entities";
+import { type DeviceId, deviceIdSchema } from "../../domain/ids";
+import { MAX_TRACK_INSERTS } from "../../domain/parse";
+import { byOrder, findTrack, renumber, withSong } from "../projectEdits";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+import { chainTargetSchema, type DeviceChainTarget } from "./deviceChains";
+
+/**
+ * Device lifecycle commands for every insert chain — a track's inserts, a
+ * return bus's chain, or the master chain (PRD FX-01, LOOP-008).
+ *
+ * A device is added, removed, reordered, duplicated, bypassed, and reset
+ * through these commands, so every mutation shares the command layer's
+ * validation, atomic transaction, generated inverse, and one-revision history.
+ * Payloads carry explicit device IDs for anything they create, so replay,
+ * redo, and an assistant preview reproduce the same graph. Only the eight-insert
+ * ceiling is a command-level guard here (a friendlier message than the parse
+ * failure); every other invariant is left to `checkProjectIntegrity`, which
+ * `executeTransaction` runs on the working copy.
+ */
+
+// --- Generic chain read/write ---------------------------------------------
+
+/** Reads the device array a chain target points at, or `undefined` if it is gone. */
+function readChain(
+	project: Project,
+	target: DeviceChainTarget,
+): readonly Device[] | undefined {
+	switch (target.chain) {
+		case "insert":
+			return findTrack(project, target.trackId)?.devices;
+		case "return":
+			return project.song.returns.find((bus) => bus.id === target.returnId)
+				?.devices;
+		case "master":
+			return project.song.master.devices;
+	}
+}
+
+/** Writes a new device array into the chain the target names. */
+function writeChain(
+	project: Project,
+	target: DeviceChainTarget,
+	devices: readonly Device[],
+): Project {
+	switch (target.chain) {
+		case "insert": {
+			const track = findTrack(project, target.trackId);
+			if (!track) return project;
+			return withSong(project, {
+				...project.song,
+				tracks: project.song.tracks.map((candidate) =>
+					candidate.id === track.id
+						? { ...candidate, devices: [...devices] }
+						: candidate,
+				),
+			});
+		}
+		case "return":
+			return withSong(project, {
+				...project.song,
+				returns: project.song.returns.map((bus) =>
+					bus.id === target.returnId ? { ...bus, devices: [...devices] } : bus,
+				),
+			});
+		case "master":
+			return withSong(project, {
+				...project.song,
+				master: { ...project.song.master, devices: [...devices] },
+			});
+	}
+}
+
+function chainMissingMessage(target: DeviceChainTarget): string {
+	switch (target.chain) {
+		case "insert":
+			return `Track ${target.trackId} does not exist`;
+		case "return":
+			return `Return bus ${target.returnId} does not exist`;
+		case "master":
+			return "The master chain does not exist";
+	}
+}
+
+// --- Payloads --------------------------------------------------------------
+
+export const deviceAddPayloadSchema = z.strictObject({
+	target: chainTargetSchema,
+	device: deviceSchema,
+});
+export type DeviceAddPayload = z.infer<typeof deviceAddPayloadSchema>;
+
+export const deviceRemovePayloadSchema = z.strictObject({
+	target: chainTargetSchema,
+	deviceId: deviceIdSchema,
+});
+export type DeviceRemovePayload = z.infer<typeof deviceRemovePayloadSchema>;
+
+export const deviceReorderPayloadSchema = z.strictObject({
+	target: chainTargetSchema,
+	deviceId: deviceIdSchema,
+	toIndex: z.int().min(0),
+});
+export type DeviceReorderPayload = z.infer<typeof deviceReorderPayloadSchema>;
+
+export const deviceDuplicatePayloadSchema = z.strictObject({
+	target: chainTargetSchema,
+	deviceId: deviceIdSchema,
+	newDeviceId: deviceIdSchema,
+});
+export type DeviceDuplicatePayload = z.infer<
+	typeof deviceDuplicatePayloadSchema
+>;
+
+export const deviceSetBypassPayloadSchema = z.strictObject({
+	target: chainTargetSchema,
+	deviceId: deviceIdSchema,
+	bypassed: z.boolean(),
+});
+export type DeviceSetBypassPayload = z.infer<
+	typeof deviceSetBypassPayloadSchema
+>;
+
+export const deviceResetPayloadSchema = z.strictObject({
+	target: chainTargetSchema,
+	deviceId: deviceIdSchema,
+});
+export type DeviceResetPayload = z.infer<typeof deviceResetPayloadSchema>;
+
+// --- Commands --------------------------------------------------------------
+
+export const deviceAddCommand = defineCommand<DeviceAddPayload>({
+	type: "device.add",
+	version: 1,
+	schema: deviceAddPayloadSchema,
+	summarize: (payload) => `Add ${payload.device.type} device`,
+	apply(project, payload) {
+		const devices = readChain(project, payload.target);
+		if (!devices) return rejected(chainMissingMessage(payload.target));
+		if (devices.some((device) => device.id === payload.device.id)) {
+			return rejected(`Device ${payload.device.id} already exists`);
+		}
+		if (
+			payload.target.chain === "insert" &&
+			devices.length >= MAX_TRACK_INSERTS
+		) {
+			return rejected(
+				`A track may have at most ${MAX_TRACK_INSERTS} insert devices`,
+			);
+		}
+		const sorted = byOrder(devices);
+		if (payload.device.order > sorted.length) {
+			return rejected(
+				`Cannot insert a device at position ${payload.device.order} of ${sorted.length}`,
+			);
+		}
+		const next = renumber([
+			...sorted.slice(0, payload.device.order),
+			payload.device,
+			...sorted.slice(payload.device.order),
+		]);
+		return applied(writeChain(project, payload.target, next));
+	},
+	invert: (payload) => [removeDevice(payload.target, payload.device.id)],
+});
+
+export const deviceRemoveCommand = defineCommand<DeviceRemovePayload>({
+	type: "device.remove",
+	version: 1,
+	schema: deviceRemovePayloadSchema,
+	summarize: () => "Remove device",
+	apply(project, payload) {
+		const devices = readChain(project, payload.target);
+		if (!devices) return rejected(chainMissingMessage(payload.target));
+		if (!devices.some((device) => device.id === payload.deviceId)) {
+			return rejected(`Device ${payload.deviceId} does not exist`);
+		}
+		const next = renumber(
+			byOrder(devices).filter((device) => device.id !== payload.deviceId),
+		);
+		return applied(writeChain(project, payload.target, next));
+	},
+	invert(payload, before) {
+		const device = readChain(before, payload.target)?.find(
+			(candidate) => candidate.id === payload.deviceId,
+		);
+		return device ? [addDevice(payload.target, device)] : [];
+	},
+});
+
+export const deviceReorderCommand = defineCommand<DeviceReorderPayload>({
+	type: "device.reorder",
+	version: 1,
+	schema: deviceReorderPayloadSchema,
+	summarize: (payload) => `Move device to position ${payload.toIndex + 1}`,
+	apply(project, payload) {
+		const devices = readChain(project, payload.target);
+		if (!devices) return rejected(chainMissingMessage(payload.target));
+		const sorted = byOrder(devices);
+		const from = sorted.findIndex((device) => device.id === payload.deviceId);
+		if (from < 0) return rejected(`Device ${payload.deviceId} does not exist`);
+		if (payload.toIndex >= sorted.length) {
+			return rejected(
+				`Cannot move a device to position ${payload.toIndex} of ${sorted.length}`,
+			);
+		}
+		const moved = sorted[from];
+		const without = sorted.filter((_, index) => index !== from);
+		const next = renumber([
+			...without.slice(0, payload.toIndex),
+			moved,
+			...without.slice(payload.toIndex),
+		]);
+		return applied(writeChain(project, payload.target, next));
+	},
+	invert(payload, before) {
+		const device = readChain(before, payload.target)?.find(
+			(candidate) => candidate.id === payload.deviceId,
+		);
+		return device
+			? [reorderDevice(payload.target, payload.deviceId, device.order)]
+			: [];
+	},
+});
+
+export const deviceDuplicateCommand = defineCommand<DeviceDuplicatePayload>({
+	type: "device.duplicate",
+	version: 1,
+	schema: deviceDuplicatePayloadSchema,
+	summarize: () => "Duplicate device",
+	apply(project, payload) {
+		const devices = readChain(project, payload.target);
+		if (!devices) return rejected(chainMissingMessage(payload.target));
+		const source = devices.find((device) => device.id === payload.deviceId);
+		if (!source) return rejected(`Device ${payload.deviceId} does not exist`);
+		if (devices.some((device) => device.id === payload.newDeviceId)) {
+			return rejected(`Device ${payload.newDeviceId} already exists`);
+		}
+		if (
+			payload.target.chain === "insert" &&
+			devices.length >= MAX_TRACK_INSERTS
+		) {
+			return rejected(
+				`A track may have at most ${MAX_TRACK_INSERTS} insert devices`,
+			);
+		}
+		// A deep, independent copy placed immediately after the source, carrying
+		// the same parameters, bypass state, and preset provenance.
+		const copy: Device = {
+			...source,
+			id: payload.newDeviceId,
+			order: source.order + 1,
+			parameters: { ...source.parameters },
+			preset: source.preset ? { ...source.preset } : null,
+		};
+		const sorted = byOrder(devices);
+		const at = sorted.findIndex((device) => device.id === source.id) + 1;
+		const next = renumber([...sorted.slice(0, at), copy, ...sorted.slice(at)]);
+		return applied(writeChain(project, payload.target, next));
+	},
+	invert: (payload) => [removeDevice(payload.target, payload.newDeviceId)],
+});
+
+export const deviceSetBypassCommand = defineCommand<DeviceSetBypassPayload>({
+	type: "device.setBypass",
+	version: 1,
+	schema: deviceSetBypassPayloadSchema,
+	summarize: (payload) =>
+		payload.bypassed ? "Bypass device" : "Enable device",
+	apply(project, payload) {
+		const devices = readChain(project, payload.target);
+		if (!devices) return rejected(chainMissingMessage(payload.target));
+		if (!devices.some((device) => device.id === payload.deviceId)) {
+			return rejected(`Device ${payload.deviceId} does not exist`);
+		}
+		const next = devices.map((device) =>
+			device.id === payload.deviceId
+				? { ...device, bypassed: payload.bypassed }
+				: device,
+		);
+		return applied(writeChain(project, payload.target, next));
+	},
+	invert(payload, before) {
+		const device = readChain(before, payload.target)?.find(
+			(candidate) => candidate.id === payload.deviceId,
+		);
+		return device
+			? [setDeviceBypass(payload.target, payload.deviceId, device.bypassed)]
+			: [];
+	},
+});
+
+export const deviceResetCommand = defineCommand<DeviceResetPayload>({
+	type: "device.reset",
+	version: 1,
+	schema: deviceResetPayloadSchema,
+	summarize: () => "Reset device",
+	apply(project, payload) {
+		const devices = readChain(project, payload.target);
+		if (!devices) return rejected(chainMissingMessage(payload.target));
+		const device = devices.find((entry) => entry.id === payload.deviceId);
+		if (!device) return rejected(`Device ${payload.deviceId} does not exist`);
+		// Reset restores factory parameter values but preserves the device's
+		// place, bypass state, and preset provenance — it is a "back to default
+		// tone", not a delete-and-recreate.
+		const next = devices.map((entry) =>
+			entry.id === device.id
+				? { ...entry, parameters: defaultDeviceParameters(entry.type) }
+				: entry,
+		);
+		return applied(writeChain(project, payload.target, next));
+	},
+	invert(payload, before) {
+		const device = readChain(before, payload.target)?.find(
+			(candidate) => candidate.id === payload.deviceId,
+		);
+		return device
+			? [
+					restoreDeviceParameters(
+						payload.target,
+						payload.deviceId,
+						device.parameters,
+					),
+				]
+			: [];
+	},
+});
+
+/**
+ * The inverse of a reset: it restores the exact parameter map the reset
+ * discarded. Kept as its own command (rather than reusing `parameter.set` per
+ * parameter) so one reset undoes as one history entry and one revision.
+ */
+export const deviceResetRestorePayloadSchema = z.strictObject({
+	target: chainTargetSchema,
+	deviceId: deviceIdSchema,
+	parameters: z.record(z.string(), z.number()),
+});
+export type DeviceResetRestorePayload = z.infer<
+	typeof deviceResetRestorePayloadSchema
+>;
+
+export const deviceResetRestoreCommand =
+	defineCommand<DeviceResetRestorePayload>({
+		type: "device.restoreParameters",
+		version: 1,
+		schema: deviceResetRestorePayloadSchema,
+		summarize: () => "Restore device parameters",
+		apply(project, payload) {
+			const devices = readChain(project, payload.target);
+			if (!devices) return rejected(chainMissingMessage(payload.target));
+			const device = devices.find((entry) => entry.id === payload.deviceId);
+			if (!device) return rejected(`Device ${payload.deviceId} does not exist`);
+			const next = devices.map((entry) =>
+				entry.id === device.id
+					? { ...entry, parameters: { ...payload.parameters } }
+					: entry,
+			);
+			return applied(writeChain(project, payload.target, next));
+		},
+		invert(payload, before) {
+			const device = readChain(before, payload.target)?.find(
+				(candidate) => candidate.id === payload.deviceId,
+			);
+			return device
+				? [
+						restoreDeviceParameters(
+							payload.target,
+							payload.deviceId,
+							device.parameters,
+						),
+					]
+				: [];
+		},
+	});
+
+/** Overwrites a device's parameter map wholesale (the inverse of a reset). */
+export function restoreDeviceParameters(
+	target: DeviceChainTarget,
+	deviceId: DeviceId,
+	parameters: Readonly<Record<string, number>>,
+): CommandInput<DeviceResetRestorePayload> {
+	return {
+		type: deviceResetRestoreCommand.type,
+		payload: { target, deviceId, parameters: { ...parameters } },
+	};
+}
+
+// --- Typed builders --------------------------------------------------------
+
+export function addDevice(
+	target: DeviceChainTarget,
+	device: Device,
+): CommandInput<DeviceAddPayload> {
+	return { type: deviceAddCommand.type, payload: { target, device } };
+}
+
+export function removeDevice(
+	target: DeviceChainTarget,
+	deviceId: DeviceId,
+): CommandInput<DeviceRemovePayload> {
+	return { type: deviceRemoveCommand.type, payload: { target, deviceId } };
+}
+
+export function reorderDevice(
+	target: DeviceChainTarget,
+	deviceId: DeviceId,
+	toIndex: number,
+): CommandInput<DeviceReorderPayload> {
+	return {
+		type: deviceReorderCommand.type,
+		payload: { target, deviceId, toIndex },
+	};
+}
+
+export function duplicateDevice(
+	target: DeviceChainTarget,
+	deviceId: DeviceId,
+	newDeviceId: DeviceId,
+): CommandInput<DeviceDuplicatePayload> {
+	return {
+		type: deviceDuplicateCommand.type,
+		payload: { target, deviceId, newDeviceId },
+	};
+}
+
+export function setDeviceBypass(
+	target: DeviceChainTarget,
+	deviceId: DeviceId,
+	bypassed: boolean,
+): CommandInput<DeviceSetBypassPayload> {
+	return {
+		type: deviceSetBypassCommand.type,
+		payload: { target, deviceId, bypassed },
+	};
+}
+
+export function resetDevice(
+	target: DeviceChainTarget,
+	deviceId: DeviceId,
+): CommandInput<DeviceResetPayload> {
+	return { type: deviceResetCommand.type, payload: { target, deviceId } };
+}
+
+/** Registered, payload-erased commands from this module. */
+export const deviceCommands: readonly RegisteredCommand[] = [
+	eraseCommand(deviceAddCommand),
+	eraseCommand(deviceRemoveCommand),
+	eraseCommand(deviceReorderCommand),
+	eraseCommand(deviceDuplicateCommand),
+	eraseCommand(deviceSetBypassCommand),
+	eraseCommand(deviceResetCommand),
+	eraseCommand(deviceResetRestoreCommand),
+];

--- a/src/commands/devices.test.ts
+++ b/src/commands/devices.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	createDevice,
+	createSeededIdFactory,
+	type DeviceId,
+	type Project,
+} from "../domain";
+import {
+	addDevice,
+	duplicateDevice,
+	insertChain,
+	masterChain,
+	removeDevice,
+	reorderDevice,
+	resetDevice,
+	returnChain,
+	setDeviceBypass,
+	setParameter,
+} from ".";
+import { executeCommand } from "./execute";
+import { findTrack } from "./projectEdits";
+import {
+	type CommandTestProject,
+	createCommandTestProject,
+} from "./testProjects";
+
+const ids = createSeededIdFactory("devices-command-test");
+const newDeviceId = (): DeviceId => ids("device");
+
+function apply(
+	project: Project,
+	command: Parameters<typeof executeCommand>[1],
+): Project {
+	const result = executeCommand(project, command);
+	if (!result.ok) {
+		throw new Error(`Expected success: ${result.issues[0].message}`);
+	}
+	return result.project;
+}
+
+function trackDevices(project: Project, fixture: CommandTestProject) {
+	return findTrack(project, fixture.trackAId)?.devices ?? [];
+}
+
+describe("device.add across chains", () => {
+	let fixture: CommandTestProject;
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	it("adds a device to a track's insert chain with a stable id and contiguous order", () => {
+		const id = newDeviceId();
+		const next = apply(
+			fixture.project,
+			addDevice(insertChain(fixture.trackAId), createDevice(id, "reverb", 2)),
+		);
+		const devices = trackDevices(next, fixture);
+		expect(devices.map((d) => d.order)).toEqual([0, 1, 2]);
+		expect(devices.find((d) => d.id === id)?.type).toBe("reverb");
+	});
+
+	it("adds a device to a return bus chain", () => {
+		const id = newDeviceId();
+		const next = apply(
+			fixture.project,
+			addDevice(returnChain(fixture.returnId), createDevice(id, "delay", 0)),
+		);
+		const bus = next.song.returns.find((b) => b.id === fixture.returnId);
+		expect(bus?.devices.map((d) => d.id)).toEqual([id]);
+	});
+
+	it("adds a device to the master chain", () => {
+		const id = newDeviceId();
+		const next = apply(
+			fixture.project,
+			addDevice(masterChain, createDevice(id, "compressor", 0)),
+		);
+		expect(next.song.master.devices.map((d) => d.id)).toEqual([id]);
+	});
+
+	it("rejects a duplicate device id rather than corrupting the chain", () => {
+		const result = executeCommand(
+			fixture.project,
+			addDevice(
+				insertChain(fixture.trackAId),
+				createDevice(fixture.deviceId, "reverb", 0),
+			),
+		);
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("device.remove and device.reorder renumber contiguously", () => {
+	it("removes a device and closes the order gap", () => {
+		const fixture = createCommandTestProject();
+		const next = apply(
+			fixture.project,
+			removeDevice(insertChain(fixture.trackAId), fixture.deviceId),
+		);
+		const devices = trackDevices(next, fixture);
+		expect(devices.some((d) => d.id === fixture.deviceId)).toBe(false);
+		expect(devices.map((d) => d.order)).toEqual(
+			devices.map((_, index) => index),
+		);
+	});
+
+	it("reorders a device and keeps every order 0..n-1", () => {
+		const fixture = createCommandTestProject();
+		const next = apply(
+			fixture.project,
+			reorderDevice(insertChain(fixture.trackAId), fixture.deviceId, 1),
+		);
+		const devices = trackDevices(next, fixture);
+		// The first device now sits last, and orders stay serial.
+		expect(devices.map((d) => d.order)).toEqual(
+			devices.map((_, index) => index),
+		);
+		const moved = devices.find((d) => d.id === fixture.deviceId);
+		expect(moved?.order).toBe(1);
+	});
+});
+
+describe("eight-insert ceiling (FX-01)", () => {
+	it("accepts an eighth insert but rejects a ninth", () => {
+		let project = createCommandTestProject().project;
+		const trackId = project.song.tracks[0].id;
+		// The fixture starts with two inserts; fill to eight.
+		for (let i = 0; i < 6; i++) {
+			project = apply(
+				project,
+				addDevice(
+					insertChain(trackId),
+					createDevice(newDeviceId(), "filter", 2 + i),
+				),
+			);
+		}
+		expect(findTrack(project, trackId)?.devices.length).toBe(8);
+
+		const ninth = executeCommand(
+			project,
+			addDevice(insertChain(trackId), createDevice(newDeviceId(), "filter", 8)),
+		);
+		expect(ninth.ok).toBe(false);
+	});
+});
+
+describe("device.duplicate", () => {
+	it("places an independent copy right after the source with a fresh id", () => {
+		const fixture = createCommandTestProject();
+		const sourceId = newDeviceId();
+		const copyId = newDeviceId();
+		// A real delay device with a distinct feedback value to copy.
+		let project = apply(
+			fixture.project,
+			addDevice(
+				insertChain(fixture.trackAId),
+				createDevice(sourceId, "delay", 2),
+			),
+		);
+		project = apply(
+			project,
+			setParameter(
+				{
+					scope: "trackDevice",
+					trackId: fixture.trackAId,
+					deviceId: sourceId,
+					parameterId: "feedback",
+				},
+				0.6,
+			),
+		);
+		const next = apply(
+			project,
+			duplicateDevice(insertChain(fixture.trackAId), sourceId, copyId),
+		);
+		const devices = trackDevices(next, fixture);
+		const sourceIndex = devices.findIndex((d) => d.id === sourceId);
+		const copyIndex = devices.findIndex((d) => d.id === copyId);
+		expect(copyIndex).toBe(sourceIndex + 1);
+		expect(devices[copyIndex].parameters).toEqual(
+			devices[sourceIndex].parameters,
+		);
+		expect(devices[copyIndex].parameters).not.toBe(
+			devices[sourceIndex].parameters,
+		);
+		expect(devices.map((d) => d.order)).toEqual(
+			devices.map((_, index) => index),
+		);
+	});
+});
+
+describe("device.setBypass and device.reset", () => {
+	it("bypasses a device without touching its parameters", () => {
+		const fixture = createCommandTestProject();
+		const next = apply(
+			fixture.project,
+			setDeviceBypass(insertChain(fixture.trackAId), fixture.deviceId, true),
+		);
+		const device = trackDevices(next, fixture).find(
+			(d) => d.id === fixture.deviceId,
+		);
+		expect(device?.bypassed).toBe(true);
+		expect(device?.parameters).toEqual({ time: 0.25 });
+	});
+
+	it("reset restores factory parameters but keeps position, bypass, and preset", () => {
+		const fixture = createCommandTestProject();
+		// Registered type so reset has real defaults to restore to.
+		const id = newDeviceId();
+		let project = apply(
+			fixture.project,
+			addDevice(insertChain(fixture.trackAId), createDevice(id, "delay", 2)),
+		);
+		project = apply(
+			project,
+			setParameter(
+				{
+					scope: "trackDevice",
+					trackId: fixture.trackAId,
+					deviceId: id,
+					parameterId: "feedback",
+				},
+				0.9,
+			),
+		);
+		project = apply(
+			project,
+			setDeviceBypass(insertChain(fixture.trackAId), id, true),
+		);
+		const reset = apply(
+			project,
+			resetDevice(insertChain(fixture.trackAId), id),
+		);
+		const device = trackDevices(reset, fixture).find((d) => d.id === id);
+		expect(device?.parameters.feedback).toBe(0.4); // default, not 0.9
+		expect(device?.bypassed).toBe(true); // preserved
+	});
+});
+
+describe("unrelated graphs keep identity (structural sharing)", () => {
+	it("adding a device to track A leaves track B's object referentially identical", () => {
+		const fixture = createCommandTestProject();
+		const before = fixture.project.song.tracks.find(
+			(t) => t.id === fixture.trackBId,
+		);
+		const next = apply(
+			fixture.project,
+			addDevice(
+				insertChain(fixture.trackAId),
+				createDevice(newDeviceId(), "reverb", 2),
+			),
+		);
+		const after = next.song.tracks.find((t) => t.id === fixture.trackBId);
+		expect(after).toBe(before);
+	});
+});
+
+describe("device parameter safety (FX-02)", () => {
+	it("rejects an unsafe delay feedback at unity rather than clamping it", () => {
+		const fixture = createCommandTestProject();
+		const id = newDeviceId();
+		const project = apply(
+			fixture.project,
+			addDevice(insertChain(fixture.trackAId), createDevice(id, "delay", 2)),
+		);
+		const result = executeCommand(
+			project,
+			setParameter(
+				{
+					scope: "trackDevice",
+					trackId: fixture.trackAId,
+					deviceId: id,
+					parameterId: "feedback",
+				},
+				1,
+			),
+		);
+		expect(result.ok).toBe(false);
+	});
+
+	it("keeps an extreme-but-finite feedback setting", () => {
+		const fixture = createCommandTestProject();
+		const id = newDeviceId();
+		let project = apply(
+			fixture.project,
+			addDevice(insertChain(fixture.trackAId), createDevice(id, "delay", 2)),
+		);
+		project = apply(
+			project,
+			setParameter(
+				{
+					scope: "trackDevice",
+					trackId: fixture.trackAId,
+					deviceId: id,
+					parameterId: "feedback",
+				},
+				0.99,
+			),
+		);
+		const device = trackDevices(project, fixture).find((d) => d.id === id);
+		expect(device?.parameters.feedback).toBe(0.99);
+	});
+});

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,8 @@
  */
 
 export * from "./definitions/clips";
+export * from "./definitions/deviceChains";
+export * from "./definitions/devices";
 export * from "./definitions/drum";
 export * from "./definitions/instruments";
 export * from "./definitions/notes";

--- a/src/commands/inverse.test.ts
+++ b/src/commands/inverse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	bars,
+	createDevice,
 	createDrumPad,
 	createNoteClip,
 	createNoteEvent,
@@ -16,22 +17,29 @@ import {
 } from "../domain";
 import {
 	addClip,
+	addDevice,
 	addNotes,
 	addPad,
 	addPlacement,
 	addTrack,
 	changeInstrument,
 	clearNotes,
+	duplicateDevice,
 	duplicateNotes,
+	insertChain,
 	quantizeNotes,
 	removeClip,
+	removeDevice,
 	removeNotes,
 	removePad,
 	removePlacement,
 	removeTrack,
+	reorderDevice,
 	reorderPad,
 	reorderTrack,
+	resetDevice,
 	scaleNoteVelocity,
+	setDeviceBypass,
 	setPadAsset,
 	setPadChoke,
 	setPadFlag,
@@ -269,6 +277,59 @@ const cases: InverseCase[] = [
 	{
 		type: "instrument.setSample",
 		build: (fixture) => setSample(fixture.trackAId, null),
+	},
+	{
+		type: "device.add",
+		build: (fixture) =>
+			addDevice(
+				insertChain(fixture.trackAId),
+				createDevice(
+					createSeededIdFactory("inverse-device-add")("device"),
+					"reverb",
+					1,
+				),
+			),
+	},
+	{
+		type: "device.remove",
+		build: (fixture) =>
+			removeDevice(insertChain(fixture.trackAId), fixture.deviceId),
+	},
+	{
+		type: "device.reorder",
+		// The fixture's track A has two inserts; move the first past the second.
+		build: (fixture) =>
+			reorderDevice(insertChain(fixture.trackAId), fixture.deviceId, 1),
+	},
+	{
+		type: "device.duplicate",
+		build: (fixture) =>
+			duplicateDevice(
+				insertChain(fixture.trackAId),
+				fixture.deviceId,
+				createSeededIdFactory("inverse-device-dup")("device"),
+			),
+	},
+	{
+		type: "device.setBypass",
+		build: (fixture) =>
+			setDeviceBypass(insertChain(fixture.trackAId), fixture.deviceId, true),
+	},
+	{
+		type: "device.reset",
+		build: (fixture) =>
+			resetDevice(insertChain(fixture.trackAId), fixture.deviceId),
+	},
+	{
+		type: "device.restoreParameters",
+		build: (fixture) => ({
+			type: "device.restoreParameters",
+			payload: {
+				target: insertChain(fixture.trackAId),
+				deviceId: fixture.deviceId,
+				parameters: { time: 0.5 },
+			},
+		}),
 	},
 ];
 

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -45,6 +45,13 @@ const EXPECTED_COMMANDS = [
 	"drum.reorderPad",
 	"instrument.change",
 	"instrument.setSample",
+	"device.add",
+	"device.remove",
+	"device.reorder",
+	"device.duplicate",
+	"device.setBypass",
+	"device.reset",
+	"device.restoreParameters",
 ];
 
 describe("command registry", () => {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,4 +1,5 @@
 import { clipCommands } from "./definitions/clips";
+import { deviceCommands } from "./definitions/devices";
 import { drumCommands } from "./definitions/drum";
 import { instrumentCommands } from "./definitions/instruments";
 import { noteCommands } from "./definitions/notes";
@@ -30,6 +31,7 @@ const ALL_DEFINITIONS: readonly RegisteredCommand[] = [
 	...parameterCommands,
 	...drumCommands,
 	...instrumentCommands,
+	...deviceCommands,
 ];
 
 function buildRegistry(

--- a/src/commands/testProjects.ts
+++ b/src/commands/testProjects.ts
@@ -62,6 +62,7 @@ export interface CommandTestProject {
 	clipAId: ClipId;
 	clipBId: ClipId;
 	deviceId: DeviceId;
+	device2Id: DeviceId;
 	returnId: ReturnId;
 	placementAId: PlacementId;
 	padIds: PadId[];
@@ -109,6 +110,15 @@ export function createCommandTestProject(
 		parameters: { [TEST_DEVICE_PARAMETER]: 0.25 },
 		preset: null,
 	};
+	// A second insert device so a device reorder has something to move past.
+	const device2: Device = {
+		id: context.ids("device"),
+		type: TEST_DEVICE_TYPE,
+		order: 1,
+		bypassed: false,
+		parameters: {},
+		preset: null,
+	};
 
 	const returnBus = createReturnBus(context, { name: "Reverb", order: 0 });
 
@@ -116,7 +126,7 @@ export function createCommandTestProject(
 		name: "Bass",
 		order: 0,
 		instrument: createSamplerInstrument(asset.id),
-		devices: [device],
+		devices: [device, device2],
 		sendConfig: [createSend(returnBus.id, 0.25)],
 	});
 
@@ -208,6 +218,7 @@ export function createCommandTestProject(
 		clipAId: clipA.id,
 		clipBId: clipB.id,
 		deviceId: device.id,
+		device2Id: device2.id,
 		returnId: returnBus.id,
 		placementAId: placementA.id,
 		padIds: [kick.id, clap.id],


### PR DESCRIPTION
## What & why

**PR 2 of 4 in the LOOP-008 stack.** Based on **PR 1** (`claude/loop-008-domain`, #138) — review and merge that first.

Adds the device and routing command family (`src/commands/definitions/devices.ts`, `deviceChains.ts`): `device.add`, `device.remove`, `device.reorder`, `device.duplicate`, `device.setBypass`, `device.reset`, `device.restoreParameters` — registered in the command registry, with stable IDs, generated inverses, history/autosave integration, and the `COMMAND_IDS` analytics registration that keeps `catalog.test.ts`'s registry cross-check green.

Satisfies PRD **FX-01**, **FX-02** (the command half).

Part of #48.

> ### This PR is large but atomic — please review it as one unit
> `src/commands/registry.test.ts` pins the exact set of seven `device.*` commands as a snapshot, and `src/commands/inverse.test.ts` exercises every one of them. Registering fewer than all seven fails the registry snapshot, so the seven commands **cannot** be split into separate PRs without a red tree in between. This is the one genuinely-indivisible unit of LOOP-008; the surrounding domain contract, analytics enum claim, and audio relink were split out into PRs 1, 3, and 4 precisely so this one carries only what must travel together. It comes in at ~891 changed lines, above the 400-line cap, for that reason.

**Note on the base:** because PR 1 targets `main`, GitHub shows this PR's diff against `main` until PR 1 merges (so it appears to include PR 1's files). Its own commit is the single `device and routing commands` commit; retarget to `main` once PR 1 lands.

## Walkthrough

No UI change. Command layer and tests only — no component or styling change.

## Evidence

Run on this branch (which includes PR 1):
- `bun run typecheck` — passes.
- Targeted: `registry.test.ts` (7), `devices.test.ts` (13), `inverse.test.ts` (75), `catalog.test.ts` (31) — all pass.
- Full `bun run test` on the stack tip (PR 3) — 133 files, 1742 tests passed; `bun run check:ci` clean.

## Acceptance criteria met

- [x] Device/routing commands preserve invariants, history, autosave, and stable IDs.
