### PR TITLE
REFACTOR-002 (6 of 6): extract entry points; parse.ts becomes a pure barrel

### DIFF
--- a/src/domain/parse.ts
+++ b/src/domain/parse.ts
@@ -1,46 +1,3 @@
-import {
-	type Clip,
-	clipSchema,
-	type Project,
-	type ProjectMetadata,
-	projectMetadataSchema,
-	projectSchema,
-	SCHEMA_VERSION,
-	type Song,
-	songSchema,
-} from "./entities";
-import { checkClipInvariants, checkClipOwnership } from "./parse/clip";
-import {
-	checkAddedPacks,
-	checkMetadata,
-	checkPackQualification,
-} from "./parse/packs";
-import {
-	claimId,
-	type DomainIssue,
-	type DomainIssueCode,
-	DomainValidationError,
-	formatIssue,
-	issue,
-	type ParseResult,
-	parseWith,
-} from "./parse/primitives";
-import {
-	checkSongIntegrity,
-	MAX_RETURN_BUSES,
-	MAX_TRACK_INSERTS,
-} from "./parse/song";
-
-export type { DomainIssue, DomainIssueCode, ParseResult };
-export {
-	checkClipInvariants,
-	checkSongIntegrity,
-	DomainValidationError,
-	formatIssue,
-	MAX_RETURN_BUSES,
-	MAX_TRACK_INSERTS,
-};
-
 /**
  * Parsing and cross-entity integrity (PRD section 9.5).
  *
@@ -49,187 +6,32 @@ export {
  * project or a list of issues — it never mutates its input and never returns
  * partially repaired state.
  *
- * This file is being split into per-concern modules under `./parse/*` so a
- * new invariant lands in its own file instead of appending to one growing
- * one (REFACTOR-002). The issue primitives, clip invariants, automation
- * invariants, pack invariants, and song/routing/device invariants have moved
- * out so far; only the entry points and the top-level aggregate invariant
- * still live here.
+ * The implementation lives in `./parse/*`, split by concern so a new invariant
+ * lands in its own module instead of appending to one growing file. This
+ * module re-exports the same public surface the monolith used to (nothing
+ * more — the per-concern helpers stay module-private the way they were
+ * before), so no importer needs to change.
  */
 
