### PR TITLE
REFACTOR-001 (2/3): extract TrackEditor and InstrumentPanel from EditorView

### DIFF
--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -18,8 +18,7 @@ import type { NoteTrigger } from "../domain/entities";
 import type { EventId } from "../domain/ids";
 import { SONG_TEMPO } from "../domain/parameters";
 import { formatBarsBeatsSixteenths, TICKS_PER_QUARTER } from "../domain/time";
-import SamplerPanel, { type SampleChoice } from "../instrument/SamplerPanel";
-import SynthPanel from "../instrument/SynthPanel";
+import type { SampleChoice } from "../instrument/SamplerPanel";
 import type { PreviewEngine } from "../library/audition";
 import LibraryBrowser from "../library/LibraryBrowser";
 import { ToneAuditionEngine } from "../library/toneAuditionEngine";
@@ -31,9 +30,10 @@ import DrumMachinePanel from "./DrumMachinePanel";
 import EditorHeader from "./EditorHeader";
 import LoopInfo from "./LoopInfo";
 import Mixer from "./Mixer";
-import PianoRoll, { type PianoRollActions } from "./PianoRoll";
-import StepEditor, { deleteSelectedNotes } from "./StepEditor";
+import type { PianoRollActions } from "./PianoRoll";
+import { deleteSelectedNotes } from "./StepEditor";
 import { playbackStep as playbackStepOf } from "./stepEditorModel";
+import TrackEditor from "./TrackEditor";
 import { useEditorSession } from "./useEditorSession";
 import { useProjectAudio } from "./useProjectAudio";
 import "./EditorView.css";
@@ -450,90 +450,25 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 										}
 									>
 										{(currentClip) => (
-											<div class="track-editor">
-												<div class="track-info">
-													<span class="track-name">{track()?.name}</span>
-													<Show when={packDependencyLabel()}>
-														<span class="pack-dependency">
-															Pack: {packDependencyLabel()}
-														</span>
-													</Show>
-												</div>
-												{/*
-												 * A synth track's note clip gets the CLP-03 piano
-												 * roll; everything else stays on LOOP-010's CLP-02
-												 * step editor. Pitched notes want two dimensions
-												 * (pitch x time), which a one-row-per-step grid
-												 * cannot show.
-												 */}
-												<Show
-													when={showPianoRoll()}
-													fallback={
-														<StepEditor
-															clip={currentClip()}
-															instrument={instrument()}
-															dispatch={session.dispatch}
-															beginGesture={session.beginGesture}
-															playbackStep={editorPlaybackStep}
-															selectedIds={selectedNoteIds}
-															setSelectedIds={setSelectedNoteIds}
-														/>
-													}
-												>
-													<PianoRoll
-														clip={currentClip()}
-														project={currentProject()}
-														dispatch={session.dispatch}
-														beginGesture={session.beginGesture}
-														playheadTicks={audio.positionTicks()}
-														registerActions={setPianoRollActions}
-													/>
-												</Show>
-												<Show when={instrumentPanelTrackId()}>
-													{(trackId) => (
-														<Switch>
-															<Match
-																when={
-																	instrument()?.kind === "sampler" &&
-																	(instrument() as Extract<
-																		NonNullable<ReturnType<typeof instrument>>,
-																		{ kind: "sampler" }
-																	>)
-																}
-															>
-																{(sampler) => (
-																	<SamplerPanel
-																		trackId={trackId()}
-																		instrument={sampler()}
-																		sampleName={sampleName()}
-																		replacementOptions={replacementOptions()}
-																		dispatch={session.dispatch}
-																		audition={auditionInstrument}
-																	/>
-																)}
-															</Match>
-															<Match
-																when={
-																	instrument()?.kind === "synth" &&
-																	(instrument() as Extract<
-																		NonNullable<ReturnType<typeof instrument>>,
-																		{ kind: "synth" }
-																	>)
-																}
-															>
-																{(synth) => (
-																	<SynthPanel
-																		trackId={trackId()}
-																		instrument={synth()}
-																		dispatch={session.dispatch}
-																		audition={auditionInstrument}
-																	/>
-																)}
-															</Match>
-														</Switch>
-													)}
-												</Show>
-											</div>
+											<TrackEditor
+												clip={currentClip()}
+												trackName={track()?.name}
+												packDependencyLabel={packDependencyLabel()}
+												showPianoRoll={showPianoRoll}
+												instrument={instrument()}
+												dispatch={session.dispatch}
+												beginGesture={session.beginGesture}
+												editorPlaybackStep={editorPlaybackStep}
+												selectedNoteIds={selectedNoteIds}
+												setSelectedNoteIds={setSelectedNoteIds}
+												project={currentProject()}
+												playheadTicks={audio.positionTicks()}
+												registerPianoRollActions={setPianoRollActions}
+												instrumentPanelTrackId={instrumentPanelTrackId()}
+												sampleName={sampleName()}
+												replacementOptions={replacementOptions()}
+												auditionInstrument={auditionInstrument}
+											/>
 										)}
 									</Show>
 									<Mixer

