### PR TITLE
LOOP-008 (3/4): claim device_added analytics keys

### DIFF
--- a/src/analytics/analytics.test.ts
+++ b/src/analytics/analytics.test.ts
@@ -260,13 +260,27 @@ describe("type safety (PRD OPS-02: logging an unregistered event is a type error
 
 	it("cannot log an event whose keys a later task still owns", () => {
 		const { analytics } = setup();
-		// `device_added`'s `device_type` keys are authored per device by
-		// LOOP-008/009. Until those land the enum is empty, so the event is
-		// declared but un-loggable — no call site can ship ahead of its keys.
-		// (`shortcut_used`'s `action_id` was the example here until LOOP-014
-		// claimed it from the shortcut registry.)
+		// `arrangement_outline_created`'s `template_id` keys are authored by
+		// ARR-003. Until then the enum is empty, so the event is declared but
+		// un-loggable — no call site can ship ahead of its keys. (`device_added`
+		// was the example here until LOOP-008 claimed its `device_type` keys, and
+		// `shortcut_used` before that until LOOP-014.)
+		const emptyEnum = {
+			template_id: "verse_chorus",
+			section_count: 4,
+		} as const;
 		// @ts-expect-error - no value satisfies an empty enum.
+		analytics.log("arrangement_outline_created", emptyEnum);
+	});
+
+	it("logs device_added now that LOOP-008 has claimed its device_type keys", () => {
+		const { analytics } = setup();
+		// A correct call compiles...
 		analytics.log("device_added", { device_type: "reverb", chain: "insert" });
+		// ...but an unregistered device type does not.
+		const unknownType = { device_type: "bitcrusher", chain: "insert" } as const;
+		// @ts-expect-error - "bitcrusher" is not one of the authored device types.
+		analytics.log("device_added", unknownType);
 	});
 });
 

--- a/src/analytics/catalog.ts
+++ b/src/analytics/catalog.ts
@@ -457,8 +457,16 @@ export const ANALYTICS_EVENTS = {
 		phase: 1,
 		owners: ["LOOP-008", "LOOP-009"],
 		params: {
-			// Device keys are authored per-device in Alpha Milestone 1 (LOOP-008/009).
-			device_type: enumParam(UNCLAIMED),
+			// The alpha's six core device types (LOOP-008); LOOP-009 extends this
+			// list as it authors more. Kept in sync with `src/domain/devices.ts`.
+			device_type: enumParam([
+				"filter",
+				"overdrive",
+				"saturator",
+				"compressor",
+				"delay",
+				"reverb",
+			]),
 			chain: enumParam(["insert", "return", "master"]),
 		},
 	},


### PR DESCRIPTION
## What & why

**PR 3 of 4 in the LOOP-008 stack.** Based on **PR 2** (`claude/loop-008-commands`, #139) — review and merge that first.

Claims the `device_added` event's `device_type` analytics keys: replaces the placeholder empty enum with the six core device types (mirroring `src/domain/devices.ts`), and retires the `analytics.test.ts` placeholder that asserted `device_added` was un-loggable. `arrangement_outline_created` takes over as the "declared but un-loggable until its owning task lands" example.

Satisfies the analytics half of the LOOP-008 acceptance criterion (emitting `device_added` with `device_type` and `chain`). The `COMMAND_IDS` registration that pairs with the commands lives in PR 2, because `catalog.test.ts` requires it to stay green.

Part of #48.

**Why separate from PR 2:** the `device_type` enum claim is independent of the command registry — it mirrors the domain device types and has no dependency on the commands existing. Splitting it keeps PR 2 to strictly the atomic command set.

## Walkthrough

No UI change. Analytics catalog and its type-level tests only.

## Evidence

Run on this branch (which includes PRs 1–2):
- `bun run typecheck` — passes (the `@ts-expect-error` on an unregistered device type is what proves the enum is claimed).
- `analytics.test.ts` (25), `catalog.test.ts` (31) — pass.
- Full `bun run test` on this tip — 133 files, 1742 tests passed; `bun run check:ci` clean.

## Acceptance criteria met

- [x] Emits `device_added` with `device_type` and `chain` (device_type keys claimed here; chain enum and the feature_first_use keys are already in the catalog).
