### PR TITLE
Refactor: extract ArrangementView canvas lifecycle into a hook

### DIFF
--- a/src/arrangement/ArrangementToolbar.tsx
+++ b/src/arrangement/ArrangementToolbar.tsx
@@ -1,0 +1,58 @@
+/**
+ * The arrangement's named DOM actions (PRD 9.3 accessibility): zoom in/out,
+ * zoom to selection, and scroll to playhead, as real buttons so canvas pixels
+ * are never the sole way to drive the surface. Each is also the keyboard
+ * equivalent of a pointer gesture on the timeline.
+ */
+export interface ArrangementToolbarProps {
+	readonly onZoomIn: () => void;
+	readonly onZoomOut: () => void;
+	readonly onZoomToSelection: () => void;
+	readonly onScrollToPlayhead: () => void;
+	/** Zoom-to-selection is meaningless with nothing selected. */
+	readonly hasSelection: boolean;
+}
+
+export function ArrangementToolbar(props: ArrangementToolbarProps) {
+	return (
+		<div class="arrangement-toolbar">
+			<button
+				type="button"
+				class="arrangement-action"
+				data-action="zoom-in"
+				aria-label="Zoom in"
+				onClick={() => props.onZoomIn()}
+			>
+				Zoom in
+			</button>
+			<button
+				type="button"
+				class="arrangement-action"
+				data-action="zoom-out"
+				aria-label="Zoom out"
+				onClick={() => props.onZoomOut()}
+			>
+				Zoom out
+			</button>
+			<button
+				type="button"
+				class="arrangement-action"
+				data-action="zoom-to-selection"
+				aria-label="Zoom to selection"
+				disabled={!props.hasSelection}
+				onClick={() => props.onZoomToSelection()}
+			>
+				Zoom to selection
+			</button>
+			<button
+				type="button"
+				class="arrangement-action"
+				data-action="scroll-to-playhead"
+				aria-label="Scroll to playhead"
+				onClick={() => props.onScrollToPlayhead()}
+			>
+				Scroll to playhead
+			</button>
+		</div>
+	);
+}

--- a/src/arrangement/ArrangementView.tsx
+++ b/src/arrangement/ArrangementView.tsx
@@ -4,7 +4,6 @@ import {
 	createMemo,
 	createSignal,
 	For,
-	onCleanup,
 	onMount,
 	Show,
 } from "solid-js";
@@ -14,16 +13,13 @@ import {
 } from "../analytics/analytics";
 import type { Project } from "../domain/entities";
 import { TICKS_PER_BAR } from "../domain/time";
+import { ArrangementToolbar } from "./ArrangementToolbar";
 import {
 	type ArrangementShell,
 	createArrangementShell,
 } from "./arrangementShell";
 import {
 	createArrangementWaveformCache,
-	type DrawEnvironment,
-	drawBackgroundLayer,
-	drawContentLayer,
-	drawInteractionLayer,
 	type InteractionState,
 	RULER_HEIGHT_PX,
 } from "./canvasRenderer";
@@ -32,6 +28,7 @@ import {
 	type ArrangementProjection,
 	buildArrangementProjection,
 } from "./projection";