--- a/src/editor/InstrumentPanel.tsx
+++ b/src/editor/InstrumentPanel.tsx
@@ -1,0 +1,68 @@
+import { Match, Switch } from "solid-js";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import type { Instrument } from "../domain/entities";
+import type { TrackId } from "../domain/ids";
+import SamplerPanel, { type SampleChoice } from "../instrument/SamplerPanel";
+import SynthPanel from "../instrument/SynthPanel";
+
+export interface InstrumentPanelProps {
+	readonly trackId: TrackId;
+	readonly instrument: Instrument | null;
+	/** Display name of the currently loaded sample, or null when empty. */
+	readonly sampleName: string | null;
+	/** Samples the sampler panel can swap to (a real browser lands with LOOP-013). */
+	readonly replacementOptions: readonly SampleChoice[];
+	dispatch(
+		commands: RawCommandInput | readonly RawCommandInput[],
+	): TransactionResult | undefined;
+	audition(): void;
+}
+
+/**
+ * The sampler/synth instrument panel switch. The drum machine's panel is
+ * mounted separately by `EditorView` (it does not share this track-editor
+ * seam); an instrument of any other kind renders nothing.
+ *
+ * Split out of `EditorView` (`REFACTOR-001`) to encapsulate the `Extract<>`
+ * narrowing this switch needs — `instrument` is a discriminated union and
+ * `Show`'s `when` alone can't narrow it, so each branch re-asserts its own
+ * variant.
+ */
+export default function InstrumentPanel(props: InstrumentPanelProps) {
+	return (
+		<Switch>
+			<Match
+				when={
+					props.instrument?.kind === "sampler" &&
+					(props.instrument as Extract<Instrument, { kind: "sampler" }>)
+				}
+			>
+				{(sampler) => (
+					<SamplerPanel
+						trackId={props.trackId}
+						instrument={sampler()}
+						sampleName={props.sampleName}
+						replacementOptions={props.replacementOptions}
+						dispatch={props.dispatch}
+						audition={props.audition}
+					/>
+				)}
+			</Match>
+			<Match
+				when={
+					props.instrument?.kind === "synth" &&
+					(props.instrument as Extract<Instrument, { kind: "synth" }>)
+				}
+			>
+				{(synth) => (
+					<SynthPanel
+						trackId={props.trackId}
+						instrument={synth()}
+						dispatch={props.dispatch}
+						audition={props.audition}
+					/>
+				)}
+			</Match>
+		</Switch>
+	);
+}

