### PR TITLE
LOOP-008 (4/4): click-safe device-chain relink

### DIFF
--- a/src/audio/DeviceChain.test.ts
+++ b/src/audio/DeviceChain.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { Device } from "../domain/entities";
+import { createManualScheduler } from "../shared/scheduler";
 import { installWebAudioGlobals, rms } from "./testAudioContext";
 
 // Must run before Tone is imported — see AudioRuntime.test.ts for why.
@@ -179,11 +180,17 @@ describe("DeviceChain", () => {
 	it("dips the chain output around a relink so a reorder is click-safe", () => {
 		const runtime = new AudioRuntimeModule.AudioRuntime();
 		const scope = runtime.openProjectScope("p");
-		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory([]));
+		const scheduler = createManualScheduler();
+		const chain = new DeviceChainModule.DeviceChain(
+			scope,
+			fakeFactory([]),
+			scheduler,
+		);
 
 		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
-		// A reorder relinks: the output gain must be scheduled down to 0 and back
-		// to 1 (a make-before-break fade) rather than switching topology at full
+		// A reorder relinks: the output gain must be scheduled down to 0, and
+		// (once the down-ramp has actually reached silence) back to 1 — a
+		// make-before-break fade — rather than switching topology at full
 		// gain, which is the audible transient FX-01 forbids.
 		const rampsScheduled: number[] = [];
 		const gain = chain.output.gain;
@@ -194,10 +201,176 @@ describe("DeviceChain", () => {
 		}) as typeof gain.linearRampToValueAtTime;
 
 		chain.reconcile([device("dev_b", 0), device("dev_a", 1)]);
+		expect(rampsScheduled).toEqual([0]);
+
+		scheduler.advance(DeviceChainModule.RELINK_FADE_SECONDS * 1000);
 		expect(rampsScheduled).toEqual([0, 1]);
 
 		chain.dispose();
 		return runtime.close();
+	});
+
+	it("defers the topology rewire until the down-ramp has reached silence (true make-before-break)", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const scheduler = createManualScheduler();
+		const chain = new DeviceChainModule.DeviceChain(
+			scope,
+			fakeFactory([]),
+			scheduler,
+		);
+
+		// First reconcile is the initial build — no prior topology, so it
+		// links immediately with no fade (see the initial-build guard test).
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+
+		const events: string[] = [];
+		const originalDisconnect = chain.input.disconnect.bind(chain.input);
+		chain.input.disconnect = (() => {
+			events.push("rewire");
+			return originalDisconnect();
+		}) as typeof chain.input.disconnect;
+		const gain = chain.output.gain;
+		const originalRamp = gain.linearRampToValueAtTime.bind(gain);
+		gain.linearRampToValueAtTime = ((value: number, time: number) => {
+			events.push(value === 0 ? "ramp-down" : "ramp-up");
+			return originalRamp(value, time);
+		}) as typeof gain.linearRampToValueAtTime;
+
+		// A reorder is a genuine relink: the down-ramp must be scheduled, but
+		// the rewire (input.disconnect(), the FX-01 bug's synchronous half)
+		// must NOT run yet — the previous topology is still live and
+		// connected, and the down-ramp is only a future automation curve at
+		// this point, not yet a value of 0.
+		chain.reconcile([device("dev_b", 0), device("dev_a", 1)]);
+		expect(events).toEqual(["ramp-down"]);
+		expect(scheduler.pending).toBe(1);
+
+		// Only once the scheduler fires — i.e. once the down-ramp has actually
+		// reached 0 — does the rewire run, immediately followed by the ramp
+		// back up. This ordering (rewire strictly after ramp-down) is exactly
+		// what the pre-fix synchronous code got backwards.
+		scheduler.advance(DeviceChainModule.RELINK_FADE_SECONDS * 1000);
+		expect(events).toEqual(["ramp-down", "rewire", "ramp-up"]);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("the initial build links directly with no fade or deferred rewire", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const scheduler = createManualScheduler();
+		const chain = new DeviceChainModule.DeviceChain(
+			scope,
+			fakeFactory([]),
+			scheduler,
+		);
+
+		const gain = chain.output.gain;
+		let ramps = 0;
+		const originalRamp = gain.linearRampToValueAtTime.bind(gain);
+		gain.linearRampToValueAtTime = ((value: number, time: number) => {
+			ramps += 1;
+			return originalRamp(value, time);
+		}) as typeof gain.linearRampToValueAtTime;
+
+		// The very first reconcile builds topology from empty — there is no
+		// prior live routing to click away from, so it must not schedule any
+		// fade (which would just be an audible dip/fade-in on project open).
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+
+		expect(ramps).toBe(0);
+		expect(scheduler.pending).toBe(0);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("coalesces a relink that arrives mid-fade into exactly one consistent wiring and one gain recovery", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const scheduler = createManualScheduler();
+		const chain = new DeviceChainModule.DeviceChain(
+			scope,
+			fakeFactory([]),
+			scheduler,
+		);
+
+		chain.reconcile([
+			device("dev_a", 0),
+			device("dev_b", 1),
+			device("dev_c", 2),
+		]);
+
+		let disconnectCalls = 0;
+		const originalDisconnect = chain.input.disconnect.bind(chain.input);
+		chain.input.disconnect = (() => {
+			disconnectCalls += 1;
+			return originalDisconnect();
+		}) as typeof chain.input.disconnect;
+		const gain = chain.output.gain;
+		let rampUps = 0;
+		const originalRamp = gain.linearRampToValueAtTime.bind(gain);
+		gain.linearRampToValueAtTime = ((value: number, time: number) => {
+			if (value === 1) rampUps += 1;
+			return originalRamp(value, time);
+		}) as typeof gain.linearRampToValueAtTime;
+
+		// First relink starts fading out...
+		chain.reconcile([
+			device("dev_b", 0),
+			device("dev_a", 1),
+			device("dev_c", 2),
+		]);
+		expect(scheduler.pending).toBe(1);
+
+		// ...but a second relink arrives before the first's deferred rewire
+		// fires. The first's pending rewire must be superseded, not run.
+		chain.reconcile([
+			device("dev_c", 0),
+			device("dev_a", 1),
+			device("dev_b", 2),
+		]);
+		expect(scheduler.pending).toBe(1); // still exactly one pending rewire
+		expect(disconnectCalls).toBe(0); // neither has rewired yet
+
+		scheduler.runAll();
+
+		// Exactly one rewire ran (the superseded one never fired), and the
+		// gain recovered to 1 exactly once — never stuck at 0, never double.
+		expect(disconnectCalls).toBe(1);
+		expect(rampUps).toBe(1);
+		expect(scheduler.pending).toBe(0);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("dispose() cancels a pending scheduled rewire so it can never fire after teardown", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const scheduler = createManualScheduler();
+		const chain = new DeviceChainModule.DeviceChain(
+			scope,
+			fakeFactory([]),
+			scheduler,
+		);
+
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		chain.reconcile([device("dev_b", 0), device("dev_a", 1)]);
+		expect(scheduler.pending).toBe(1);
+
+		chain.dispose();
+
+		// Advancing the scheduler afterward must not throw or touch disposed
+		// nodes — the pending rewire was cancelled by dispose().
+		expect(() =>
+			scheduler.advance(DeviceChainModule.RELINK_FADE_SECONDS * 1000),
+		).not.toThrow();
+		expect(scheduler.pending).toBe(0);
+
+		await runtime.close();
 	});
 
 	it("does not dip the output on a bypass/parameter-only reconcile", () => {

--- a/src/audio/DeviceChain.test.ts
+++ b/src/audio/DeviceChain.test.ts
@@ -176,6 +176,55 @@ describe("DeviceChain", () => {
 		await runtime.close();
 	});
 
+	it("dips the chain output around a relink so a reorder is click-safe", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory([]));
+
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		// A reorder relinks: the output gain must be scheduled down to 0 and back
+		// to 1 (a make-before-break fade) rather than switching topology at full
+		// gain, which is the audible transient FX-01 forbids.
+		const rampsScheduled: number[] = [];
+		const gain = chain.output.gain;
+		const originalRamp = gain.linearRampToValueAtTime.bind(gain);
+		gain.linearRampToValueAtTime = ((value: number, time: number) => {
+			rampsScheduled.push(value);
+			return originalRamp(value, time);
+		}) as typeof gain.linearRampToValueAtTime;
+
+		chain.reconcile([device("dev_b", 0), device("dev_a", 1)]);
+		expect(rampsScheduled).toEqual([0, 1]);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
+	it("does not dip the output on a bypass/parameter-only reconcile", () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const scope = runtime.openProjectScope("p");
+		const chain = new DeviceChainModule.DeviceChain(scope, fakeFactory([]));
+
+		chain.reconcile([device("dev_a", 0), device("dev_b", 1)]);
+		const gain = chain.output.gain;
+		let ramps = 0;
+		const originalRamp = gain.linearRampToValueAtTime.bind(gain);
+		gain.linearRampToValueAtTime = ((value: number, time: number) => {
+			ramps += 1;
+			return originalRamp(value, time);
+		}) as typeof gain.linearRampToValueAtTime;
+
+		// Same ids, same order, only a bypass flip — no relink, so no fade.
+		chain.reconcile([
+			{ ...device("dev_a", 0), bypassed: true },
+			device("dev_b", 1),
+		]);
+		expect(ramps).toBe(0);
+
+		chain.dispose();
+		return runtime.close();
+	});
+
 	it("the default passthrough device leaves a signal unchanged", async () => {
 		const rendered = await Tone.Offline(({ destination }) => {
 			const runtime = new AudioRuntimeModule.AudioRuntime();

--- a/src/audio/DeviceChain.ts
+++ b/src/audio/DeviceChain.ts
@@ -50,6 +50,18 @@ export function createPassthroughDeviceNode(device: Device): DeviceNode {
 
 const defaultDeviceNodeFactory: DeviceNodeFactory = createPassthroughDeviceNode;
 
+/**
+ * The gain dip applied around a chain relink so composition or order changes do
+ * not click (PRD FX-01: a reorder's reconnection must be click-safe). A Web
+ * Audio `disconnect()`/`connect()` is an instantaneous topology change: the
+ * sample the graph produces on the block after the change can jump from the old
+ * routing's value to the new one, and that step is an audible transient. Ramping
+ * the chain's own output to zero, relinking, then ramping back masks the step in
+ * a fade far shorter than a fader move yet long enough to avoid the click. It
+ * costs nothing on a parameter- or bypass-only reconcile, which never relinks.
+ */
+export const RELINK_FADE_SECONDS = 0.005;
+
 interface TrackedDevice {
 	node: DeviceNode;
 	handle: ReturnType<AudioProjectScope["register"]>;
@@ -115,7 +127,19 @@ export class DeviceChain {
 		if (compositionChanged || orderChanged) this.relink();
 	}
 
+	/**
+	 * Rewires the serial signal path, click-safe: the output is faded to zero
+	 * across `RELINK_FADE_SECONDS`, the topology is rebuilt while it is silent,
+	 * then it is faded back. Only the added/removed/reordered case reaches here;
+	 * a bypass- or parameter-only reconcile applies changes on the existing nodes
+	 * and never relinks, so it pays no fade.
+	 */
 	private relink(): void {
+		const now = this.output.immediate();
+		this.output.gain.cancelScheduledValues(now);
+		this.output.gain.setValueAtTime(this.output.gain.value, now);
+		this.output.gain.linearRampToValueAtTime(0, now + RELINK_FADE_SECONDS);
+
 		this.input.disconnect();
 		let previous: Tone.ToneAudioNode = this.input;
 		for (const id of this.order) {
@@ -126,6 +150,8 @@ export class DeviceChain {
 			previous = tracked.node.output;
 		}
 		previous.connect(this.output);
+
+		this.output.gain.linearRampToValueAtTime(1, now + 2 * RELINK_FADE_SECONDS);
 	}
 
 	/** Tears down every device node and this chain's own shell. Idempotent. */

--- a/src/audio/DeviceChain.ts
+++ b/src/audio/DeviceChain.ts
@@ -1,6 +1,8 @@
 import * as Tone from "tone";
 import type { Device } from "../domain/entities";
 import type { DeviceId } from "../domain/ids";
+import type { CancelScheduled, Scheduler } from "../shared/scheduler";
+import { timeoutScheduler } from "../shared/scheduler";
 import type { AudioProjectScope } from "./AudioRuntime";
 
 /**
@@ -80,10 +82,20 @@ export class DeviceChain {
 	private readonly nodes = new Map<DeviceId, TrackedDevice>();
 	private order: DeviceId[] = [];
 	private readonly chainHandle: ReturnType<AudioProjectScope["register"]>;
+	/** True once the signal path has been wired at least once. Guards the very
+	 * first `relink()` (empty -> initial topology) so it connects directly at
+	 * gain 1 instead of scheduling a spurious dip nothing was ever routed
+	 * through in the first place. */
+	private linked = false;
+	/** Cancels a rewire deferred by a relink still fading out, so a second
+	 * relink arriving before the first completes supersedes it instead of
+	 * racing it (see `relink()`). */
+	private pendingRelink: CancelScheduled | null = null;
 
 	constructor(
 		private readonly scope: AudioProjectScope,
 		private readonly createNode: DeviceNodeFactory = defaultDeviceNodeFactory,
+		private readonly scheduler: Scheduler = timeoutScheduler,
 	) {
 		this.input = new Tone.Gain(1);
 		this.output = new Tone.Gain(1);
@@ -128,18 +140,58 @@ export class DeviceChain {
 	}
 
 	/**
-	 * Rewires the serial signal path, click-safe: the output is faded to zero
-	 * across `RELINK_FADE_SECONDS`, the topology is rebuilt while it is silent,
-	 * then it is faded back. Only the added/removed/reordered case reaches here;
-	 * a bypass- or parameter-only reconcile applies changes on the existing nodes
-	 * and never relinks, so it pays no fade.
+	 * Rewires the serial signal path with a true make-before-break: the output
+	 * is ramped to zero across `RELINK_FADE_SECONDS`, and only once that ramp
+	 * has actually reached silence does the topology change (deferred via the
+	 * injectable `Scheduler`, so tests can drive it deterministically instead
+	 * of racing a real timer). Rewiring synchronously — before the ramp
+	 * completes — was the FX-01 bug this guards against: the graph's sample
+	 * discontinuity would have played through at ~full gain, since a scheduled
+	 * ramp is only a future automation curve, not an instantaneous value.
+	 *
+	 * The very first relink (nothing was ever live) skips the fade entirely —
+	 * there is no prior routing to click away from, so dipping to 0 and back
+	 * would just be an audible fade-in on project open.
+	 *
+	 * A relink that arrives while a previous one is still fading cancels the
+	 * previous one's deferred rewire outright and starts its own down-ramp
+	 * fresh from `now`; only the newest relink's rewire ever runs, reading
+	 * `this.order`/`this.nodes` at fire time so the latest composition wins
+	 * even if it changed again while waiting out the fade.
 	 */
 	private relink(): void {
+		this.pendingRelink?.();
+		this.pendingRelink = null;
+
+		if (!this.linked) {
+			this.rewire();
+			this.linked = true;
+			return;
+		}
+
 		const now = this.output.immediate();
 		this.output.gain.cancelScheduledValues(now);
 		this.output.gain.setValueAtTime(this.output.gain.value, now);
 		this.output.gain.linearRampToValueAtTime(0, now + RELINK_FADE_SECONDS);
 
+		this.pendingRelink = this.scheduler.schedule(() => {
+			this.pendingRelink = null;
+			this.rewire();
+			const resumeNow = this.output.immediate();
+			this.output.gain.cancelScheduledValues(resumeNow);
+			this.output.gain.setValueAtTime(0, resumeNow);
+			this.output.gain.linearRampToValueAtTime(
+				1,
+				resumeNow + RELINK_FADE_SECONDS,
+			);
+		}, RELINK_FADE_SECONDS * 1000);
+	}
+
+	/** Rebuilds the serial signal path from the current `order`/`nodes`. Only
+	 * ever called while the output is silent (or, for the very first link,
+	 * before anything has ever been connected), so the topology change itself
+	 * is inaudible regardless of when it runs. */
+	private rewire(): void {
 		this.input.disconnect();
 		let previous: Tone.ToneAudioNode = this.input;
 		for (const id of this.order) {
@@ -150,12 +202,12 @@ export class DeviceChain {
 			previous = tracked.node.output;
 		}
 		previous.connect(this.output);
-
-		this.output.gain.linearRampToValueAtTime(1, now + 2 * RELINK_FADE_SECONDS);
 	}
 
 	/** Tears down every device node and this chain's own shell. Idempotent. */
 	dispose(): void {
+		this.pendingRelink?.();
+		this.pendingRelink = null;
 		for (const [, tracked] of this.nodes) {
 			void this.scope.release(tracked.handle);
 		}


### PR DESCRIPTION
## What & why

**PR 4 of 4 in the LOOP-008 stack — independent, based directly on `main`.** Has no code or file overlap with PRs 1–3 and can be reviewed and merged in any order relative to them.

Makes `DeviceChain`'s reorder relink click-safe: reordering an insert chain reuses existing nodes and reconnects them without recreating anything, so unrelated device graphs retain node identity and playback is not interrupted (`src/audio/DeviceChain.ts` + its test). Operates only on the passthrough nodes Schema v1 uses today; no concrete DSP.

Satisfies PRD **FX-01** (the audio-layer reconnection guarantee).

Part of #48.

**Why its own PR:** this is the only audio-layer change in LOOP-008. It shares no file and no dependency with the domain contract, command family, or analytics claim, so folding it into any of them would force those reviewers to re-review an unrelated audio concern.

## Walkthrough

No UI change. Audio-graph reconnection strategy and its test only.

## Evidence

Run on this branch (based on `main`):
- `bun run typecheck` — passes.
- `bun run check:ci` — `Checked 382 files. No fixes applied.`
- `src/audio/DeviceChain.test.ts` — 9 tests passed.
- Full `bun run test` — 131 files, 1705 tests passed.

## Acceptance criteria met

- [x] Reorder reuses nodes with a measured click-safe reconnection strategy; unrelated graphs retain identity.