-/**
- * Parses one `projects/{projectId}` metadata document.
- *
- * Like `parseClip`, this applies every invariant the document can be judged on
- * alone — timestamps, collaborators, and the shape of the pack dependency list.
- * Whether that list matches the project's assets is only decidable in the
- * aggregate path, which holds the song.
- */
-export function parseProjectMetadata(
-	input: unknown,
-): ParseResult<ProjectMetadata> {
-	const versionIssues = checkSchemaVersion(input, []);
-	if (versionIssues.length > 0) {
-		return { ok: false, issues: versionIssues };
-	}
-	const result = parseWith(projectMetadataSchema, input);
-	if (!result.ok) {
-		return result;
-	}
-	const issues = checkMetadata(result.value);
-	return issues.length > 0 ? { ok: false, issues } : result;
-}
-
-/** Parses one `projects/{projectId}/song/current` document. */
-export function parseSong(input: unknown): ParseResult<Song> {
-	const result = parseWith(songSchema, input);
-	if (!result.ok) {
-		return result;
-	}
-	const issues = checkSongIntegrity(result.value, ["song"]);
-	return issues.length > 0 ? { ok: false, issues } : result;
-}
-
-/**
- * Parses one `projects/{projectId}/clips/{clipId}` document.
- *
- * A clip document carries no track or asset context, so this applies every
- * invariant that a clip can be judged on alone. Owner-dependent rules (pad
- * ownership, audio-loop asset) are checked in the aggregate path, which holds
- * the track and asset sets.
- */
-export function parseClip(input: unknown): ParseResult<Clip> {
-	const result = parseWith(clipSchema, input);
-	if (!result.ok) {
-		return result;
-	}
-	const issues = checkClipInvariants(result.value, []);
-	return issues.length > 0 ? { ok: false, issues } : result;
-}
-
-/** Parses and fully validates a whole project aggregate. */
-export function parseProject(input: unknown): ParseResult<Project> {
-	const versionIssues = checkSchemaVersion(
-		(input as { metadata?: unknown } | null | undefined)?.metadata,
-		["metadata"],
-	);
-	if (versionIssues.length > 0) {
-		return { ok: false, issues: versionIssues };
-	}
-	const shape = parseWith(projectSchema, input);
-	if (!shape.ok) {
-		return shape;
-	}
-	const issues = checkProjectIntegrity(shape.value);
-	return issues.length > 0 ? { ok: false, issues } : shape;
-}
-
-/** Parses a project, throwing `DomainValidationError` when it is invalid. */
-export function assertProject(input: unknown): Project {
-	const result = parseProject(input);
-	if (!result.ok) {
-		throw new DomainValidationError("Invalid schema-v1 project", result.issues);
-	}
-	return result.value;
-}
-
-export function isProject(input: unknown): input is Project {
-	return parseProject(input).ok;
-}
-
-/**
- * A future schema version is reported rather than parsed, so a newer document
- * is never silently coerced into v1 shape and overwritten (PRJ-04).
- */
-function checkSchemaVersion(
-	metadata: unknown,
-	path: ReadonlyArray<string | number>,
-): DomainIssue[] {
-	if (typeof metadata !== "object" || metadata === null) {
-		return [];
-	}
-	const version = (metadata as { schemaVersion?: unknown }).schemaVersion;
-	if (typeof version !== "number" || !Number.isInteger(version)) {
-		return [];
-	}
-	if (version > SCHEMA_VERSION) {
-		return [
-			issue(
-				"unsupported_schema_version",
-				[...path, "schemaVersion"],
-				`Schema version ${version} is newer than the supported version ${SCHEMA_VERSION}; refusing to read or overwrite it`,
-			),
-		];
-	}
-	if (version < SCHEMA_VERSION) {
-		return [
-			issue(
-				"unsupported_schema_version",
-				[...path, "schemaVersion"],
-				`Schema version ${version} predates schema v1 and is not migrated`,
-			),
-		];
-	}
-	return [];
-}
-
-/** Every cross-entity invariant in PRD section 9.5. */
-export function checkProjectIntegrity(project: Project): DomainIssue[] {
-	const issues: DomainIssue[] = [];
-	const seenIds = new Set<string>();
-
-	issues.push(...checkMetadata(project.metadata));
-	issues.push(...checkSongIntegrity(project.song, ["song"], seenIds));
-	issues.push(...checkPackQualification(project));
-	issues.push(...checkAddedPacks(project));
-
-	const trackIds = new Map(
-		project.song.tracks.map((track) => [track.id, track]),
-	);
-	const assetIds = new Set(project.song.assets.map((asset) => asset.id));
-	const clipIds = new Map<string, Clip>();
-
-	project.clips.forEach((clip, index) => {
-		const path = ["clips", index] as const;
-		claimId(seenIds, clip.id, [...path, "id"], issues);
-		clipIds.set(clip.id, clip);
-		const owner = trackIds.get(clip.trackId);
-		if (!owner) {
-			issues.push(
-				issue(
-					"dangling_reference",
-					[...path, "trackId"],
-					`Clip ${clip.id} references missing track ${clip.trackId}`,
-				),
-			);
-		}
-		issues.push(...checkClipInvariants(clip, [...path], seenIds));
-		issues.push(...checkClipOwnership(clip, owner, assetIds, [...path]));
-	});
-
-	project.song.placements.forEach((placement, index) => {
-		const path = ["song", "placements", index] as const;
-		const clip = clipIds.get(placement.clipId);
-		if (!clip) {
-			issues.push(
-				issue(
-					"dangling_reference",
-					[...path, "clipId"],
-					`Placement ${placement.id} references missing clip ${placement.clipId}`,
-				),
-			);
-			return;
-		}
-		if (clip.trackId !== placement.trackId) {
-			issues.push(
-				issue(
-					"cross_owner_reference",
-					[...path, "trackId"],
-					`Placement ${placement.id} puts clip ${clip.id} (owned by track ${clip.trackId}) on track ${placement.trackId}`,
-				),
-			);
-		}
-	});
-
-	return issues;
-}
+export { checkClipInvariants } from "./parse/clip";
+export {
+	type DomainIssue,
+	type DomainIssueCode,
+	DomainValidationError,
+	formatIssue,
+	type ParseResult,
+} from "./parse/primitives";
+export {
+	assertProject,
+	checkProjectIntegrity,
+	isProject,
+	parseClip,
+	parseProject,
+	parseProjectMetadata,
+	parseSong,
+} from "./parse/project";
+export {
+	checkSongIntegrity,
+	MAX_RETURN_BUSES,
+	MAX_TRACK_INSERTS,
+} from "./parse/song";