--- a/src/editor/TrackEditor.tsx
+++ b/src/editor/TrackEditor.tsx
@@ -1,0 +1,98 @@
+import { type Accessor, Show } from "solid-js";
+import type {
+	Gesture,
+	GestureOptions,
+	RawCommandInput,
+	TransactionResult,
+} from "../commands";
+import type { Clip, Instrument, Project } from "../domain/entities";
+import type { EventId, TrackId } from "../domain/ids";
+import type { SampleChoice } from "../instrument/SamplerPanel";
+import InstrumentPanel from "./InstrumentPanel";
+import PianoRoll, { type PianoRollActions } from "./PianoRoll";
+import StepEditor from "./StepEditor";
+
+export interface TrackEditorProps {
+	readonly clip: Clip;
+	readonly trackName: string | undefined;
+	readonly packDependencyLabel: string | null;
+	/** A synth track's note clip gets the CLP-03 piano roll instead of the grid. */
+	readonly showPianoRoll: Accessor<boolean>;
+	readonly instrument: Instrument | null;
+	dispatch(
+		commands: RawCommandInput | readonly RawCommandInput[],
+	): TransactionResult | undefined;
+	beginGesture(options?: GestureOptions): Gesture | undefined;
+	readonly editorPlaybackStep: Accessor<number | null>;
+	readonly selectedNoteIds: Accessor<readonly EventId[]>;
+	readonly setSelectedNoteIds: (ids: readonly EventId[]) => void;
+	readonly project: Project;
+	readonly playheadTicks: number;
+	readonly registerPianoRollActions: (actions: PianoRollActions) => void;
+	/** Present only when the instrument gets a panel (sampler or synth). */
+	readonly instrumentPanelTrackId: TrackId | null;
+	readonly sampleName: string | null;
+	readonly replacementOptions: readonly SampleChoice[];
+	readonly auditionInstrument: () => void;
+}
+
+/**
+ * One track's editing surface: track info (name, pack dependency), the
+ * CLP-02 step grid or CLP-03 piano roll switch, and the instrument panel.
+ *
+ * Split out of `EditorView` (`REFACTOR-001`); every prop here mirrors the
+ * exact value/handler `EditorView` used to close over directly, so this is a
+ * pure structural move.
+ */
+export default function TrackEditor(props: TrackEditorProps) {
+	return (
+		<div class="track-editor">
+			<div class="track-info">
+				<span class="track-name">{props.trackName}</span>
+				<Show when={props.packDependencyLabel}>
+					<span class="pack-dependency">Pack: {props.packDependencyLabel}</span>
+				</Show>
+			</div>
+			{/*
+			 * A synth track's note clip gets the CLP-03 piano roll; everything
+			 * else stays on LOOP-010's CLP-02 step editor. Pitched notes want two
+			 * dimensions (pitch x time), which a one-row-per-step grid cannot show.
+			 */}
+			<Show
+				when={props.showPianoRoll()}
+				fallback={
+					<StepEditor
+						clip={props.clip}
+						instrument={props.instrument}
+						dispatch={props.dispatch}
+						beginGesture={props.beginGesture}
+						playbackStep={props.editorPlaybackStep}
+						selectedIds={props.selectedNoteIds}
+						setSelectedIds={props.setSelectedNoteIds}
+					/>
+				}
+			>
+				<PianoRoll
+					clip={props.clip}
+					project={props.project}
+					dispatch={props.dispatch}
+					beginGesture={props.beginGesture}
+					playheadTicks={props.playheadTicks}
+					registerActions={props.registerPianoRollActions}
+				/>
+			</Show>
+			<Show when={props.instrumentPanelTrackId}>
+				{(trackId) => (
+					<InstrumentPanel
+						trackId={trackId()}
+						instrument={props.instrument}
+						sampleName={props.sampleName}
+						replacementOptions={props.replacementOptions}
+						dispatch={props.dispatch}
+						audition={props.auditionInstrument}
+					/>
+				)}
+			</Show>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Second of a 3-PR stack breaking `src/editor/EditorView.tsx` into a shallow component hierarchy, per #142. Builds on #149 (EditorHeader/SaveStatus). Pure structural move — no user-visible behavior change.

- `TrackEditor` — the whole `<div class="track-editor">` block: track info (name, pack dependency), the `StepEditor`/`PianoRoll` `Show` switch, and the instrument panel mount.
- `InstrumentPanel` — the sampler/synth `Switch`, encapsulating the `Extract<Instrument, {...}>` narrowing that switch needs (the discriminated union can't be narrowed by `Show`'s `when` alone). The drum-machine panel is mounted separately by `EditorView` — it isn't part of this seam.

Props again follow the codebase's accessor convention where the original read reactively (`showPianoRoll: Accessor<boolean>`, `selectedNoteIds: Accessor<readonly EventId[]>`, etc.) and plain values where it didn't (`clip`, `project`, `playheadTicks` are read once per render the same way `ArrangementView`/`Mixer` already take them).

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run test -- src/editor/EditorView.test.tsx` — all 22 tests pass unchanged
- [x] `bun run check` — clean

## Walkthrough

No user-visible change — pure structural refactor. Evidence is `EditorView.test.tsx` passing unchanged.

Refs #142 — 2 of 3, builds on #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)