+import { useArrangementCanvas } from "./useArrangementCanvas";
 import "./ArrangementView.css";
 
 /**
@@ -97,7 +94,6 @@ export default function ArrangementView(props: ArrangementViewProps) {
 
 	const waveformCache = createArrangementWaveformCache();
 	let shell: ArrangementShell | null = null;
-	let rafHandle: number | null = null;
 	let firstUseLogged = false;
 
 	function initialViewport(): Viewport {
@@ -110,61 +106,6 @@ export default function ArrangementView(props: ArrangementViewProps) {
 		};
 	}
 
-	function scheduleDraw(): void {
-		if (rafHandle !== null) return;
-		rafHandle =
-			typeof requestAnimationFrame === "function"
-				? requestAnimationFrame(() => {
-						rafHandle = null;
-						drawDirtyLayers();
-					})
-				: (setTimeout(() => {
-						rafHandle = null;
-						drawDirtyLayers();
-					}, 16) as unknown as number);
-	}
-
-	function cancelScheduledDraw(): void {
-		if (rafHandle === null) return;
-		if (typeof cancelAnimationFrame === "function")
-			cancelAnimationFrame(rafHandle);
-		else clearTimeout(rafHandle);
-		rafHandle = null;
-	}
-
-	function hostDevicePixelRatio(): number {
-		return typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
-	}
-
-	function sizeCanvas(canvas: HTMLCanvasElement, port: Viewport): void {
-		const ratio = shell?.devicePixelRatio(hostDevicePixelRatio()) ?? 1;
-		const targetWidth = Math.round(port.width * ratio);
-		const targetHeight = Math.round(port.height * ratio);
-		if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
-			canvas.width = targetWidth;
-			canvas.height = targetHeight;
-		}
-		canvas.style.width = `${port.width}px`;
-		canvas.style.height = `${port.height}px`;
-	}
-
-	function drawEnv(canvas: HTMLCanvasElement): DrawEnvironment | null {
-		if (!shell) return null;
-		const ctx = canvas.getContext("2d");
-		if (!ctx) return null;
-		const port = shell.getViewport();
-		const ratio = shell.devicePixelRatio(hostDevicePixelRatio());
-		ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
-		return {
-			ctx,
-			viewport: port,
-			projection: projection(),
-			rowRange: shell.rowRange(),
-			tickRange: shell.tickRange(),
-			waveformCache,
-		};
-	}
-
 	function interactionState(): InteractionState {
 		const state = shell?.getState();
 		return {
@@ -174,29 +115,21 @@ export default function ArrangementView(props: ArrangementViewProps) {
 		};
 	}
 
-	/** Draws exactly the layers marked dirty since the last frame. A playhead
-	 * move touches only the interaction canvas (PRD 9.3 dirty reasons). */
-	function drawDirtyLayers(): void {
-		if (!shell) return;
-		const layers = shell.takeDirty();
-		if (layers.size === 0) return;
-		const port = shell.getViewport();
-		for (const canvas of [backgroundCanvas, contentCanvas, interactionCanvas]) {
-			sizeCanvas(canvas, port);
-		}
-		if (layers.has("background")) {
-			const env = drawEnv(backgroundCanvas);
-			if (env) drawBackgroundLayer(env);
-		}
-		if (layers.has("content")) {
-			const env = drawEnv(contentCanvas);
-			if (env) drawContentLayer(env);
-		}
-		if (layers.has("interaction")) {
-			const env = drawEnv(interactionCanvas);
-			if (env) drawInteractionLayer(env, interactionState());
-		}
-	}
+	// The canvas lifecycle — frame scheduling, DPR sizing, per-layer dirty
+	// dispatch, resize observation — lives in `useArrangementCanvas`. The shell
+	// and the canvas refs are read through accessors because both are assigned
+	// during render/mount, after this call.
+	const canvas = useArrangementCanvas({
+		shell: () => shell,
+		projection: () => projection(),
+		canvases: () => ({
+			background: backgroundCanvas,
+			content: contentCanvas,
+			interaction: interactionCanvas,
+		}),
+		interactionState,
+		waveformCache,
+	});
 
 	/** One arrangement interaction the user initiated: the once-per-account
 	 * `feature_first_use` for `arrangement` (PRD OPS-02). */
@@ -213,22 +146,10 @@ export default function ArrangementView(props: ArrangementViewProps) {
 		shell = createArrangementShell(() => projection(), {
 			initialViewport: initialViewport(),
 			config: { maxDevicePixelRatio: 2 },
-			onDirty: () => scheduleDraw(),
+			onDirty: () => canvas.scheduleDraw(),
 		});
 
-		// Resize / DPR: the native scroll viewport's own rect drives canvas size.
-		// Every supported browser has `ResizeObserver`; guarded only so a
-		// non-browser test host (jsdom, which has no `ResizeObserver`) can still
-		// render the shell.
-		if (typeof ResizeObserver === "function") {
-			const resizeObserver = new ResizeObserver(() => {
-				const rect = scrollEl.getBoundingClientRect();
-				shell?.resize(rect.width, rect.height);
-				bumpState();
-			});
-			resizeObserver.observe(scrollEl);
-			onCleanup(() => resizeObserver.disconnect());
-		}
+		canvas.observeViewport(scrollEl, bumpState);
 
 		// Prime the initial size and paint every layer once.
 		const rect = scrollEl.getBoundingClientRect();
@@ -238,10 +159,6 @@ export default function ArrangementView(props: ArrangementViewProps) {
 			shell.markDirty("background", "content", "interaction");
 		}
 		bumpState();
-	});
-
-	onCleanup(() => {
-		cancelScheduledDraw();
 	});
 
 	// Project identity / structure changed: everything is dirty, scroll bounds