--- a/src/domain/parse/project.ts
+++ b/src/domain/parse/project.ts
@@ -1,0 +1,203 @@
+import {
+	type Clip,
+	clipSchema,
+	type Project,
+	type ProjectMetadata,
+	projectMetadataSchema,
+	projectSchema,
+	SCHEMA_VERSION,
+	type Song,
+	songSchema,
+} from "../entities";
+import { checkClipInvariants, checkClipOwnership } from "./clip";
+import {
+	checkAddedPacks,
+	checkMetadata,
+	checkPackQualification,
+} from "./packs";
+import {
+	claimId,
+	type DomainIssue,
+	DomainValidationError,
+	issue,
+	type ParseResult,
+	parseWith,
+} from "./primitives";
+import { checkSongIntegrity } from "./song";
+
+/**
+ * Parses one `projects/{projectId}` metadata document.
+ *
+ * Like `parseClip`, this applies every invariant the document can be judged on
+ * alone — timestamps, collaborators, and the shape of the pack dependency list.
+ * Whether that list matches the project's assets is only decidable in the
+ * aggregate path, which holds the song.
+ */
+export function parseProjectMetadata(
+	input: unknown,
+): ParseResult<ProjectMetadata> {
+	const versionIssues = checkSchemaVersion(input, []);
+	if (versionIssues.length > 0) {
+		return { ok: false, issues: versionIssues };
+	}
+	const result = parseWith(projectMetadataSchema, input);
+	if (!result.ok) {
+		return result;
+	}
+	const issues = checkMetadata(result.value);
+	return issues.length > 0 ? { ok: false, issues } : result;
+}
+
+/** Parses one `projects/{projectId}/song/current` document. */
+export function parseSong(input: unknown): ParseResult<Song> {
+	const result = parseWith(songSchema, input);
+	if (!result.ok) {
+		return result;
+	}
+	const issues = checkSongIntegrity(result.value, ["song"]);
+	return issues.length > 0 ? { ok: false, issues } : result;
+}
+
+/**
+ * Parses one `projects/{projectId}/clips/{clipId}` document.
+ *
+ * A clip document carries no track or asset context, so this applies every
+ * invariant that a clip can be judged on alone. Owner-dependent rules (pad
+ * ownership, audio-loop asset) are checked in the aggregate path, which holds
+ * the track and asset sets.
+ */
+export function parseClip(input: unknown): ParseResult<Clip> {
+	const result = parseWith(clipSchema, input);
+	if (!result.ok) {
+		return result;
+	}
+	const issues = checkClipInvariants(result.value, []);
+	return issues.length > 0 ? { ok: false, issues } : result;
+}
+
+/** Parses and fully validates a whole project aggregate. */
+export function parseProject(input: unknown): ParseResult<Project> {
+	const versionIssues = checkSchemaVersion(
+		(input as { metadata?: unknown } | null | undefined)?.metadata,
+		["metadata"],
+	);
+	if (versionIssues.length > 0) {
+		return { ok: false, issues: versionIssues };
+	}
+	const shape = parseWith(projectSchema, input);
+	if (!shape.ok) {
+		return shape;
+	}
+	const issues = checkProjectIntegrity(shape.value);
+	return issues.length > 0 ? { ok: false, issues } : shape;
+}
+
+/** Parses a project, throwing `DomainValidationError` when it is invalid. */
+export function assertProject(input: unknown): Project {
+	const result = parseProject(input);
+	if (!result.ok) {
+		throw new DomainValidationError("Invalid schema-v1 project", result.issues);
+	}
+	return result.value;
+}
+
+export function isProject(input: unknown): input is Project {
+	return parseProject(input).ok;
+}
+
+/**
+ * A future schema version is reported rather than parsed, so a newer document
+ * is never silently coerced into v1 shape and overwritten (PRJ-04).
+ */
+function checkSchemaVersion(
+	metadata: unknown,
+	path: ReadonlyArray<string | number>,
+): DomainIssue[] {
+	if (typeof metadata !== "object" || metadata === null) {
+		return [];
+	}
+	const version = (metadata as { schemaVersion?: unknown }).schemaVersion;
+	if (typeof version !== "number" || !Number.isInteger(version)) {
+		return [];
+	}
+	if (version > SCHEMA_VERSION) {
+		return [
+			issue(
+				"unsupported_schema_version",
+				[...path, "schemaVersion"],
+				`Schema version ${version} is newer than the supported version ${SCHEMA_VERSION}; refusing to read or overwrite it`,
+			),
+		];
+	}
+	if (version < SCHEMA_VERSION) {
+		return [
+			issue(
+				"unsupported_schema_version",
+				[...path, "schemaVersion"],
+				`Schema version ${version} predates schema v1 and is not migrated`,
+			),
+		];
+	}
+	return [];
+}
+
+/** Every cross-entity invariant in PRD section 9.5. */
+export function checkProjectIntegrity(project: Project): DomainIssue[] {
+	const issues: DomainIssue[] = [];
+	const seenIds = new Set<string>();
+
+	issues.push(...checkMetadata(project.metadata));
+	issues.push(...checkSongIntegrity(project.song, ["song"], seenIds));
+	issues.push(...checkPackQualification(project));
+	issues.push(...checkAddedPacks(project));
+
+	const trackIds = new Map(
+		project.song.tracks.map((track) => [track.id, track]),
+	);
+	const assetIds = new Set(project.song.assets.map((asset) => asset.id));
+	const clipIds = new Map<string, Clip>();
+
+	project.clips.forEach((clip, index) => {
+		const path = ["clips", index] as const;
+		claimId(seenIds, clip.id, [...path, "id"], issues);
+		clipIds.set(clip.id, clip);
+		const owner = trackIds.get(clip.trackId);
+		if (!owner) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "trackId"],
+					`Clip ${clip.id} references missing track ${clip.trackId}`,
+				),
+			);
+		}
+		issues.push(...checkClipInvariants(clip, [...path], seenIds));
+		issues.push(...checkClipOwnership(clip, owner, assetIds, [...path]));
+	});
+
+	project.song.placements.forEach((placement, index) => {
+		const path = ["song", "placements", index] as const;
+		const clip = clipIds.get(placement.clipId);
+		if (!clip) {
+			issues.push(
+				issue(
+					"dangling_reference",
+					[...path, "clipId"],
+					`Placement ${placement.id} references missing clip ${placement.clipId}`,
+				),
+			);
+			return;
+		}
+		if (clip.trackId !== placement.trackId) {
+			issues.push(
+				issue(
+					"cross_owner_reference",
+					[...path, "trackId"],
+					`Placement ${placement.id} puts clip ${clip.id} (owned by track ${clip.trackId}) on track ${placement.trackId}`,
+				),
+			);
+		}
+	});
+
+	return issues;
+}


