### PR TITLE
REFACTOR-002 (2 of 6): extract clip invariants

### DIFF
--- a/src/domain/parse.ts
+++ b/src/domain/parse.ts
@@ -19,6 +19,7 @@ import {
 	SAMPLER_SAMPLE_END,
 	SAMPLER_SAMPLE_START,
 } from "./parameters";
+import { checkClipInvariants, checkClipOwnership } from "./parse/clip";
 import {
 	checkOrdering,
 	claimId,
@@ -30,10 +31,9 @@ import {
 	type ParseResult,
 	parseWith,
 } from "./parse/primitives";
-import { TICKS_PER_BAR } from "./time";
 
 export type { DomainIssue, DomainIssueCode, ParseResult };
-export { DomainValidationError, formatIssue };
+export { checkClipInvariants, DomainValidationError, formatIssue };
 
 /**
  * Routing capacity ceilings (PRD FX-01, LOOP-008). The PRD states a floor —
@@ -58,9 +58,8 @@ export const MAX_RETURN_BUSES = 8;
  *
  * This file is being split into per-concern modules under `./parse/*` so a
  * new invariant lands in its own file instead of appending to one growing
- * one (REFACTOR-002). The issue primitives and the shared `claimId`/
- * `checkOrdering` helpers have moved to `./parse/primitives`; the rest still
- * live here.
+ * one (REFACTOR-002). The issue primitives and clip invariants have moved
+ * out so far; the rest still live here.
  */
 
 /**
@@ -660,111 +659,6 @@ function checkInstrumentParameters(
 			);
 		}
 	}
-	return issues;
-}
-
-/**
- * Clip-local integrity: everything a clip document can be judged on without its
- * owning track or the song's assets. Both `parseClip` and the aggregate path run
- * this, so the two entry points agree on what a valid clip is.
- *
- * Aggregate callers pass their `seenIds` set so event IDs are also unique across
- * the whole project.
- */
-export function checkClipInvariants(
-	clip: Clip,
-	path: ReadonlyArray<string | number>,
-	seenIds: Set<string> = new Set(),
-): DomainIssue[] {
-	const issues: DomainIssue[] = [];
-	if (clip.content.kind !== "notes") {
-		return issues;
-	}
-	clip.content.events.forEach((event, index) => {
-		const eventPath = [...path, "content", "events", index] as const;
-		claimId(seenIds, event.id, [...eventPath, "id"], issues);
-		if (event.startTicks >= clip.lengthTicks) {
-			issues.push(
-				issue(
-					"invalid_musical_time",
-					[...eventPath, "startTicks"],
-					`Note ${event.id} starts at ${event.startTicks} which is outside its ${clip.lengthTicks}-tick clip`,
-				),
-			);
-		}
-	});
-	return issues;
-}
-
-/**
- * Clip integrity that depends on the clip's owner and the song's assets, and so
- * is only decidable in the aggregate path.
- */
-function checkClipOwnership(
-	clip: Clip,
-	owner: Track | undefined,
-	assetIds: ReadonlySet<string>,
-	path: ReadonlyArray<string | number>,
-): DomainIssue[] {
-	const issues: DomainIssue[] = [];
-	if (clip.content.kind === "audioLoop") {
-		if (!assetIds.has(clip.content.assetId)) {
-			issues.push(
-				issue(
-					"dangling_reference",
-					[...path, "content", "assetId"],
-					`Clip ${clip.id} references missing asset ${clip.content.assetId}`,
-				),
-			);
-		}
-		// INS-02: "Every loop declares source BPM and bar length." The source BPM
-		// is range-checked by the clip content schema (SONG_TEMPO); the bar length
-		// is checked here because a tempo-labelled loop is authored to a whole
-		// number of bars — that is what lets its boundaries stay aligned when the
-		// song tempo moves. A length that is not a multiple of one bar could never
-		// tile the arrangement grid cleanly, so it is malformed input, not content
-		// to repair.
-		if (clip.lengthTicks % TICKS_PER_BAR !== 0) {
-			issues.push(
-				issue(
-					"invalid_musical_time",
-					[...path, "lengthTicks"],
-					`Audio loop clip ${clip.id} has length ${clip.lengthTicks} ticks, which is not a whole number of bars (${TICKS_PER_BAR} ticks)`,
-				),
-			);
-		}
-		// The authored start offset selects where inside the loop its first repeat
-		// begins; an offset at or past the loop's own length would skip the entire
-		// clip and leave nothing to play, so it is rejected rather than silently
-		// wrapping.
-		if (clip.content.startOffsetTicks >= clip.lengthTicks) {
-			issues.push(
-				issue(
-					"invalid_musical_time",
-					[...path, "content", "startOffsetTicks"],
-					`Audio loop clip ${clip.id} start offset ${clip.content.startOffsetTicks} is not before its length ${clip.lengthTicks}`,
-				),
-			);
-		}
-		return issues;
-	}
-	const padIds = new Set(
-		owner?.instrument?.kind === "drumMachine"
-			? owner.instrument.pads.map((pad) => pad.id)
-			: [],
-	);
-	clip.content.events.forEach((event, index) => {
-		const eventPath = [...path, "content", "events", index] as const;
-		if (event.trigger.kind === "pad" && !padIds.has(event.trigger.padId)) {
-			issues.push(
-				issue(
-					"dangling_reference",
-					[...eventPath, "trigger", "padId"],
-					`Note ${event.id} triggers pad ${event.trigger.padId}, which its track does not own`,
-				),
-			);
-		}
-	});
 	return issues;
 }
 

--- a/src/domain/parse/clip.ts
+++ b/src/domain/parse/clip.ts
@@ -1,0 +1,108 @@
+import type { Clip, Track } from "../entities";
+import { TICKS_PER_BAR } from "../time";
+import { claimId, type DomainIssue, issue } from "./primitives";
+
+/**
+ * Clip-local integrity: everything a clip document can be judged on without its
+ * owning track or the song's assets. Both `parseClip` and the aggregate path run
+ * this, so the two entry points agree on what a valid clip is.
+ *
+ * Aggregate callers pass their `seenIds` set so event IDs are also unique across
+ * the whole project.
+ */
+export function checkClipInvariants(
+	clip: Clip,
+	path: ReadonlyArray<string | number>,
+	seenIds: Set<string> = new Set(),
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	if (clip.content.kind !== "notes") {
+		return issues;
+	}
+	clip.content.events.forEach((event, index) => {
+		const eventPath = [...path, "content", "events", index] as const;
+		claimId(seenIds, event.id, [...eventPath, "id"], issues);
+		if (event.startTicks >= clip.lengthTicks) {
+			issues.push(
+				issue(
+					"invalid_musical_time",
+					[...eventPath, "startTicks"],
+					`Note ${event.id} starts at ${event.startTicks} which is outside its ${clip.lengthTicks}-tick clip`,
+				),
+			);
+		}
+	});
+	return issues;
+}
+
+/**
+ * Clip integrity that depends on the clip's owner and the song's assets, and so
+ * is only decidable in the aggregate path.
+ */
+export function checkClipOwnership(
+	clip: Clip,
+	owner: Track | undefined,
+	assetIds: ReadonlySet<string>,
+	path: ReadonlyArray<string | number>,
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	if (clip.content.kind === "audioLoop") {
+		if (!assetIds.has(clip.content.assetId)) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "content", "assetId"],
+					`Clip ${clip.id} references missing asset ${clip.content.assetId}`,
+				),
+			);
+		}
+		// INS-02: "Every loop declares source BPM and bar length." The source BPM
+		// is range-checked by the clip content schema (SONG_TEMPO); the bar length
+		// is checked here because a tempo-labelled loop is authored to a whole
+		// number of bars — that is what lets its boundaries stay aligned when the
+		// song tempo moves. A length that is not a multiple of one bar could never
+		// tile the arrangement grid cleanly, so it is malformed input, not content
+		// to repair.
+		if (clip.lengthTicks % TICKS_PER_BAR !== 0) {
+			issues.push(
+				issue(
+					"invalid_musical_time",
+					[...path, "lengthTicks"],
+					`Audio loop clip ${clip.id} has length ${clip.lengthTicks} ticks, which is not a whole number of bars (${TICKS_PER_BAR} ticks)`,
+				),
+			);
+		}
+		// The authored start offset selects where inside the loop its first repeat
+		// begins; an offset at or past the loop's own length would skip the entire
+		// clip and leave nothing to play, so it is rejected rather than silently
+		// wrapping.
+		if (clip.content.startOffsetTicks >= clip.lengthTicks) {
+			issues.push(
+				issue(
+					"invalid_musical_time",
+					[...path, "content", "startOffsetTicks"],
+					`Audio loop clip ${clip.id} start offset ${clip.content.startOffsetTicks} is not before its length ${clip.lengthTicks}`,
+				),
+			);
+		}
+		return issues;
+	}
+	const padIds = new Set(
+		owner?.instrument?.kind === "drumMachine"
+			? owner.instrument.pads.map((pad) => pad.id)
+			: [],
+	);
+	clip.content.events.forEach((event, index) => {
+		const eventPath = [...path, "content", "events", index] as const;
+		if (event.trigger.kind === "pad" && !padIds.has(event.trigger.padId)) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...eventPath, "trigger", "padId"],
+					`Note ${event.id} triggers pad ${event.trigger.padId}, which its track does not own`,
+				),
+			);
+		}
+	});
+	return issues;
+}


### PR DESCRIPTION
## Summary

Second PR in the REFACTOR-002 stack (see #143 and #146). Builds on #146 (primitives extraction).

Moves the clip invariants out of `parse.ts`:
- `checkClipInvariants` (exported — clip-local rules both `parseClip` and the aggregate path share)
- `checkClipOwnership` (module-private — owner/asset-dependent rules only the aggregate path can check)

into `src/domain/parse/clip.ts`. `parse.ts` re-exports `checkClipInvariants` unchanged, so no consumer import changes.

Pure structural move — no behavior change, no logic altered.

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run check` — passes
- [x] `bun run test` — `src/domain/parse.test.ts` passes unchanged. Full relevant-scope suite: 928/929 passing; the one failure (`src/commands/devices.test.ts` eight-insert ceiling test) is pre-existing on `main`, unrelated to this stack (see #146 for verification).

## Walkthrough
No user-visible change — pure domain-layer refactor.

Refs #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)