@@ -437,45 +354,13 @@ export default function ArrangementView(props: ArrangementViewProps) {
 
 	return (
 		<div class="arrangement-view" data-testid="arrangement-view-ready">
-			<div class="arrangement-toolbar">
-				<button
-					type="button"
-					class="arrangement-action"
-					data-action="zoom-in"
-					aria-label="Zoom in"
-					onClick={zoomIn}
-				>
-					Zoom in
-				</button>
-				<button
-					type="button"
-					class="arrangement-action"
-					data-action="zoom-out"
-					aria-label="Zoom out"
-					onClick={zoomOut}
-				>
-					Zoom out
-				</button>
-				<button
-					type="button"
-					class="arrangement-action"
-					data-action="zoom-to-selection"
-					aria-label="Zoom to selection"
-					disabled={selectionSummary() === null}
-					onClick={zoomToSelection}
-				>
-					Zoom to selection
-				</button>
-				<button
-					type="button"
-					class="arrangement-action"
-					data-action="scroll-to-playhead"
-					aria-label="Scroll to playhead"
-					onClick={scrollToPlayhead}
-				>
-					Scroll to playhead
-				</button>
-			</div>
+			<ArrangementToolbar
+				onZoomIn={zoomIn}
+				onZoomOut={zoomOut}
+				onZoomToSelection={zoomToSelection}
+				onScrollToPlayhead={scrollToPlayhead}
+				hasSelection={selectionSummary() !== null}
+			/>
 			<div class="arrangement-body">
 				<div
 					class="arrangement-headers"

--- a/src/arrangement/useArrangementCanvas.test.ts
+++ b/src/arrangement/useArrangementCanvas.test.ts
@@ -1,0 +1,210 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import { createArrangementSpikeProject } from "../domain/fixtures";
+import {
+	type ArrangementShell,
+	createArrangementShell,
+} from "./arrangementShell";
+import { createArrangementWaveformCache } from "./canvasRenderer";
+import type { Viewport } from "./geometry";
+import { buildArrangementProjection } from "./projection";
+import { useArrangementCanvas } from "./useArrangementCanvas";
+
+const ROW_METRICS = { trackHeightPx: 28, headerHeightPx: 28 };
+
+/**
+ * jsdom canvases return `null` from `getContext("2d")`, so each layer canvas
+ * gets a recording stub. Only the calls the drawing contract is asserted
+ * through are needed — this is not a pixel test.
+ */
+function fakeCanvas(): HTMLCanvasElement & { setTransformCalls: number } {
+	const canvas = document.createElement("canvas");
+	let setTransformCalls = 0;
+	const ctx = new Proxy(
+		{},
+		{
+			get(_target, prop) {
+				if (prop === "setTransform") {
+					return () => {
+						setTransformCalls += 1;
+					};
+				}
+				if (prop === "canvas") return canvas;
+				return () => undefined;
+			},
+			set() {
+				return true;
+			},
+		},
+	) as CanvasRenderingContext2D;
+	canvas.getContext = (() => ctx) as unknown as HTMLCanvasElement["getContext"];
+	Object.defineProperty(canvas, "setTransformCalls", {
+		get: () => setTransformCalls,
+	});
+	return canvas as HTMLCanvasElement & { setTransformCalls: number };
+}
+
+const INITIAL_VIEWPORT: Viewport = {
+	scrollLeft: 0,
+	scrollTop: 0,
+	width: 960,
+	height: 480,
+	pixelsPerTick: 0.08,
+};
+
+/** Builds a live shell plus the hook wired onto three stub canvases, inside a
+ * disposable reactive root so `onCleanup` runs. */
+function harness() {
+	const projection = buildArrangementProjection(
+		createArrangementSpikeProject(20),
+		ROW_METRICS,
+	);
+	const canvases = {
+		background: fakeCanvas(),
+		content: fakeCanvas(),
+		interaction: fakeCanvas(),
+	};
+	let shell: ArrangementShell | null = null;
+	let dispose = () => {};
+	const canvas = createRoot((disposeRoot) => {
+		dispose = disposeRoot;
+		return useArrangementCanvas({
+			shell: () => shell,
+			projection: () => projection,
+			canvases: () => canvases,
+			interactionState: () => ({
+				playheadTicks: 0,
+				selection: null,
+				hoverPlacementId: null,
+			}),
+			waveformCache: createArrangementWaveformCache(),
+		});
+	});
+	shell = createArrangementShell(() => projection, {
+		initialViewport: INITIAL_VIEWPORT,
+		config: { maxDevicePixelRatio: 2 },
+		onDirty: () => canvas.scheduleDraw(),
+	});
+	return { canvas, canvases, shell, dispose };
+}
+
+describe("useArrangementCanvas drawing contract (PRD 9.3)", () => {
+	it("draws at most one frame however many times a layer is marked dirty", async () => {
+		const frames: FrameRequestCallback[] = [];
+		vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+			frames.push(cb);
+			return frames.length;
+		});
+		try {
+			const { shell, canvases, dispose } = harness();
+			shell.markDirty("background");
+			shell.markDirty("content");
+			shell.markDirty("interaction");
+			// Three dirty marks within one frame coalesce into a single request.
+			expect(frames.length).toBe(1);
+
+			frames[0]?.(0);
+			// All three layers were dirty, so all three drew exactly once.
+			expect(canvases.background.setTransformCalls).toBe(1);
+			expect(canvases.content.setTransformCalls).toBe(1);
+			expect(canvases.interaction.setTransformCalls).toBe(1);
+			dispose();
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it("redraws only the layer whose dirty reason fired", () => {
+		const frames: FrameRequestCallback[] = [];
+		vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+			frames.push(cb);
+			return frames.length;
+		});
+		try {
+			const { shell, canvases, dispose } = harness();
+			// A playhead move marks only the interaction layer.
+			shell.markDirty("interaction");
+			frames[frames.length - 1]?.(0);
+			expect(canvases.interaction.setTransformCalls).toBe(1);
+			expect(canvases.background.setTransformCalls).toBe(0);
+			expect(canvases.content.setTransformCalls).toBe(0);
+			dispose();
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it("stays idle when nothing is dirty, touching neither context nor backing store", () => {
+		const { canvas, canvases, dispose } = harness();
+		const layers = [
+			canvases.background,
+			canvases.content,
+			canvases.interaction,
+		];
+		// jsdom's default canvas backing store, before any sizing has happened.
+		const defaultWidth = layers[0]?.width;
+		const defaultHeight = layers[0]?.height;
+		expect(defaultWidth).not.toBe(INITIAL_VIEWPORT.width);
+
+		// No dirty marks at all: a forced draw must return before it draws *or*
+		// resizes. Sizing is the observable half — writing `canvas.width` clears
+		// the canvas, so an idle frame that still sized would wipe visible pixels.
+		canvas.drawDirtyLayers();
+		for (const layer of layers) {
+			expect(layer.setTransformCalls).toBe(0);
+			expect(layer.width).toBe(defaultWidth);
+			expect(layer.height).toBe(defaultHeight);
+			expect(layer.style.width).toBe("");
+		}
+		dispose();
+	});
+
+	it("sizes each backing store to the viewport at the shell's capped ratio", () => {
+		const { canvas, canvases, shell, dispose } = harness();
+		shell.markDirty("background", "content", "interaction");
+		canvas.drawDirtyLayers();
+		// jsdom reports devicePixelRatio 1, and the shell caps at 2.
+		for (const layer of [
+			canvases.background,
+			canvases.content,
+			canvases.interaction,
+		]) {
+			expect(layer.width).toBe(INITIAL_VIEWPORT.width);
+			expect(layer.height).toBe(INITIAL_VIEWPORT.height);
+			expect(layer.style.width).toBe(`${INITIAL_VIEWPORT.width}px`);
+			expect(layer.style.height).toBe(`${INITIAL_VIEWPORT.height}px`);
+		}
+		dispose();
+	});
+
+	it("cancels a pending frame on cleanup, so an unmounted view never draws", () => {
+		const frames: FrameRequestCallback[] = [];
+		const cancelled: number[] = [];
+		vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+			frames.push(cb);
+			return frames.length;
+		});
+		vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+			cancelled.push(handle);
+		});
+		try {
+			const { shell, dispose } = harness();
+			shell.markDirty("content");
+			expect(frames.length).toBe(1);
+			dispose();
+			expect(cancelled).toEqual([1]);
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it("reports no observer when the host has no ResizeObserver (jsdom)", () => {
+		const { canvas, dispose } = harness();
+		const installed = canvas.observeViewport(
+			document.createElement("div"),
+			() => {},
+		);
+		expect(installed).toBe(typeof ResizeObserver === "function");
+		dispose();
+	});
+});

--- a/src/arrangement/useArrangementCanvas.ts
+++ b/src/arrangement/useArrangementCanvas.ts
@@ -1,0 +1,192 @@
+import { onCleanup } from "solid-js";
+import type { ArrangementShell, DirtyLayer } from "./arrangementShell";
+import {
+	type DrawEnvironment,
+	drawBackgroundLayer,
+	drawContentLayer,
+	drawInteractionLayer,
+	type InteractionState,
+} from "./canvasRenderer";
+import type { Viewport } from "./geometry";
+import type { ArrangementProjection } from "./projection";
+import type { WaveformCache } from "./waveformCache";
+
+/**
+ * The imperative canvas lifecycle behind `ArrangementView` (PRD ARR-01,
+ * section 9.3): frame scheduling, device-pixel-ratio sizing of the three
+ * stacked layer canvases, per-layer dirty dispatch, and viewport resize
+ * observation.
+ *
+ * This is deliberately a hook rather than a pure module. Every piece of it is
+ * bound to real DOM objects — a `CanvasRenderingContext2D`, a canvas backing
+ * store, `requestAnimationFrame`, `ResizeObserver` — and its whole job is to
+ * own their lifetimes and tear them down on unmount. Splitting it into
+ * "pure" helpers would only relocate that coupling, not remove it.
+ *
+ * The PRD 9.3 drawing contract it upholds:
+ *
+ * - **at most one draw per animation frame** — `scheduleDraw` coalesces any
+ *   number of dirty marks arriving within a frame into a single callback, and
+ *   is a no-op while a frame is already pending;
+ * - **each layer redrawn only for its own dirty reason** — `drawDirtyLayers`
+ *   drains the shell's dirty set and draws exactly those layers, so a playhead
+ *   move touches only the interaction canvas;
+ * - **idle when nothing is dirty** — an empty dirty set returns before
+ *   touching a context, and no frame is ever scheduled speculatively, so a
+ *   stopped transport runs no permanent 60 Hz loop.
+ */
+
+/** Everything the canvas lifecycle needs from the component that hosts it. */
+export interface ArrangementCanvasOptions {
+	/** The live shell, or `null` before `onMount` has created it. */
+	readonly shell: () => ArrangementShell | null;
+	/** The current projection to draw. */
+	readonly projection: () => ArrangementProjection;
+	/** The three stacked layer canvases, in z-order. */
+	readonly canvases: () => ArrangementLayerCanvases;
+	/** Playhead/selection/hover state for the interaction layer. */
+	readonly interactionState: () => InteractionState;
+	/** The shared waveform cache the content layer draws from. */
+	readonly waveformCache: WaveformCache;
+}
+
+/** The three stacked, dirty-tracked layer canvases, in z-order. */
+export interface ArrangementLayerCanvases {
+	readonly background: HTMLCanvasElement;
+	readonly content: HTMLCanvasElement;
+	readonly interaction: HTMLCanvasElement;
+}
+
+export interface ArrangementCanvas {
+	/** Requests a draw on the next animation frame. Idempotent within a frame:
+	 * marking three layers dirty still produces exactly one draw. */
+	readonly scheduleDraw: () => void;
+	/** Draws exactly the layers marked dirty since the last frame, sizing the
+	 * backing stores first. Exposed for the initial paint and for tests. */
+	readonly drawDirtyLayers: () => void;
+	/** Observes `element` and pushes its content-box size onto the shell, so
+	 * the canvases follow the native scroll viewport. Returns whether an
+	 * observer was installed (a non-browser test host has none). */
+	readonly observeViewport: (element: Element, onResize: () => void) => boolean;
+}
+
+function hostDevicePixelRatio(): number {
+	return typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+}
+
+export function useArrangementCanvas(
+	options: ArrangementCanvasOptions,
+): ArrangementCanvas {
+	let rafHandle: number | null = null;
+
+	function scheduleDraw(): void {
+		if (rafHandle !== null) return;
+		rafHandle =
+			typeof requestAnimationFrame === "function"
+				? requestAnimationFrame(() => {
+						rafHandle = null;
+						drawDirtyLayers();
+					})
+				: (setTimeout(() => {
+						rafHandle = null;
+						drawDirtyLayers();
+					}, 16) as unknown as number);
+	}
+
+	function cancelScheduledDraw(): void {
+		if (rafHandle === null) return;
+		if (typeof cancelAnimationFrame === "function")
+			cancelAnimationFrame(rafHandle);
+		else clearTimeout(rafHandle);
+		rafHandle = null;
+	}
+
+	/** Matches the canvas backing store to the viewport at the shell's capped
+	 * device pixel ratio, leaving the CSS box at logical size. Only assigns
+	 * `width`/`height` on an actual change — writing either clears the canvas. */
+	function sizeCanvas(canvas: HTMLCanvasElement, port: Viewport): void {
+		const ratio =
+			options.shell()?.devicePixelRatio(hostDevicePixelRatio()) ?? 1;
+		const targetWidth = Math.round(port.width * ratio);
+		const targetHeight = Math.round(port.height * ratio);
+		if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+			canvas.width = targetWidth;
+			canvas.height = targetHeight;
+		}
+		canvas.style.width = `${port.width}px`;
+		canvas.style.height = `${port.height}px`;
+	}
+
+	/** The per-draw environment for one layer: a DPR-scaled 2D context plus the
+	 * culling ranges the renderer draws within. `null` when there is no shell
+	 * yet or the host cannot give us a 2D context. */
+	function drawEnv(canvas: HTMLCanvasElement): DrawEnvironment | null {
+		const shell = options.shell();
+		if (!shell) return null;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return null;
+		const port = shell.getViewport();
+		const ratio = shell.devicePixelRatio(hostDevicePixelRatio());
+		ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+		return {
+			ctx,
+			viewport: port,
+			projection: options.projection(),
+			rowRange: shell.rowRange(),
+			tickRange: shell.tickRange(),
+			waveformCache: options.waveformCache,
+		};
+	}
+
+	/** Draws exactly the layers marked dirty since the last frame. A playhead
+	 * move touches only the interaction canvas (PRD 9.3 dirty reasons). */
+	function drawDirtyLayers(): void {
+		const shell = options.shell();
+		if (!shell) return;
+		const layers: ReadonlySet<DirtyLayer> = shell.takeDirty();
+		if (layers.size === 0) return;
+		const port = shell.getViewport();
+		const canvases = options.canvases();
+		for (const canvas of [
+			canvases.background,
+			canvases.content,
+			canvases.interaction,
+		]) {
+			sizeCanvas(canvas, port);
+		}
+		if (layers.has("background")) {
+			const env = drawEnv(canvases.background);
+			if (env) drawBackgroundLayer(env);
+		}
+		if (layers.has("content")) {
+			const env = drawEnv(canvases.content);
+			if (env) drawContentLayer(env);
+		}
+		if (layers.has("interaction")) {
+			const env = drawEnv(canvases.interaction);
+			if (env) drawInteractionLayer(env, options.interactionState());
+		}
+	}
+
+	/** Resize / DPR: the native scroll viewport's own rect drives canvas size.
+	 * Every supported browser has `ResizeObserver`; guarded only so a
+	 * non-browser test host (jsdom, which has no `ResizeObserver`) can still
+	 * render the shell. */
+	function observeViewport(element: Element, onResize: () => void): boolean {
+		if (typeof ResizeObserver !== "function") return false;
+		const resizeObserver = new ResizeObserver(() => {
+			const rect = element.getBoundingClientRect();
+			options.shell()?.resize(rect.width, rect.height);
+			onResize();
+		});
+		resizeObserver.observe(element);
+		onCleanup(() => resizeObserver.disconnect());
+		return true;
+	}
+
+	onCleanup(() => {
+		cancelScheduledDraw();
+	});
+
+	return { scheduleDraw, drawDirtyLayers, observeViewport };
+}


### PR DESCRIPTION
Pure refactor of `src/arrangement/ArrangementView.tsx` (564 lines), which had ~305 lines of imperative setup ahead of a single ~175-line JSX tree. The domain logic was already extracted into independently tested modules (`arrangementShell.ts`, `geometry.ts`, `projection.ts`, `canvasRenderer.ts`, `waveformCache.ts`, `revision.ts`); what remained inline was DOM/canvas plumbing.

## What moved

**`useArrangementCanvas.ts` (new, 192 lines)** — the canvas lifecycle: rAF scheduling and cancellation, DPR backing-store sizing, `DrawEnvironment` construction, dirty-layer dispatch, and ResizeObserver wiring.

This is a **hook rather than a pure module** deliberately. Every piece of it is bound to a live `CanvasRenderingContext2D`, a canvas backing store, `requestAnimationFrame`, or a `ResizeObserver`, and its whole job is owning those lifetimes and tearing them down on unmount. Forcing it into "pure" helpers would relocate the DOM coupling rather than remove it. All cleanup is via `onCleanup` (CLAUDE.md), including the observer, which the hook registers itself.

**`ArrangementToolbar.tsx` (new, 58 lines)** — the four named DOM actions (zoom in/out, zoom to selection, scroll to playhead).

**`ArrangementView.tsx` (564 → 449 lines)** — keeps shell wiring, scroll/spacer sync, wheel-zoom mapping, pointer handling, headers, the a11y mirror, and JSX.

## PRD 9.3 contract preserved

The layer/dirty semantics move unchanged, with their doc comments:

- per-layer dirty reasons — a playhead move still touches only the interaction canvas;
- at most one draw per animation frame — `scheduleDraw` is a no-op while a frame is pending;
- idle when nothing is dirty — no speculative frame is ever scheduled, so a stopped transport runs no permanent 60 Hz loop.

## UI walkthrough

**No user-visible change** — this is a pure refactor, so there is no walkthrough to record. Every `data-testid` (`arrangement-view-ready`, `arrangement-selection-live`), aria attribute, CSS class, and `data-action` is preserved verbatim; the toolbar extraction reproduces the same DOM the inline JSX emitted. How that was verified:

- The existing `ArrangementView.test.tsx` (6 tests) passes **unmodified** — it asserts the four `aria-label`s, header windowing, the accessible per-track select controls, the live selection region, and the `feature_first_use` analytics contract. Not one existing test was weakened.
- The `ArrangementView.tsx` diff is a move: the deleted block and the new module are line-for-line equivalent apart from reading `shell`/canvases through accessors (both are assigned during render/mount, after the hook call).
- No CSS was touched.

## Evidence

- `bun run typecheck` — clean.
- `bun run check:ci` — clean, 426 files, no fixes needed. No unrelated churn: the diff touches only `src/arrangement/ArrangementView*` and the two new modules.
- `bun run test` — **1926 passed**, 2 failed. Both failures are pre-existing environment flakes unrelated to this change, and **both pass when re-run in isolation**: `src/audio/testAudioTeardown.test.ts` (contends for the single real audio output device — `cpal backend error ... coreaudio`) and `scripts/starter-library/runtime.test.mjs` (a 46s asset test that exceeds its 60s budget only under parallel load). Neither touches arrangement code.
- All 79 `src/arrangement/` tests pass.

## Added tests

`useArrangementCanvas.test.ts` (new, 6 tests) covers the PRD 9.3 drawing contract directly at its new boundary. These are **added, never substituted** for existing coverage.

The two guards that carry the contract were mutation-checked rather than assumed:

- deleting the `layers.size === 0` early return fails the idle test;
- deleting the `rafHandle !== null` coalescing guard fails the one-frame test.

The first mutation initially *survived* — asserting "no context was touched" passes vacuously with an empty dirty set, since no `layers.has(...)` branch fires either way. The guard's real observable effect is skipping `sizeCanvas`, so the test now asserts the backing store is left at its default size: writing `canvas.width` clears the canvas, so an idle frame that still sized would wipe visible pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)