### PR TITLE
REFACTOR-001 (3/3): extract ProjectLoadStates and useEditorShortcuts; closes the issue

### DIFF
--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -12,8 +12,6 @@ import ArrangementView from "../arrangement/ArrangementView";
 import { getAudioRuntime } from "../audio/AudioRuntime";
 import { clampTempo } from "../audio/Transport";
 import { setParameter } from "../commands/definitions/parameters";
-import ProjectNotFound from "../components/ProjectNotFound";
-import TapeLoader from "../components/TapeLoader";
 import type { NoteTrigger } from "../domain/entities";
 import type { EventId } from "../domain/ids";
 import { SONG_TEMPO } from "../domain/parameters";
@@ -23,18 +21,18 @@ import type { PreviewEngine } from "../library/audition";
 import LibraryBrowser from "../library/LibraryBrowser";
 import { ToneAuditionEngine } from "../library/toneAuditionEngine";
 import { getProjectRepository } from "../projectRepositoryClient";
-import type { ShortcutContext, ShortcutHandlers } from "../shortcuts";
-import { shortcutLabel, useShortcuts } from "../shortcuts";
 import ShortcutGuide from "../shortcuts/ShortcutGuide";
 import DrumMachinePanel from "./DrumMachinePanel";
 import EditorHeader from "./EditorHeader";
 import LoopInfo from "./LoopInfo";
 import Mixer from "./Mixer";
 import type { PianoRollActions } from "./PianoRoll";
+import ProjectLoadStates from "./ProjectLoadStates";
 import { deleteSelectedNotes } from "./StepEditor";
 import { playbackStep as playbackStepOf } from "./stepEditorModel";
 import TrackEditor from "./TrackEditor";
 import { useEditorSession } from "./useEditorSession";
+import { useEditorShortcuts } from "./useEditorShortcuts";
 import { useProjectAudio } from "./useProjectAudio";
 import "./EditorView.css";
 
@@ -140,77 +138,6 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		return `${Number(bars) + 1}.${Number(beats) + 1}`;
 	});
 
-	// The KEY-01 registry owns every mapping; this component only says which
-	// actions exist here and what they do. An action the slice does not
-	// implement yet simply has no handler and never fires.
-	const handlers = (): ShortcutHandlers => ({
-		"transport.play_stop": { run: () => void audio.toggle() },
-		// Shift+Space resumes from where playback last stopped, exactly as the
-		// registry describes it — not a second play/stop toggle.
-		"transport.continue": { run: () => void audio.continueFromStop() },
-		"transport.metronome": { run: () => audio.toggleMetronome() },
-		"edit.undo": {
-			run: () => session.undo(),
-			isEnabled: () => session.state.canUndo,
-		},
-		"edit.redo": {
-			run: () => session.redo(),
-			isEnabled: () => session.state.canRedo,
-		},
-		// Delete the selected notes of whichever note editor is showing: the piano
-		// roll keeps its own selection and hands the operation up through
-		// `registerActions` (CLP-03), the step editor's is lifted into this
-		// component (CLP-02). Either way it only fires when that selection is
-		// non-empty, so an empty-selection Delete leaves the browser default alone
-		// (PRD KEY-02).
-		"edit.delete": {
-			run: () => {
-				if (showPianoRoll()) pianoRollActions()?.deleteSelection();
-				else deleteSelection();
-			},
-			isEnabled: () =>
-				showPianoRoll()
-					? (pianoRollActions()?.hasSelection() ?? false)
-					: selectedNoteIds().length > 0,
-		},
-		"help.shortcut_guide": { run: () => setGuideOpen(true) },
-		"view.close_surface": {
-			run: () => setGuideOpen(false),
-			isEnabled: () => guideOpen(),
-		},
-		// The piano roll's remaining note operations, dispatched by the registry
-		// (KEY-01), not by a listener the roll owns. Each is enabled only while the
-		// roll is showing; duplicate additionally needs a selection.
-		"edit.duplicate": {
-			run: () => pianoRollActions()?.duplicateSelection(),
-			isEnabled: () => pianoRollActions()?.hasSelection() ?? false,
-		},
-		"edit.select_all": {
-			run: () => pianoRollActions()?.selectAll(),
-			isEnabled: () => pianoRollActions() !== null,
-		},
-	});
-
-	// The surfaces this slice actually shows. The guide filters against these,
-	// so "shortcuts valid in the current context" means the editor underneath
-	// rather than the modal covering it. The piano roll adds its own contexts:
-	// `piano_roll` (where `edit.delete` lives) and `selection` (where
-	// `edit.duplicate`/`edit.select_all` live).
-	const editorContexts = (): readonly ShortcutContext[] =>
-		showPianoRoll()
-			? ["editor", "step_editor", "piano_roll", "selection"]
-			: ["editor", "step_editor"];
-
-	// While a modal is open it is the only active context, so nothing behind it
-	// can fire — including playback and selection (PRD KEY-02). The pack browser
-	// is a modal surface like the guide, so it takes the keyboard the same way.
-	const contexts = (): readonly ShortcutContext[] =>
-		guideOpen() || packBrowserOpen() ? ["dialog"] : editorContexts();
-
-	const shortcuts = useShortcuts({ handlers, contexts });
-	const keyHint = (action: Parameters<typeof shortcutLabel>[0]) =>
-		shortcutLabel(action, shortcuts.platform);
-
 	const track = createMemo(() => project()?.song.tracks[0] ?? null);
 	// The first drum-machine track, if any, gets its instrument panel. The
 	// `FND-009` starter is sampler-only; this surfaces the `LOOP-005` drum
