### PR TITLE
REFACTOR-001 (1/3): extract EditorHeader and SaveStatus from EditorView

### DIFF
--- a/src/editor/EditorHeader.tsx
+++ b/src/editor/EditorHeader.tsx
@@ -1,0 +1,181 @@
+import { A } from "@solidjs/router";
+import {
+	HiSolidArrowPathRoundedSquare,
+	HiSolidArrowUturnLeft,
+	HiSolidArrowUturnRight,
+	HiSolidMusicalNote,
+	HiSolidPlay,
+	HiSolidQuestionMarkCircle,
+	HiSolidRectangleStack,
+	HiSolidSquares2x2,
+	HiSolidStop,
+} from "solid-icons/hi";
+import { type Accessor, Show } from "solid-js";
+import { MAX_TEMPO_BPM, MIN_TEMPO_BPM } from "../audio/Transport";
+import type { TimeSignature } from "../domain/entities";
+import type { SaveStatus as SaveStatusValue } from "../persistence/autosave";
+import type { shortcutLabel } from "../shortcuts";
+import SaveStatus from "./SaveStatus";
+
+export interface EditorHeaderProps {
+	readonly projectName: string;
+	readonly canUndo: boolean;
+	readonly undoSummary: string | null;
+	readonly canRedo: boolean;
+	readonly redoSummary: string | null;
+	readonly onUndo: () => void;
+	readonly onRedo: () => void;
+	readonly isPlaying: Accessor<boolean>;
+	readonly onTogglePlay: () => void;
+	readonly loopEnabled: Accessor<boolean>;
+	readonly onToggleLoop: () => void;
+	readonly metronomeEnabled: Accessor<boolean>;
+	readonly onToggleMetronome: () => void;
+	readonly tempo: Accessor<number>;
+	readonly onTempoChange: (value: number) => void;
+	readonly timeSignature: Accessor<TimeSignature | null>;
+	readonly playheadLabel: Accessor<string>;
+	readonly libraryOpen: Accessor<boolean>;
+	readonly onToggleLibrary: () => void;
+	readonly onOpenGuide: () => void;
+	readonly keyHint: (action: Parameters<typeof shortcutLabel>[0]) => string;
+	readonly saveStatus: Accessor<SaveStatusValue | null>;
+	readonly onRetrySave: () => void;
+}
+
+/**
+ * The editor's top bar: back link, project name, transport controls, tempo,
+ * time signature, playhead, the Library/shortcut-guide toggles, and the
+ * `SaveStatus` group. Split out of `EditorView` (`REFACTOR-001`) purely to
+ * shrink the parent's merge-clash surface — no behavior changed, so every
+ * prop here mirrors the exact value/handler `EditorView` used to close over
+ * directly.
+ */
+export default function EditorHeader(props: EditorHeaderProps) {
+	return (
+		<header class="editor-header">
+			<A
+				class="back-to-projects"
+				href="/dashboard"
+				aria-label="Projects"
+				title="Projects"
+			>
+				<HiSolidSquares2x2 size={18} />
+			</A>
+			<h1 class="project-name">{props.projectName}</h1>
+			<div class="transport-controls">
+				<button
+					type="button"
+					class="undo-button"
+					disabled={!props.canUndo}
+					aria-label={props.undoSummary ? `Undo ${props.undoSummary}` : "Undo"}
+					title={`${props.undoSummary ?? "Undo"} (${props.keyHint("edit.undo")})`}
+					onClick={() => props.onUndo()}
+				>
+					<HiSolidArrowUturnLeft size={18} />
+				</button>
+				<button
+					type="button"
+					class="redo-button"
+					disabled={!props.canRedo}
+					aria-label={props.redoSummary ? `Redo ${props.redoSummary}` : "Redo"}
+					title={`${props.redoSummary ?? "Redo"} (${props.keyHint("edit.redo")})`}
+					onClick={() => props.onRedo()}
+				>
+					<HiSolidArrowUturnRight size={18} />
+				</button>
+				<button
+					type="button"
+					class="transport-toggle"
+					onClick={() => props.onTogglePlay()}
+					aria-pressed={props.isPlaying()}
+					aria-label={props.isPlaying() ? "Stop playback" : "Start playback"}
+					title={`${props.isPlaying() ? "Stop" : "Play"} (${props.keyHint(
+						"transport.play_stop",
+					)})`}
+				>
+					<Show when={props.isPlaying()} fallback={<HiSolidPlay size={22} />}>
+						<HiSolidStop size={22} />
+					</Show>
+				</button>
+				<button
+					type="button"
+					class="loop-toggle"
+					onClick={() => props.onToggleLoop()}
+					aria-pressed={props.loopEnabled()}
+					aria-label={props.loopEnabled() ? "Disable loop" : "Enable loop"}
+					title={props.loopEnabled() ? "Disable loop" : "Enable loop"}
+				>
+					<HiSolidArrowPathRoundedSquare size={18} />
+				</button>
+				<button
+					type="button"
+					class="metronome-toggle"
+					onClick={() => props.onToggleMetronome()}
+					aria-pressed={props.metronomeEnabled()}
+					aria-label={
+						props.metronomeEnabled() ? "Disable metronome" : "Enable metronome"
+					}
+					title={`Metronome (${props.keyHint("transport.metronome")})`}
+				>
+					<HiSolidMusicalNote size={18} />
+				</button>
+				<div class="tempo-control">
+					{/* The label is the input's only accessible name — no
+					    aria-label to override it — and the unit is decorative
+					    text the name already carries. */}
+					<label class="visually-hidden" for="tempo-input">
+						Tempo (BPM)
+					</label>
+					<input
+						id="tempo-input"
+						type="number"
+						class="tempo-input"
+						min={MIN_TEMPO_BPM}
+						max={MAX_TEMPO_BPM}
+						step={1}
+						value={props.tempo()}
+						onChange={(event) =>
+							props.onTempoChange(event.currentTarget.valueAsNumber)
+						}
+					/>
+					<span class="tempo-unit" aria-hidden="true">
+						BPM
+					</span>
+				</div>
+				<Show when={props.timeSignature()}>
+					{(signature) => (
+						<span class="time-signature" title="Time signature (fixed at 4/4)">
+							<span class="visually-hidden">Time signature </span>
+							{signature().numerator}/{signature().denominator}
+						</span>
+					)}
+				</Show>
+				<span class="playhead-position" title="Playhead (bar.beat)">
+					<span class="visually-hidden">Playhead at bar </span>
+					{props.playheadLabel()}
+				</span>
+			</div>
+			<button
+				type="button"
+				class="library-toggle"
+				aria-label="Library"
+				aria-pressed={props.libraryOpen()}
+				title="Library"
+				onClick={() => props.onToggleLibrary()}
+			>
+				<HiSolidRectangleStack size={18} />
+			</button>
+			<button
+				type="button"
+				class="shortcut-guide-button"
+				aria-label="Keyboard shortcuts"
+				title={`Keyboard shortcuts (${props.keyHint("help.shortcut_guide")})`}
+				onClick={() => props.onOpenGuide()}
+			>
+				<HiSolidQuestionMarkCircle size={18} />
+			</button>
+			<SaveStatus saveStatus={props.saveStatus} onRetry={props.onRetrySave} />
+		</header>
+	);
+}

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -1,15 +1,3 @@
-import { A } from "@solidjs/router";
-import {
-	HiSolidArrowPathRoundedSquare,
-	HiSolidArrowUturnLeft,
-	HiSolidArrowUturnRight,
-	HiSolidMusicalNote,
-	HiSolidPlay,
-	HiSolidQuestionMarkCircle,
-	HiSolidRectangleStack,
-	HiSolidSquares2x2,
-	HiSolidStop,
-} from "solid-icons/hi";
 import {
 	createMemo,
 	createResource,
@@ -22,7 +10,7 @@ import {
 } from "solid-js";
 import ArrangementView from "../arrangement/ArrangementView";
 import { getAudioRuntime } from "../audio/AudioRuntime";
-import { clampTempo, MAX_TEMPO_BPM, MIN_TEMPO_BPM } from "../audio/Transport";
+import { clampTempo } from "../audio/Transport";
 import { setParameter } from "../commands/definitions/parameters";
 import ProjectNotFound from "../components/ProjectNotFound";
 import TapeLoader from "../components/TapeLoader";
@@ -35,12 +23,12 @@ import SynthPanel from "../instrument/SynthPanel";
 import type { PreviewEngine } from "../library/audition";
 import LibraryBrowser from "../library/LibraryBrowser";
 import { ToneAuditionEngine } from "../library/toneAuditionEngine";
-import type { SaveFailureReason } from "../persistence/projectRepository";
 import { getProjectRepository } from "../projectRepositoryClient";
 import type { ShortcutContext, ShortcutHandlers } from "../shortcuts";
 import { shortcutLabel, useShortcuts } from "../shortcuts";
 import ShortcutGuide from "../shortcuts/ShortcutGuide";
 import DrumMachinePanel from "./DrumMachinePanel";
+import EditorHeader from "./EditorHeader";
 import LoopInfo from "./LoopInfo";
 import Mixer from "./Mixer";
 import PianoRoll, { type PianoRollActions } from "./PianoRoll";
@@ -59,31 +47,6 @@ export interface EditorViewProps {
 	 */
 	readonly createAuditionEngine?: () => PreviewEngine;
 }
-
-const SAVE_STATUS_LABEL: Record<string, string> = {
-	idle: "",
-	pending: "Saving…",
-	saving: "Saving…",
-	saved: "Saved",
-	failed: "Save failed",
-};
-
-/**
- * Actionable text for the PRD `PRJ-03` "actionable Save failed" state. Never
- * the repository's raw `SaveFailure.message` — that can carry backend error
- * text not meant for a user-facing surface — and never the reason string
- * itself, which is an internal, unlocalized identifier.
- */
-const SAVE_FAILURE_REASON_LABEL: Record<SaveFailureReason, string> = {
-	unavailable: "Check your connection.",
-	revision_conflict: "This project changed in another tab or session.",
-	not_found: "This project no longer exists.",
-	already_exists: "A save conflict occurred.",
-	unsupported_schema_version:
-		"This project needs a newer version of Solid Groove.",
-	invalid_document: "Something about this save wasn't valid.",
-	document_too_large: "This project is too large to save further changes.",
-};
 
 /**
  * The project editor: open a schema-v1 project, program its clip — on the
@@ -363,14 +326,7 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		return dependency ? `${dependency.packId} @ ${dependency.version}` : null;
 	});
 
-	const saveStatusLabel = createMemo(
-		() => SAVE_STATUS_LABEL[session.state.saveStatus?.state ?? "idle"],
-	);
-	const saveFailure = createMemo(() => session.state.saveStatus?.failure);
-	const saveFailureMessage = createMemo(() => {
-		const failure = saveFailure();
-		return failure ? SAVE_FAILURE_REASON_LABEL[failure.reason] : null;
-	});
+	const saveStatus = createMemo(() => session.state.saveStatus);
 
 	return (
 		<main class="editor">
@@ -401,175 +357,31 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 				<Match when={project()}>
 					{(currentProject) => (
 						<>
-							<header class="editor-header">
-								<A
-									class="back-to-projects"
-									href="/dashboard"
-									aria-label="Projects"
-									title="Projects"
-								>
-									<HiSolidSquares2x2 size={18} />
-								</A>
-								<h1 class="project-name">{currentProject().metadata.name}</h1>
-								<div class="transport-controls">
-									<button
-										type="button"
-										class="undo-button"
-										disabled={!session.state.canUndo}
-										aria-label={
-											session.state.undoSummary
-												? `Undo ${session.state.undoSummary}`
-												: "Undo"
-										}
-										title={`${session.state.undoSummary ?? "Undo"} (${keyHint("edit.undo")})`}
-										onClick={() => session.undo()}
-									>
-										<HiSolidArrowUturnLeft size={18} />
-									</button>
-									<button
-										type="button"
-										class="redo-button"
-										disabled={!session.state.canRedo}
-										aria-label={
-											session.state.redoSummary
-												? `Redo ${session.state.redoSummary}`
-												: "Redo"
-										}
-										title={`${session.state.redoSummary ?? "Redo"} (${keyHint("edit.redo")})`}
-										onClick={() => session.redo()}
-									>
-										<HiSolidArrowUturnRight size={18} />
-									</button>
-									<button
-										type="button"
-										class="transport-toggle"
-										onClick={() => void audio.toggle()}
-										aria-pressed={audio.isPlaying()}
-										aria-label={
-											audio.isPlaying() ? "Stop playback" : "Start playback"
-										}
-										title={`${audio.isPlaying() ? "Stop" : "Play"} (${keyHint(
-											"transport.play_stop",
-										)})`}
-									>
-										<Show
-											when={audio.isPlaying()}
-											fallback={<HiSolidPlay size={22} />}
-										>
-											<HiSolidStop size={22} />
-										</Show>
-									</button>
-									<button
-										type="button"
-										class="loop-toggle"
-										onClick={() => audio.toggleLoop()}
-										aria-pressed={audio.loopEnabled()}
-										aria-label={
-											audio.loopEnabled() ? "Disable loop" : "Enable loop"
-										}
-										title={audio.loopEnabled() ? "Disable loop" : "Enable loop"}
-									>
-										<HiSolidArrowPathRoundedSquare size={18} />
-									</button>
-									<button
-										type="button"
-										class="metronome-toggle"
-										onClick={() => audio.toggleMetronome()}
-										aria-pressed={audio.metronomeEnabled()}
-										aria-label={
-											audio.metronomeEnabled()
-												? "Disable metronome"
-												: "Enable metronome"
-										}
-										title={`Metronome (${keyHint("transport.metronome")})`}
-									>
-										<HiSolidMusicalNote size={18} />
-									</button>
-									<div class="tempo-control">
-										{/* The label is the input's only accessible name — no
-										    aria-label to override it — and the unit is decorative
-										    text the name already carries. */}
-										<label class="visually-hidden" for="tempo-input">
-											Tempo (BPM)
-										</label>
-										<input
-											id="tempo-input"
-											type="number"
-											class="tempo-input"
-											min={MIN_TEMPO_BPM}
-											max={MAX_TEMPO_BPM}
-											step={1}
-											value={tempo()}
-											onChange={(event) =>
-												applyTempo(event.currentTarget.valueAsNumber)
-											}
-										/>
-										<span class="tempo-unit" aria-hidden="true">
-											BPM
-										</span>
-									</div>
-									<Show when={timeSignature()}>
-										{(signature) => (
-											<span
-												class="time-signature"
-												title="Time signature (fixed at 4/4)"
-											>
-												<span class="visually-hidden">Time signature </span>
-												{signature().numerator}/{signature().denominator}
-											</span>
-										)}
-									</Show>
-									<span class="playhead-position" title="Playhead (bar.beat)">
-										<span class="visually-hidden">Playhead at bar </span>
-										{playheadLabel()}
-									</span>
-								</div>
-								<button
-									type="button"
-									class="library-toggle"
-									aria-label="Library"
-									aria-pressed={libraryOpen()}
-									title="Library"
-									onClick={() => setLibraryOpen((open) => !open)}
-								>
-									<HiSolidRectangleStack size={18} />
-								</button>
-								<button
-									type="button"
-									class="shortcut-guide-button"
-									aria-label="Keyboard shortcuts"
-									title={`Keyboard shortcuts (${keyHint("help.shortcut_guide")})`}
-									onClick={() => setGuideOpen(true)}
-								>
-									<HiSolidQuestionMarkCircle size={18} />
-								</button>
-								<div class="save-status-group">
-									<div
-										class="save-status"
-										data-state={session.state.saveStatus?.state}
-										data-revision={session.state.saveStatus?.revision}
-										title={`Revision ${session.state.saveStatus?.revision ?? 0}`}
-									>
-										{saveStatusLabel()}
-									</div>
-									<Show when={saveFailure()}>
-										<div class="save-recovery" role="alert">
-											<span class="save-recovery-message">
-												{saveFailureMessage()}
-											</span>
-											<Show when={saveFailure()?.retryable}>
-												<button
-													type="button"
-													class="save-retry-button"
-													onClick={() => void session.retry()}
-												>
-													Retry
-												</button>
-											</Show>
-										</div>
-									</Show>
-								</div>
-							</header>
+							<EditorHeader
+								projectName={currentProject().metadata.name}
+								canUndo={session.state.canUndo}
+								undoSummary={session.state.undoSummary}
+								canRedo={session.state.canRedo}
+								redoSummary={session.state.redoSummary}
+								onUndo={() => session.undo()}
+								onRedo={() => session.redo()}
+								isPlaying={audio.isPlaying}
+								onTogglePlay={() => void audio.toggle()}
+								loopEnabled={audio.loopEnabled}
+								onToggleLoop={() => audio.toggleLoop()}
+								metronomeEnabled={audio.metronomeEnabled}
+								onToggleMetronome={() => audio.toggleMetronome()}
+								tempo={tempo}
+								onTempoChange={applyTempo}
+								timeSignature={timeSignature}
+								playheadLabel={playheadLabel}
+								libraryOpen={libraryOpen}
+								onToggleLibrary={() => setLibraryOpen((open) => !open)}
+								onOpenGuide={() => setGuideOpen(true)}
+								keyHint={keyHint}
+								saveStatus={saveStatus}
+								onRetrySave={() => void session.retry()}
+							/>
 							<div class="arrangement-panel">
 								<ArrangementView
 									project={currentProject()}