### PR DESCRIPTION
## Summary

Sixth and final PR in the REFACTOR-002 stack (see #143, #146, #147, #148, #152, #153). Builds on #153 (song/routing/device invariants extraction). **Closes #143.**

Moves the remaining logic out of `parse.ts`:
- `parseProjectMetadata`, `parseSong`, `parseClip`, `parseProject` (the four document-tier entry points)
- `assertProject`, `isProject` (thin `parseProject` wrappers)
- `checkSchemaVersion` (module-private)
- `checkProjectIntegrity` (the top-level cross-entity aggregate invariant)

into `src/domain/parse/project.ts`.

With this move, **`parse.ts` holds no logic of its own** — it is a pure re-export barrel of the exact same 15 symbols it exported before this stack started:

`MAX_TRACK_INSERTS`, `MAX_RETURN_BUSES`, `DomainIssueCode`, `DomainIssue`, `ParseResult`, `DomainValidationError`, `formatIssue`, `parseProjectMetadata`, `parseSong`, `parseClip`, `parseProject`, `assertProject`, `isProject`, `checkProjectIntegrity`, `checkSongIntegrity`, `checkClipInvariants`.

All 20 existing importers of `src/domain/parse.ts` (including `src/domain/index.ts`, `src/commands/execute.ts`, `src/commands/types.ts`, `src/persistence/documents.ts`, `src/editor/starterProject.ts`) keep importing from `./parse`/`../domain/parse` completely unchanged — this is proven by `bun run typecheck` passing with zero import-site edits across the whole stack.

Pure structural move — no behavior change, no logic altered, no invariant semantics changed.

### Final module structure

```
src/domain/parse.ts            37 lines  — pure re-export barrel (public entry point)
src/domain/parse/primitives.ts 115 lines — issue types, issue()/fromZod()/parseWith(), claimId(), checkOrdering()
src/domain/parse/clip.ts       108 lines — checkClipInvariants, checkClipOwnership
src/domain/parse/automation.ts 106 lines — checkAutomationLane
src/domain/parse/packs.ts      197 lines — checkMetadata, checkPackDependencyList, checkPackQualification, checkAddedPacks
src/domain/parse/song.ts       306 lines — checkSongIntegrity, checkDeviceChain, checkInstrument(Parameters), MAX_TRACK_INSERTS, MAX_RETURN_BUSES
src/domain/parse/project.ts    203 lines — parseProject/parseSong/parseClip/parseProjectMetadata, assertProject, isProject, checkSchemaVersion, checkProjectIntegrity
```

Dependency graph is acyclic and one-directional: `primitives` is depended on by everything; `clip`/`automation`/`packs` depend only on `primitives`; `song` depends on `primitives` + `automation`; `project` (the aggregator) depends on `primitives` + `clip` + `packs` + `song`.

A registry/list-of-invariants assembly (as the issue suggested as a stretch goal) was **not** pursued: the invariant functions have genuinely different signatures (some take `Project`, some take `Song` + path + seenIds, some take a `Clip` + owner + assets), so a uniform registry would need a lowest-common-denominator wrapper that adds indirection without reducing merge-clash surface any further than the per-file split already does — and the priority stated in the issue (exact behavior/ordering over achieving a registry) argues against forcing it.

## Test plan
- [x] `bun run typecheck` — passes. Zero import-site changes needed across all 20 consumers.
- [x] `bun run check` — passes (biome clean throughout the stack)
- [x] `bun run test` — `src/domain/parse.test.ts` (785 lines, unmodified) passes: 58/58. `src/domain/project.property.test.ts` (fast-check property/fuzz suite) also passes, exercising generated inputs beyond the fixed test cases. Full relevant-scope suite: 928/929 passing; the one failure (`src/commands/devices.test.ts` "eight-insert ceiling... rejects a ninth") is **pre-existing on `main`**, unrelated to this stack — verified by running the identical test directly against `main` (same failure there). Full repo suite: 1919/1921, the same pre-existing failure plus one known-flaky audio-hardware-contention test (`scripts/starter-library/runtime.test.mjs` or an `AudioContext` construction test, varies by run) unrelated to any file in this stack.
- [x] Additionally verified behavioral equivalence directly: during development, a temporary test file ran the pre-refactor monolithic `parseProject` and the fully-split `parseProject` side by side against the fixture, the drum-machine fixture, and several hand-built multi-invariant-failure inputs, asserting `toEqual` (deep, order-sensitive) on the full `ParseResult` including the issues array. All cases matched exactly, confirming issue ordering is preserved byte-for-byte. This harness was removed before committing (verification-only, not shipped).

## Walkthrough
No user-visible change — this is a pure domain-layer refactor with no UI, API, or behavior change.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)