### PR TITLE
REFACTOR-002 (3 of 6): extract automation invariants

### DIFF
--- a/src/domain/parse.ts
+++ b/src/domain/parse.ts
@@ -19,6 +19,7 @@ import {
 	SAMPLER_SAMPLE_END,
 	SAMPLER_SAMPLE_START,
 } from "./parameters";
+import { checkAutomationLane } from "./parse/automation";
 import { checkClipInvariants, checkClipOwnership } from "./parse/clip";
 import {
 	checkOrdering,
@@ -58,8 +59,8 @@ export const MAX_RETURN_BUSES = 8;
  *
  * This file is being split into per-concern modules under `./parse/*` so a
  * new invariant lands in its own file instead of appending to one growing
- * one (REFACTOR-002). The issue primitives and clip invariants have moved
- * out so far; the rest still live here.
+ * one (REFACTOR-002). The issue primitives, clip invariants, and automation
+ * invariants have moved out so far; the rest still live here.
  */
 
 /**
@@ -711,108 +712,5 @@ function checkDeviceChain(
 			"devices",
 		),
 	);
-	return issues;
-}
-
-function checkAutomationLane(
-	lane: Song["automation"][number],
-	path: ReadonlyArray<string | number>,
-	tracks: ReadonlyMap<string, Track>,
-	returnIds: ReadonlySet<string>,
-): DomainIssue[] {
-	const issues: DomainIssue[] = [];
-	const target = lane.target;
-
-	if ("trackId" in target) {
-		const track = tracks.get(target.trackId);
-		if (!track) {
-			issues.push(
-				issue(
-					"dangling_reference",
-					[...path, "target", "trackId"],
-					`Automation ${lane.id} targets missing track ${target.trackId}`,
-				),
-			);
-		} else if (target.scope === "trackDevice") {
-			const device = track.devices.find(
-				(entry) => entry.id === target.deviceId,
-			);
-			if (!device) {
-				issues.push(
-					issue(
-						"dangling_reference",
-						[...path, "target", "deviceId"],
-						`Automation ${lane.id} targets missing device ${target.deviceId} on track ${track.id}`,
-					),
-				);
-			}
-		} else if (target.scope === "send") {
-			const send = track.sendConfig.find(
-				(entry) => entry.returnId === target.returnId,
-			);
-			if (!send) {
-				issues.push(
-					issue(
-						"dangling_reference",
-						[...path, "target", "returnId"],
-						`Automation ${lane.id} targets a send to ${target.returnId} that track ${track.id} does not have`,
-					),
-				);
-			}
-		}
-	}
-
-	if (target.scope === "return" && !returnIds.has(target.returnId)) {
-		issues.push(
-			issue(
-				"dangling_reference",
-				[...path, "target", "returnId"],
-				`Automation ${lane.id} targets missing return bus ${target.returnId}`,
-			),
-		);
-	}
-
-	const definition = getParameterDefinition(target.parameterId);
-	if (!definition) {
-		issues.push(
-			issue(
-				"invalid_automation",
-				[...path, "target", "parameterId"],
-				`Automation ${lane.id} targets unknown parameter "${target.parameterId}"`,
-			),
-		);
-	} else if (!definition.automatable) {
-		issues.push(
-			issue(
-				"invalid_automation",
-				[...path, "target", "parameterId"],
-				`Parameter "${definition.id}" does not support automation`,
-			),
-		);
-	}
-
-	let previousTick = -1;
-	lane.points.forEach((point, index) => {
-		if (point.tick <= previousTick) {
-			issues.push(
-				issue(
-					"invalid_automation",
-					[...path, "points", index, "tick"],
-					`Automation points must be ordered by strictly increasing tick, received ${point.tick} after ${previousTick}`,
-				),
-			);
-		}
-		previousTick = point.tick;
-		if (definition && !isParameterValueInRange(definition, point.value)) {
-			issues.push(
-				issue(
-					"invalid_parameter",
-					[...path, "points", index, "value"],
-					`Value ${point.value} is outside the declared range ${definition.min}..${definition.max} for "${definition.id}"`,
-				),
-			);
-		}
-	});
-
 	return issues;
 }

--- a/src/domain/parse/automation.ts
+++ b/src/domain/parse/automation.ts
@@ -1,0 +1,106 @@
+import type { Song, Track } from "../entities";
+import { getParameterDefinition, isParameterValueInRange } from "../parameters";
+import { type DomainIssue, issue } from "./primitives";
+
+export function checkAutomationLane(
+	lane: Song["automation"][number],
+	path: ReadonlyArray<string | number>,
+	tracks: ReadonlyMap<string, Track>,
+	returnIds: ReadonlySet<string>,
+): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	const target = lane.target;
+
+	if ("trackId" in target) {
+		const track = tracks.get(target.trackId);
+		if (!track) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "target", "trackId"],
+					`Automation ${lane.id} targets missing track ${target.trackId}`,
+				),
+			);
+		} else if (target.scope === "trackDevice") {
+			const device = track.devices.find(
+				(entry) => entry.id === target.deviceId,
+			);
+			if (!device) {
+				issues.push(
+					issue(
+						"dangling_reference",
+						[...path, "target", "deviceId"],
+						`Automation ${lane.id} targets missing device ${target.deviceId} on track ${track.id}`,
+					),
+				);
+			}
+		} else if (target.scope === "send") {
+			const send = track.sendConfig.find(
+				(entry) => entry.returnId === target.returnId,
+			);
+			if (!send) {
+				issues.push(
+					issue(
+						"dangling_reference",
+						[...path, "target", "returnId"],
+						`Automation ${lane.id} targets a send to ${target.returnId} that track ${track.id} does not have`,
+					),
+				);
+			}
+		}
+	}
+
+	if (target.scope === "return" && !returnIds.has(target.returnId)) {
+		issues.push(
+			issue(
+				"dangling_reference",
+				[...path, "target", "returnId"],
+				`Automation ${lane.id} targets missing return bus ${target.returnId}`,
+			),
+		);
+	}
+
+	const definition = getParameterDefinition(target.parameterId);
+	if (!definition) {
+		issues.push(
+			issue(
+				"invalid_automation",
+				[...path, "target", "parameterId"],
+				`Automation ${lane.id} targets unknown parameter "${target.parameterId}"`,
+			),
+		);
+	} else if (!definition.automatable) {
+		issues.push(
+			issue(
+				"invalid_automation",
+				[...path, "target", "parameterId"],
+				`Parameter "${definition.id}" does not support automation`,
+			),
+		);
+	}
+
+	let previousTick = -1;
+	lane.points.forEach((point, index) => {
+		if (point.tick <= previousTick) {
+			issues.push(
+				issue(
+					"invalid_automation",
+					[...path, "points", index, "tick"],
+					`Automation points must be ordered by strictly increasing tick, received ${point.tick} after ${previousTick}`,
+				),
+			);
+		}
+		previousTick = point.tick;
+		if (definition && !isParameterValueInRange(definition, point.value)) {
+			issues.push(
+				issue(
+					"invalid_parameter",
+					[...path, "points", index, "value"],
+					`Value ${point.value} is outside the declared range ${definition.min}..${definition.max} for "${definition.id}"`,
+				),
+			);
+		}
+	});
+
+	return issues;
+}


### PR DESCRIPTION
## Summary

Third PR in the REFACTOR-002 stack (see #143, #146, #147). Builds on #147 (clip invariants extraction).

Moves `checkAutomationLane` (module-private, called from `checkSongIntegrity`) out of `parse.ts` into `src/domain/parse/automation.ts`. No exported symbol involved, so nothing about the public surface changes.

Pure structural move — no behavior change, no logic altered.

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run check` — passes
- [x] `bun run test` — `src/domain/parse.test.ts` passes unchanged. Full relevant-scope suite: 928/929 passing; the one failure (`src/commands/devices.test.ts` eight-insert ceiling test) is pre-existing on `main`, unrelated to this stack (see #146 for verification).

## Walkthrough
No user-visible change — pure domain-layer refactor.

Refs #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)