--- a/src/editor/SaveStatus.tsx
+++ b/src/editor/SaveStatus.tsx
@@ -1,0 +1,76 @@
+import { type Accessor, Show } from "solid-js";
+import type { SaveStatus as SaveStatusValue } from "../persistence/autosave";
+import type { SaveFailureReason } from "../persistence/projectRepository";
+
+const SAVE_STATUS_LABEL: Record<string, string> = {
+	idle: "",
+	pending: "Saving…",
+	saving: "Saving…",
+	saved: "Saved",
+	failed: "Save failed",
+};
+
+/**
+ * Actionable text for the PRD `PRJ-03` "actionable Save failed" state. Never
+ * the repository's raw `SaveFailure.message` — that can carry backend error
+ * text not meant for a user-facing surface — and never the reason string
+ * itself, which is an internal, unlocalized identifier.
+ */
+const SAVE_FAILURE_REASON_LABEL: Record<SaveFailureReason, string> = {
+	unavailable: "Check your connection.",
+	revision_conflict: "This project changed in another tab or session.",
+	not_found: "This project no longer exists.",
+	already_exists: "A save conflict occurred.",
+	unsupported_schema_version:
+		"This project needs a newer version of Solid Groove.",
+	invalid_document: "Something about this save wasn't valid.",
+	document_too_large: "This project is too large to save further changes.",
+};
+
+export interface SaveStatusProps {
+	readonly saveStatus: Accessor<SaveStatusValue | null>;
+	readonly onRetry: () => void;
+}
+
+/**
+ * The header's save-status readout plus the PRD `PRJ-03` actionable
+ * Save-failed alert (retry when retryable, a plain reason otherwise). Split
+ * out of `EditorHeader` because it is fully self-contained: everything it
+ * needs comes from `saveStatus`.
+ */
+export default function SaveStatus(props: SaveStatusProps) {
+	const saveStatusLabel = () =>
+		SAVE_STATUS_LABEL[props.saveStatus()?.state ?? "idle"];
+	const saveFailure = () => props.saveStatus()?.failure;
+	const saveFailureMessage = () => {
+		const failure = saveFailure();
+		return failure ? SAVE_FAILURE_REASON_LABEL[failure.reason] : null;
+	};
+
+	return (
+		<div class="save-status-group">
+			<div
+				class="save-status"
+				data-state={props.saveStatus()?.state}
+				data-revision={props.saveStatus()?.revision}
+				title={`Revision ${props.saveStatus()?.revision ?? 0}`}
+			>
+				{saveStatusLabel()}
+			</div>
+			<Show when={saveFailure()}>
+				<div class="save-recovery" role="alert">
+					<span class="save-recovery-message">{saveFailureMessage()}</span>
+					<Show when={saveFailure()?.retryable}>
+						<button
+							type="button"
+							class="save-retry-button"
+							onClick={() => props.onRetry()}
+						>
+							Retry
+						</button>
+					</Show>
+				</div>
+			</Show>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

First of a 3-PR stack breaking `src/editor/EditorView.tsx` (750 lines on `main`) into a shallow component hierarchy, per #142. Pure structural move — no user-visible behavior change.

- `EditorHeader` — the whole `<header class="editor-header">` block: back-link, project name, transport controls (undo/redo/play/loop/metronome), tempo input, time signature, playhead, library toggle, shortcut-guide button.
- `SaveStatus` — split further out of the header's `save-status-group` div (including the PRD `PRJ-03` failure/retry alert), since it is fully self-contained.

Every prop mirrors the exact value/handler `EditorView` used to close over directly (signals passed as accessors, not unwrapped values, where the original read them reactively — e.g. `isPlaying={audio.isPlaying}`, `tempo={tempo}`, `saveStatus={saveStatus}`).

No CSS changes: `EditorView.css` selectors are all scoped as `.editor-header ...`, which is a global class regardless of which component file renders the markup.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run test -- src/editor/EditorView.test.tsx` — all 22 tests pass unchanged (no test file edits in this PR)
- [x] `bun run check` — clean

## Walkthrough

No user-visible change — pure structural refactor. Evidence is `EditorView.test.tsx` (610 lines, untouched) passing unchanged; it renders `EditorView` as a black box throughout and asserts on rendered roles/labels/titles, which are byte-identical before and after this move.

Refs #142 — 1 of 3, base of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)