@@ -277,6 +204,19 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		const c = clip();
 		return instrument()?.kind === "synth" && c?.content.kind === "notes";
 	});
+
+	const { shortcuts, editorContexts, keyHint } = useEditorShortcuts({
+		audio,
+		session,
+		showPianoRoll,
+		pianoRollActions,
+		selectedNoteIds,
+		deleteSelection,
+		guideOpen,
+		setGuideOpen,
+		packBrowserOpen,
+	});
+
 	// The track id, only when it carries an instrument this slice renders a panel
 	// for (sampler or synth). The drum machine's panel lands with LOOP-005.
 	const instrumentPanelTrackId = createMemo(() => {
@@ -331,28 +271,18 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	return (
 		<main class="editor">
 			<Switch>
-				<Match when={session.state.loading}>
-					<TapeLoader label="Loading project" />
-				</Match>
-				<Match when={session.state.notFound}>
-					<ProjectNotFound />
-				</Match>
-				<Match when={session.state.error}>
-					<div class="project-error">
-						<p class="project-error-message">{session.state.error}</p>
-						<div class="project-error-actions">
-							<button
-								type="button"
-								class="project-error-retry"
-								onClick={() => location.reload()}
-							>
-								Try again
-							</button>
-							<a class="project-error-home" href="/dashboard">
-								Back to your projects
-							</a>
-						</div>
-					</div>
+				<Match
+					when={
+						session.state.loading ||
+						session.state.notFound ||
+						session.state.error
+					}
+				>
+					<ProjectLoadStates
+						loading={session.state.loading}
+						notFound={session.state.notFound}
+						error={session.state.error}
+					/>
 				</Match>
 				<Match when={project()}>
 					{(currentProject) => (

--- a/src/editor/ProjectLoadStates.tsx
+++ b/src/editor/ProjectLoadStates.tsx
@@ -1,0 +1,51 @@
+import { Match, Switch } from "solid-js";
+import ProjectNotFound from "../components/ProjectNotFound";
+import TapeLoader from "../components/TapeLoader";
+
+export interface ProjectLoadStatesProps {
+	readonly loading: boolean;
+	readonly notFound: boolean;
+	readonly error: string | null;
+}
+
+/**
+ * The editor's three non-happy-path branches: loading, not-found, and a
+ * generic load error with a retry/back-out. `EditorView` renders this while
+ * `project()` has not resolved (or never does); once a project loads,
+ * `EditorView` renders its own tree instead — the two are mutually exclusive
+ * `Match` branches of the same parent `Switch`, so this component owns its
+ * own `Switch` over the same three conditions to keep that exclusivity and
+ * per-branch reactivity intact.
+ *
+ * Split out of `EditorView` (`REFACTOR-001`) — a pure move of the first
+ * three `<Match>` branches of its top-level `<Switch>`.
+ */
+export default function ProjectLoadStates(props: ProjectLoadStatesProps) {
+	return (
+		<Switch>
+			<Match when={props.loading}>
+				<TapeLoader label="Loading project" />
+			</Match>
+			<Match when={props.notFound}>
+				<ProjectNotFound />
+			</Match>
+			<Match when={props.error}>
+				<div class="project-error">
+					<p class="project-error-message">{props.error}</p>
+					<div class="project-error-actions">
+						<button
+							type="button"
+							class="project-error-retry"
+							onClick={() => location.reload()}
+						>
+							Try again
+						</button>
+						<a class="project-error-home" href="/dashboard">
+							Back to your projects
+						</a>
+					</div>
+				</div>
+			</Match>
+		</Switch>
+	);
+}

--- a/src/editor/useEditorShortcuts.ts
+++ b/src/editor/useEditorShortcuts.ts
@@ -1,0 +1,129 @@
+import type { Accessor } from "solid-js";
+import type { EventId } from "../domain/ids";
+import {
+	type ShortcutContext,
+	type ShortcutHandlers,
+	shortcutLabel,
+	useShortcuts,
+} from "../shortcuts";
+import type { PianoRollActions } from "./PianoRoll";
+import type { UseEditorSessionResult } from "./useEditorSession";
+import type { ProjectAudioControls } from "./useProjectAudio";
+
+export interface UseEditorShortcutsOptions {
+	readonly audio: ProjectAudioControls;
+	readonly session: UseEditorSessionResult;
+	readonly showPianoRoll: Accessor<boolean>;
+	readonly pianoRollActions: Accessor<PianoRollActions | null>;
+	readonly selectedNoteIds: Accessor<readonly EventId[]>;
+	readonly deleteSelection: () => void;
+	readonly guideOpen: Accessor<boolean>;
+	readonly setGuideOpen: (open: boolean) => void;
+	readonly packBrowserOpen: Accessor<boolean>;
+}
+
+/**
+ * Installs the editor's PRD `KEY-01` shortcut mapping: which actions this
+ * slice implements, what each does, and which contexts are active.
+ *
+ * Split out of `EditorView` (`REFACTOR-001`) as a plain function of the same
+ * dependencies `EditorView` already held (audio controls, session, the piano
+ * roll's lifted state, the guide/pack-browser open signals) — not a
+ * registration seam a panel contributes to. The issue's suggested "panel
+ * registers its own context/handlers" seam would need each panel to publish
+ * handlers the shortcut controller aggregates, which is a real architecture
+ * change (today nothing but `EditorView` calls `useShortcuts`, and every
+ * handler here reaches into state — `pianoRollActions`, `selectedNoteIds` —
+ * that is lifted to this level for exactly that reason). Building that
+ * speculatively, with only one consumer, risks the "growing inline ladder"
+ * this refactor exists to avoid in a different way. This module is still the
+ * complete answer to "touches the parent only at a small seam": a future
+ * panel's shortcut needs land here, in one file, instead of inside
+ * `EditorView.tsx` itself.
+ */
+export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
+	const {
+		audio,
+		session,
+		showPianoRoll,
+		pianoRollActions,
+		selectedNoteIds,
+		deleteSelection,
+		guideOpen,
+		setGuideOpen,
+		packBrowserOpen,
+	} = options;
+
+	// The KEY-01 registry owns every mapping; this component only says which
+	// actions exist here and what they do. An action the slice does not
+	// implement yet simply has no handler and never fires.
+	const handlers = (): ShortcutHandlers => ({
+		"transport.play_stop": { run: () => void audio.toggle() },
+		// Shift+Space resumes from where playback last stopped, exactly as the
+		// registry describes it — not a second play/stop toggle.
+		"transport.continue": { run: () => void audio.continueFromStop() },
+		"transport.metronome": { run: () => audio.toggleMetronome() },
+		"edit.undo": {
+			run: () => session.undo(),
+			isEnabled: () => session.state.canUndo,
+		},
+		"edit.redo": {
+			run: () => session.redo(),
+			isEnabled: () => session.state.canRedo,
+		},
+		// Delete the selected notes of whichever note editor is showing: the piano
+		// roll keeps its own selection and hands the operation up through
+		// `registerActions` (CLP-03), the step editor's is lifted into this
+		// component (CLP-02). Either way it only fires when that selection is
+		// non-empty, so an empty-selection Delete leaves the browser default alone
+		// (PRD KEY-02).
+		"edit.delete": {
+			run: () => {
+				if (showPianoRoll()) pianoRollActions()?.deleteSelection();
+				else deleteSelection();
+			},
+			isEnabled: () =>
+				showPianoRoll()
+					? (pianoRollActions()?.hasSelection() ?? false)
+					: selectedNoteIds().length > 0,
+		},
+		"help.shortcut_guide": { run: () => setGuideOpen(true) },
+		"view.close_surface": {
+			run: () => setGuideOpen(false),
+			isEnabled: () => guideOpen(),
+		},
+		// The piano roll's remaining note operations, dispatched by the registry
+		// (KEY-01), not by a listener the roll owns. Each is enabled only while the
+		// roll is showing; duplicate additionally needs a selection.
+		"edit.duplicate": {
+			run: () => pianoRollActions()?.duplicateSelection(),
+			isEnabled: () => pianoRollActions()?.hasSelection() ?? false,
+		},
+		"edit.select_all": {
+			run: () => pianoRollActions()?.selectAll(),
+			isEnabled: () => pianoRollActions() !== null,
+		},
+	});
+
+	// The surfaces this slice actually shows. The guide filters against these,
+	// so "shortcuts valid in the current context" means the editor underneath
+	// rather than the modal covering it. The piano roll adds its own contexts:
+	// `piano_roll` (where `edit.delete` lives) and `selection` (where
+	// `edit.duplicate`/`edit.select_all` live).
+	const editorContexts = (): readonly ShortcutContext[] =>
+		showPianoRoll()
+			? ["editor", "step_editor", "piano_roll", "selection"]
+			: ["editor", "step_editor"];
+
+	// While a modal is open it is the only active context, so nothing behind it
+	// can fire — including playback and selection (PRD KEY-02). The pack browser
+	// is a modal surface like the guide, so it takes the keyboard the same way.
+	const contexts = (): readonly ShortcutContext[] =>
+		guideOpen() || packBrowserOpen() ? ["dialog"] : editorContexts();
+
+	const shortcuts = useShortcuts({ handlers, contexts });
+	const keyHint = (action: Parameters<typeof shortcutLabel>[0]) =>
+		shortcutLabel(action, shortcuts.platform);
+
+	return { shortcuts, editorContexts, keyHint };
+}


### PR DESCRIPTION
## Summary

Final PR of the 3-PR stack breaking `src/editor/EditorView.tsx` into a shallow component hierarchy (#142). Builds on #149 and #150. Pure structural move — no user-visible behavior change.

- `ProjectLoadStates` — the loading/notFound/error branches (the first three `<Match>` arms of the top-level `<Switch>`). It owns its own internal `Switch`/`Match` over the same three conditions to preserve their mutual exclusivity and per-branch reactivity exactly as before; `EditorView`'s outer `Switch` now has two arms (load-states vs. the loaded project).
- `useEditorShortcuts` — a plain function pulling out `handlers()`, `editorContexts()`, and `contexts()` (the PRD `KEY-01` shortcut wiring), taking the same dependencies `EditorView` already held as explicit parameters (audio controls, session, the piano roll's lifted state, the guide/pack-browser open signals).

**On the "panel registers its own context/handlers" seam the issue suggests:** I did not build it. Today nothing but `EditorView` calls `useShortcuts` — every handler here reaches into state (`pianoRollActions`, `selectedNoteIds`) that is *lifted to this level specifically so the registry, not the panel, owns dispatch*. A real registration seam (each panel publishing handlers an aggregator merges) is a genuine architecture change with only one consumer to justify it today, which risks exactly the kind of speculative machinery the issue's own guidance cautions against ("if a genuinely clean seam is not available without over-engineering, keep it simple and say so"). `useEditorShortcuts` still delivers the practical goal: a future panel's shortcut needs land in one small file instead of inside `EditorView.tsx` itself, touching the parent only to pass one more dependency into the options object.

`EditorView.tsx` is now 427 lines (down from 750 on `main`), all composition plus the derived state/wiring that's genuinely shared (session, audio, tempo/track/clip memos, selection lift, shortcut controller install).

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run test -- src/editor/EditorView.test.tsx` — all 22 tests pass unchanged (0 test edits across the whole stack)
- [x] `bun run test` (full suite) — 1919-1920/1921 pass depending on run; the 1-2 failures are pre-existing and environmental, confirmed to fail identically on unmodified `origin/main`:
  - `src/commands/devices.test.ts > eight-insert ceiling (FX-01)` — fails on `main`, unrelated file, not touched by this stack.
  - Various `src/audio/*.test.ts` — real-hardware `AudioContext` contention across parallel Vitest workers on this macOS runner (`cpal backend error ... coreaudio-rs`); passes in isolation, flakes only under full-suite parallelism, confirmed identical on `main`.
- [x] `bun run check` — clean
- [x] `bun run test:browser` (Playwright, chromium/firefox/webkit) — 47-51 passed depending on run; failures confirmed pre-existing on unmodified `origin/main`:
  - `smoke.spec.ts > keeps the arrangement shell inside its panel, above the step grid` (chromium/firefox/webkit) — stale locator (`getByRole("group", { name: "16-step sequence" })`) that predates `LOOP-010`'s per-lane step editor rewrite; the actual accessible tree has `group "Lane Notes"` per lane. Confirmed broken on `main` too — pre-existing test bug, not this refactor's to fix.
  - `smoke.spec.ts > starts from the keyboard, with visible focus` (webkit only) — landing-page keyboard-focus assertion, unrelated file (`LandingPage.tsx`, never touched). Confirmed broken on `main` too — a WebKit headless focus flake.
- [x] Ran `VITE_MOCK_BACKEND=true bun run dev` and manually exercised a project: header (undo/redo, play, loop, metronome, tempo, time signature, playhead, library/guide buttons), the step editor and its instrument panel, the drum-machine/loop panels, and the shortcut guide (`?`) all render and behave as before.

## Walkthrough

No user-visible change — pure structural refactor. Evidence is `EditorView.test.tsx` (610 lines, unmodified across the whole 3-PR stack) passing unchanged, plus the manual dev-server pass above.

Closes #142 — 3 of 3, builds on #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)