### PR TITLE
Refactor: decompose PianoRoll into components and pure gesture modules

### DIFF
--- a/src/editor/PianoRoll.tsx
+++ b/src/editor/PianoRoll.tsx
@@ -4,12 +4,7 @@ import {
 	analytics as defaultAnalytics,
 } from "../analytics/analytics";
 import { bucketOf } from "../analytics/buckets";
-import type {
-	Gesture,
-	GestureOptions,
-	NoteChanges,
-	RawCommandInput,
-} from "../commands";
+import type { Gesture, GestureOptions, RawCommandInput } from "../commands";
 import {
 	addNotes,
 	duplicateNotes,
@@ -19,26 +14,35 @@ import {
 import type { Clip, NoteEvent, Project } from "../domain/entities";
 import { createFactoryContext, createNoteEvent } from "../domain/factories";
 import type { EventId } from "../domain/ids";
-import { NOTE_VELOCITY } from "../domain/parameters";
-import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH, toTicks } from "../domain/time";
+import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
+import PianoRollNote from "./PianoRollNote";
+import PianoRollToolbar from "./PianoRollToolbar";
 import {
 	clientXToTick,
 	clientYToPitch,
-	MAX_PITCH,
-	MIN_PITCH,
-	noteIntersectsRect,
 	noteRect,
 	type PianoRollViewport,
 	pitchToContentY,
-	snapTicks,
 	snapTicksFloor,
 	tickToContentX,
 } from "./pianoRollGeometry";
 import {
+	marqueeRect,
+	moveUpdates,
+	noteEvents,
+	notesInRect,
+	pitchDeltaOf,
+	pitchOf,
+	resizeUpdates,
+	selectAll as selectAllOf,
+	selectOnly as selectOnlyOf,
+	tickDeltaOf,
+	toggleSelected as toggleSelectedOf,
+} from "./pianoRollGestures";
+import {
 	isBlackKey,
 	isPitchInKey,
 	type KeyGuide,
-	PITCH_CLASS_NAMES,
 	type PitchClass,
 	pitchLabel,
 	type ScaleMode,
@@ -120,14 +124,6 @@ interface VelocityGestureState {
 	moved: boolean;
 }
 
-function noteEvents(clip: Clip): readonly NoteEvent[] {
-	return clip.content.kind === "notes" ? clip.content.events : [];
-}
-
-function pitchOf(note: NoteEvent): number {
-	return note.trigger.kind === "pitch" ? note.trigger.pitch : 60;
-}
-
 /**
  * The CLP-03 piano roll: create, move, resize, group-select, duplicate,
  * delete, and set velocity on a synth clip's pitched notes, with 16th-note
@@ -138,8 +134,12 @@ function pitchOf(note: NoteEvent): number {
  * mutation (PRD section 9.6). A continuous drag (move or resize) is one undo
  * transaction: it opens a gesture, applies each frame immediately so the UI
  * stays live, and commits once on pointer-up (PRD section 8). Pixel <-> tick /
- * pitch geometry lives in the pure `pianoRollGeometry` module so it stays
- * correct under scroll and zoom.
+ * pitch geometry lives in the pure `pianoRollGeometry` module, and the
+ * clip-and-viewport maths behind move, resize, selection, and the marquee in
+ * the pure `pianoRollGestures` module, so both stay correct under scroll and
+ * zoom. The toolbar (`PianoRollToolbar`) and each note (`PianoRollNote`) are
+ * presentational; this component keeps the grid surface, the keyboard gutter,
+ * and all of the pointer/gesture/dispatch wiring.
  */
 export default function PianoRoll(props: PianoRollProps): JSX.Element {
 	const analytics = () => props.analytics ?? defaultAnalytics;
@@ -229,16 +229,11 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 	}
 
 	function selectOnly(id: EventId): void {
-		setSelection(new Set([id]));
+		setSelection(selectOnlyOf(id));
 	}
 
 	function toggleSelected(id: EventId): void {
-		setSelection((current) => {
-			const next = new Set(current);
-			if (next.has(id)) next.delete(id);
-			else next.add(id);
-			return next;
-		});
+		setSelection((current) => toggleSelectedOf(current, id));
 	}
 
 	// --- Create ------------------------------------------------------------
@@ -301,67 +296,22 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 		const state = drag();
 		if (!state) return;
 		const view = viewport();
-		const deltaTicks =
-			(event.clientX - state.pointerStartX) / view.pixelsPerTick;
+		const deltaTicks = tickDeltaOf(
+			state.pointerStartX,
+			event.clientX,
+			view.pixelsPerTick,
+		);
 		const updates =
 			state.kind === "move"
-				? moveUpdates(state, event, view, deltaTicks)
-				: resizeUpdates(state, deltaTicks);
+				? moveUpdates(
+						state.originals,
+						deltaTicks,
+						pitchDeltaOf(state.pointerStartY, event.clientY, view.rowHeight),
+						props.clip.lengthTicks,
+					)
+				: resizeUpdates(state.originals, deltaTicks, props.clip.lengthTicks);
 		state.gesture.apply(updateNotes(props.clip.id, updates));
 		state.moved = true;
-	}
-
-	function moveUpdates(
-		state: DragState,
-		event: PointerEvent,
-		view: PianoRollViewport,
-		deltaTicks: number,
-	): { eventId: EventId; changes: NoteChanges }[] {
-		const pitchDelta = Math.round(
-			(state.pointerStartY - event.clientY) / view.rowHeight,
-		);
-		return state.originals.map((original) => ({
-			eventId: original.id,
-			changes: {
-				startTicks: toTicks(
-					clampStart(
-						snapTicks(original.startTicks + deltaTicks),
-						original.durationTicks,
-					),
-				),
-				trigger: {
-					kind: "pitch" as const,
-					pitch: clampPitch(pitchOf(original) + pitchDelta),
-				},
-			},
-		}));
-	}
-
-	function resizeUpdates(
-		state: DragState,
-		deltaTicks: number,
-	): { eventId: EventId; changes: NoteChanges }[] {
-		return state.originals.map((original) => {
-			const snapped = Math.max(
-				TICKS_PER_SIXTEENTH,
-				snapTicks(original.durationTicks + deltaTicks),
-			);
-			const maxDuration = props.clip.lengthTicks - original.startTicks;
-			return {
-				eventId: original.id,
-				changes: {
-					durationTicks: toTicks(
-						Math.max(TICKS_PER_SIXTEENTH, Math.min(snapped, maxDuration)),
-					),
-				},
-			};
-		});
-	}
-
-	/** Keeps a moved note inside the clip: start >= 0, and it never spills past the end. */
-	function clampStart(startTicks: number, durationTicks: number): number {
-		const maxStart = Math.max(0, props.clip.lengthTicks - durationTicks);
-		return Math.min(Math.max(0, startTicks), maxStart);
 	}
 
 	function endDrag(): void {
@@ -374,6 +324,19 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 		} else {
 			state.gesture.cancel();
 		}
+	}
+
+	/** Routes a press on a note to a resize (right edge) or a move (elsewhere). */
+	function beginNoteDrag(note: NoteEvent, event: PointerEvent): void {
+		if ((event.button ?? 0) !== 0) return;
+		if (event.shiftKey) {
+			event.stopPropagation();
+			toggleSelected(note.id);
+			return;
+		}
+		const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+		const nearRightEdge = event.clientX >= rect.right - RESIZE_HANDLE_PX;
+		beginDrag(nearRightEdge ? "resize" : "move", note, event);
 	}
 
 	// --- Marquee group-select ---------------------------------------------
@@ -397,30 +360,8 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 		if (!state) return;
 		const { x, y } = contentPoint(event);
 		setMarquee({ ...state, x, y });
-		const rect = {
-			left: Math.min(state.startX, x),
-			right: Math.max(state.startX, x),
-			top: Math.min(state.startY, y),
-			bottom: Math.max(state.startY, y),
-		};
-		const view = viewport();
-		const swept = new Set<EventId>();
-		for (const note of noteEvents(props.clip)) {
-			if (
-				noteIntersectsRect(
-					view,
-					{
-						startTicks: note.startTicks,
-						durationTicks: note.durationTicks,
-						pitch: pitchOf(note),
-					},
-					rect,
-				)
-			) {
-				swept.add(note.id);
-			}
-		}
-		setSelection(swept);
+		const rect = marqueeRect(state.startX, state.startY, x, y);
+		setSelection(notesInRect(props.clip, viewport(), rect));
 	}
 
 	function endMarquee(): void {
@@ -508,7 +449,7 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 	}
 
 	function selectAll(): void {
-		setSelection(new Set(noteEvents(props.clip).map((note) => note.id)));
+		setSelection(selectAllOf(props.clip));
 	}
 
 	// --- Keyboard actions ---------------------------------------------------
@@ -579,92 +520,19 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 
 	return (
 		<section class="piano-roll" aria-label={`Piano roll: ${props.clip.name}`}>
-			<div class="piano-roll-toolbar">
-				<button
-					type="button"
-					class="pr-tool"
-					onClick={duplicateSelection}
-					disabled={selection().size === 0}
-					aria-label="Duplicate selected notes"
-					title="Duplicate (Ctrl/Cmd+D)"
-				>
-					Duplicate
-				</button>
-				<button
-					type="button"
-					class="pr-tool"
-					onClick={deleteSelection}
-					disabled={selection().size === 0}
-					aria-label="Delete selected notes"
-					title="Delete (Del)"
-				>
-					Delete
-				</button>
-				<span class="pr-selection-count" aria-live="polite">
-					{selection().size} selected
-				</span>
-				<label class="pr-key-guide">
-					<input
-						type="checkbox"
-						checked={keyGuideEnabled()}
-						onChange={(event) =>
-							setKeyGuideEnabled(event.currentTarget.checked)
-						}
-					/>
-					<span>In-key guide</span>
-				</label>
-				<Show when={keyGuideEnabled()}>
-					<label class="visually-hidden" for="pr-key-root">
-						Key root
-					</label>
-					<select
-						id="pr-key-root"
-						class="pr-key-select"
-						value={String(keyRoot())}
-						onChange={(event) =>
-							setKeyRoot(Number(event.currentTarget.value) as PitchClass)
-						}
-					>
-						<For each={PITCH_CLASS_NAMES}>
-							{(name, index) => <option value={String(index())}>{name}</option>}
-						</For>
-					</select>
-					<label class="visually-hidden" for="pr-key-mode">
-						Key mode
-					</label>
-					<select
-						id="pr-key-mode"
-						class="pr-key-select"
-						value={keyMode()}
-						onChange={(event) =>
-							setKeyMode(event.currentTarget.value as ScaleMode)
-						}
-					>
-						<option value="major">Major</option>
-						<option value="minor">Minor</option>
-					</select>
-				</Show>
-				<span class="pr-zoom">
-					<button
-						type="button"
-						class="pr-tool"
-						onClick={zoomOut}
-						aria-label="Zoom out"
-						title="Zoom out"
-					>
-						−
-					</button>
-					<button
-						type="button"
-						class="pr-tool"
-						onClick={zoomIn}
-						aria-label="Zoom in"
-						title="Zoom in"
-					>
-						+
-					</button>
-				</span>
-			</div>
+			<PianoRollToolbar
+				selectionCount={selection().size}
+				duplicateSelection={duplicateSelection}
+				deleteSelection={deleteSelection}
+				keyGuideEnabled={keyGuideEnabled()}
+				setKeyGuideEnabled={setKeyGuideEnabled}
+				keyRoot={keyRoot()}
+				setKeyRoot={setKeyRoot}
+				keyMode={keyMode()}
+				setKeyMode={setKeyMode}
+				zoomIn={zoomIn}
+				zoomOut={zoomOut}
+			/>
 
 			<div class="piano-roll-body">
 				<div class="piano-roll-keys" style={{ height: `${contentHeight()}px` }}>
@@ -734,54 +602,20 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 
 					<For each={noteEvents(props.clip)}>
 						{(note) => (
-							<div
-								class="pr-note"
-								classList={{ selected: isSelected(note) }}
+							<PianoRollNote
+								note={note}
+								selected={isSelected(note)}
 								style={noteStyle(note)}
-								data-event-id={note.id}
-								title={`Note ${pitchLabel(pitchOf(note))}`}
-								onPointerDown={(event) => {
-									if ((event.button ?? 0) !== 0) return;
-									if (event.shiftKey) {
-										event.stopPropagation();
-										toggleSelected(note.id);
-										return;
-									}
-									const rect = (
-										event.currentTarget as HTMLElement
-									).getBoundingClientRect();
-									const nearRightEdge =
-										event.clientX >= rect.right - RESIZE_HANDLE_PX;
-									beginDrag(nearRightEdge ? "resize" : "move", note, event);
-								}}
+								onPointerDown={beginNoteDrag}
 								onPointerMove={(event) => {
 									if (drag()) updateDrag(event);
 								}}
 								onPointerUp={() => {
 									if (drag()) endDrag();
 								}}
-							>
-								<span class="pr-note-resize" aria-hidden="true" />
-								<input
-									class="pr-note-velocity"
-									type="range"
-									min={NOTE_VELOCITY.min}
-									max={NOTE_VELOCITY.max}
-									step={0.01}
-									value={note.velocity}
-									aria-label={`Velocity of ${pitchLabel(pitchOf(note))}`}
-									onPointerDown={(event) => event.stopPropagation()}
-									onInput={(event) =>
-										applyVelocity(note, event.currentTarget.valueAsNumber)
-									}
-									// `change` fires once the drag (or keyboard nudge) settles;
-									// pointer-up/cancel cover the mouse path. All commit the one
-									// open gesture — extra calls are a safe no-op.
-									onChange={() => commitVelocity()}
-									onPointerUp={() => commitVelocity()}
-									onPointerCancel={() => commitVelocity()}
-								/>
-							</div>
+								applyVelocity={applyVelocity}
+								commitVelocity={commitVelocity}
+							/>
 						)}
 					</For>
 
@@ -801,10 +635,4 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 			</div>
 		</section>
 	);
-}
-
-function clampPitch(pitch: number): number {
-	if (pitch < MIN_PITCH) return MIN_PITCH;
-	if (pitch > MAX_PITCH) return MAX_PITCH;
-	return pitch;
 }

--- a/src/editor/PianoRollNote.tsx
+++ b/src/editor/PianoRollNote.tsx
@@ -1,0 +1,63 @@
+import type { JSX } from "solid-js";
+import type { NoteEvent } from "../domain/entities";
+import { NOTE_VELOCITY } from "../domain/parameters";
+import { pitchOf } from "./pianoRollGestures";
+import { pitchLabel } from "./pitchClass";
+
+export interface PianoRollNoteProps {
+	readonly note: NoteEvent;
+	readonly selected: boolean;
+	/** Absolute position/size in content pixels, from `pianoRollGeometry`. */
+	readonly style: JSX.CSSProperties;
+	onPointerDown(note: NoteEvent, event: PointerEvent): void;
+	onPointerMove(event: PointerEvent): void;
+	onPointerUp(): void;
+	/** One intermediate value from the velocity slider drag. */
+	applyVelocity(note: NoteEvent, velocity: number): void;
+	/** Commits (or cancels) the open velocity gesture. */
+	commitVelocity(): void;
+}
+
+/**
+ * One note in the roll: the draggable body (whose right edge is the resize
+ * handle) plus its velocity slider.
+ *
+ * Every pointer handler forwards to the roll, which owns the drag state and the
+ * command dispatch — this component decides nothing, so a note added or removed
+ * cannot change gesture behavior.
+ */
+export default function PianoRollNote(props: PianoRollNoteProps): JSX.Element {
+	return (
+		<div
+			class="pr-note"
+			classList={{ selected: props.selected }}
+			style={props.style}
+			data-event-id={props.note.id}
+			title={`Note ${pitchLabel(pitchOf(props.note))}`}
+			onPointerDown={(event) => props.onPointerDown(props.note, event)}
+			onPointerMove={(event) => props.onPointerMove(event)}
+			onPointerUp={() => props.onPointerUp()}
+		>
+			<span class="pr-note-resize" aria-hidden="true" />
+			<input
+				class="pr-note-velocity"
+				type="range"
+				min={NOTE_VELOCITY.min}
+				max={NOTE_VELOCITY.max}
+				step={0.01}
+				value={props.note.velocity}
+				aria-label={`Velocity of ${pitchLabel(pitchOf(props.note))}`}
+				onPointerDown={(event) => event.stopPropagation()}
+				onInput={(event) =>
+					props.applyVelocity(props.note, event.currentTarget.valueAsNumber)
+				}
+				// `change` fires once the drag (or keyboard nudge) settles;
+				// pointer-up/cancel cover the mouse path. All commit the one
+				// open gesture — extra calls are a safe no-op.
+				onChange={() => props.commitVelocity()}
+				onPointerUp={() => props.commitVelocity()}
+				onPointerCancel={() => props.commitVelocity()}
+			/>
+		</div>
+	);
+}

--- a/src/editor/PianoRollToolbar.tsx
+++ b/src/editor/PianoRollToolbar.tsx
@@ -1,0 +1,123 @@
+import { For, type JSX, Show } from "solid-js";
+import {
+	PITCH_CLASS_NAMES,
+	type PitchClass,
+	type ScaleMode,
+} from "./pitchClass";
+
+export interface PianoRollToolbarProps {
+	/** How many notes are selected; 0 disables the destructive actions. */
+	readonly selectionCount: number;
+	duplicateSelection(): void;
+	deleteSelection(): void;
+	/** The in-key guide's view-only state, owned by the roll (never persisted). */
+	readonly keyGuideEnabled: boolean;
+	setKeyGuideEnabled(enabled: boolean): void;
+	readonly keyRoot: PitchClass;
+	setKeyRoot(root: PitchClass): void;
+	readonly keyMode: ScaleMode;
+	setKeyMode(mode: ScaleMode): void;
+	zoomIn(): void;
+	zoomOut(): void;
+}
+
+/**
+ * The piano roll's toolbar: duplicate/delete for the current selection, a live
+ * selection count, the CLP-03 optional in-key guide controls, and zoom.
+ *
+ * Purely presentational — it owns no state and dispatches no command. The roll
+ * passes its selection and view state down and receives the operations back, so
+ * every mutation still runs through the roll's command-layer dispatch.
+ */
+export default function PianoRollToolbar(
+	props: PianoRollToolbarProps,
+): JSX.Element {
+	return (
+		<div class="piano-roll-toolbar">
+			<button
+				type="button"
+				class="pr-tool"
+				onClick={() => props.duplicateSelection()}
+				disabled={props.selectionCount === 0}
+				aria-label="Duplicate selected notes"
+				title="Duplicate (Ctrl/Cmd+D)"
+			>
+				Duplicate
+			</button>
+			<button
+				type="button"
+				class="pr-tool"
+				onClick={() => props.deleteSelection()}
+				disabled={props.selectionCount === 0}
+				aria-label="Delete selected notes"
+				title="Delete (Del)"
+			>
+				Delete
+			</button>
+			<span class="pr-selection-count" aria-live="polite">
+				{props.selectionCount} selected
+			</span>
+			<label class="pr-key-guide">
+				<input
+					type="checkbox"
+					checked={props.keyGuideEnabled}
+					onChange={(event) =>
+						props.setKeyGuideEnabled(event.currentTarget.checked)
+					}
+				/>
+				<span>In-key guide</span>
+			</label>
+			<Show when={props.keyGuideEnabled}>
+				<label class="visually-hidden" for="pr-key-root">
+					Key root
+				</label>
+				<select
+					id="pr-key-root"
+					class="pr-key-select"
+					value={String(props.keyRoot)}
+					onChange={(event) =>
+						props.setKeyRoot(Number(event.currentTarget.value) as PitchClass)
+					}
+				>
+					<For each={PITCH_CLASS_NAMES}>
+						{(name, index) => <option value={String(index())}>{name}</option>}
+					</For>
+				</select>
+				<label class="visually-hidden" for="pr-key-mode">
+					Key mode
+				</label>
+				<select
+					id="pr-key-mode"
+					class="pr-key-select"
+					value={props.keyMode}
+					onChange={(event) =>
+						props.setKeyMode(event.currentTarget.value as ScaleMode)
+					}
+				>
+					<option value="major">Major</option>
+					<option value="minor">Minor</option>
+				</select>
+			</Show>
+			<span class="pr-zoom">
+				<button
+					type="button"
+					class="pr-tool"
+					onClick={() => props.zoomOut()}
+					aria-label="Zoom out"
+					title="Zoom out"
+				>
+					−
+				</button>
+				<button
+					type="button"
+					class="pr-tool"
+					onClick={() => props.zoomIn()}
+					aria-label="Zoom in"
+					title="Zoom in"
+				>
+					+
+				</button>
+			</span>
+		</div>
+	);
+}

--- a/src/editor/pianoRollGestures.test.ts
+++ b/src/editor/pianoRollGestures.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+import type { Clip, NoteEvent } from "../domain/entities";
+import { createPianoRollFixtureProject } from "../domain/fixtures";
+import type { EventId } from "../domain/ids";
+import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
+import {
+	MAX_PITCH,
+	MIN_PITCH,
+	type PianoRollViewport,
+} from "./pianoRollGeometry";
+import {
+	clampPitch,
+	clampStart,
+	marqueeRect,
+	moveUpdates,
+	noteEvents,
+	notesInRect,
+	pitchDeltaOf,
+	pitchOf,
+	resizeUpdates,
+	selectAll,
+	selectOnly,
+	tickDeltaOf,
+	toggleSelected,
+} from "./pianoRollGestures";
+
+/** The roll's own default scale, so these assertions read in real pixels. */
+const VIEWPORT: PianoRollViewport = {
+	pixelsPerTick: 0.25,
+	rowHeight: 14,
+	scrollTicks: 0,
+	scrollTop: 0,
+	topPitch: 96,
+};
+
+const CLIP_LENGTH = TICKS_PER_BAR * 2;
+
+function fixtureClip(): Clip {
+	return createPianoRollFixtureProject().clips[0];
+}
+
+/** A minimal pitched note; only the fields the gesture maths reads. */
+function note(
+	id: string,
+	startTicks: number,
+	durationTicks: number,
+	pitch: number,
+): NoteEvent {
+	return {
+		id: id as EventId,
+		startTicks,
+		durationTicks,
+		velocity: 0.8,
+		trigger: { kind: "pitch", pitch },
+	} as NoteEvent;
+}
+
+describe("pianoRollGestures", () => {
+	describe("noteEvents / pitchOf", () => {
+		it("reads a note clip's events and their pitches", () => {
+			const clip = fixtureClip();
+			const events = noteEvents(clip);
+			expect(events).toHaveLength(4);
+			expect(events.map(pitchOf)).toEqual([60, 64, 67, 72]);
+		});
+
+		it("reads no events from non-note clip content", () => {
+			const clip = {
+				...fixtureClip(),
+				content: { kind: "audio" },
+			} as unknown as Clip;
+			expect(noteEvents(clip)).toEqual([]);
+		});
+
+		it("falls back to middle C for a non-pitched trigger", () => {
+			const pad = {
+				id: "evt_pad" as EventId,
+				startTicks: 0,
+				durationTicks: TICKS_PER_SIXTEENTH,
+				velocity: 1,
+				trigger: { kind: "pad", padId: "pad_1" },
+			} as unknown as NoteEvent;
+			expect(pitchOf(pad)).toBe(60);
+		});
+	});
+
+	describe("clampPitch", () => {
+		it("clamps to the displayable MIDI range and passes anything inside through", () => {
+			expect(clampPitch(-5)).toBe(MIN_PITCH);
+			expect(clampPitch(500)).toBe(MAX_PITCH);
+			expect(clampPitch(60)).toBe(60);
+		});
+	});
+
+	describe("clampStart", () => {
+		it("never returns a negative start", () => {
+			expect(clampStart(-100, TICKS_PER_SIXTEENTH, CLIP_LENGTH)).toBe(0);
+		});
+
+		it("keeps the note's tail inside the clip", () => {
+			expect(clampStart(CLIP_LENGTH, TICKS_PER_SIXTEENTH, CLIP_LENGTH)).toBe(
+				CLIP_LENGTH - TICKS_PER_SIXTEENTH,
+			);
+		});
+
+		it("pins a note longer than the clip to tick 0 rather than going negative", () => {
+			expect(clampStart(50, CLIP_LENGTH * 2, CLIP_LENGTH)).toBe(0);
+		});
+	});
+
+	describe("moveUpdates", () => {
+		it("snaps the shifted start to the 16th grid and moves the pitch by whole rows", () => {
+			const original = note("evt_a", TICKS_PER_SIXTEENTH * 4, 48, 60);
+			const [update] = moveUpdates(
+				[original],
+				TICKS_PER_SIXTEENTH + 5,
+				2,
+				CLIP_LENGTH,
+			);
+			expect(update.eventId).toBe(original.id);
+			expect(update.changes.startTicks).toBe(TICKS_PER_SIXTEENTH * 5);
+			expect(update.changes.trigger).toEqual({ kind: "pitch", pitch: 62 });
+		});
+
+		it("clamps each note independently at the clip's boundaries", () => {
+			const early = note("evt_a", 0, TICKS_PER_SIXTEENTH, 60);
+			const late = note(
+				"evt_b",
+				CLIP_LENGTH - TICKS_PER_SIXTEENTH,
+				TICKS_PER_SIXTEENTH,
+				62,
+			);
+			const dragLeft = moveUpdates([early, late], -CLIP_LENGTH, 0, CLIP_LENGTH);
+			expect(dragLeft[0].changes.startTicks).toBe(0);
+			expect(dragLeft[1].changes.startTicks).toBe(0);
+
+			const dragRight = moveUpdates([early, late], CLIP_LENGTH, 0, CLIP_LENGTH);
+			expect(dragRight[0].changes.startTicks).toBe(
+				CLIP_LENGTH - TICKS_PER_SIXTEENTH,
+			);
+			expect(dragRight[1].changes.startTicks).toBe(
+				CLIP_LENGTH - TICKS_PER_SIXTEENTH,
+			);
+		});
+
+		it("clamps a pitch driven past the MIDI range", () => {
+			const high = note("evt_a", 0, TICKS_PER_SIXTEENTH, 120);
+			const low = note("evt_b", 0, TICKS_PER_SIXTEENTH, 3);
+			expect(
+				moveUpdates([high], 0, 50, CLIP_LENGTH)[0].changes.trigger,
+			).toEqual({ kind: "pitch", pitch: MAX_PITCH });
+			expect(
+				moveUpdates([low], 0, -50, CLIP_LENGTH)[0].changes.trigger,
+			).toEqual({ kind: "pitch", pitch: MIN_PITCH });
+		});
+
+		it("returns one update per dragged note, preserving order", () => {
+			const originals = noteEvents(fixtureClip());
+			const updates = moveUpdates(originals, 0, 0, CLIP_LENGTH);
+			expect(updates.map((update) => update.eventId)).toEqual(
+				originals.map((n) => n.id),
+			);
+		});
+	});
+
+	describe("resizeUpdates", () => {
+		it("snaps the new duration to the 16th grid", () => {
+			const original = note("evt_a", 0, TICKS_PER_SIXTEENTH, 60);
+			const [update] = resizeUpdates(
+				[original],
+				TICKS_PER_SIXTEENTH * 2 + 3,
+				CLIP_LENGTH,
+			);
+			expect(update.changes.durationTicks).toBe(TICKS_PER_SIXTEENTH * 3);
+		});
+
+		it("never shrinks a note below one 16th", () => {
+			const original = note("evt_a", 0, TICKS_PER_SIXTEENTH, 60);
+			const [update] = resizeUpdates([original], -CLIP_LENGTH, CLIP_LENGTH);
+			expect(update.changes.durationTicks).toBe(TICKS_PER_SIXTEENTH);
+		});
+
+		it("never grows a note past the clip's end", () => {
+			const original = note(
+				"evt_a",
+				CLIP_LENGTH - TICKS_PER_SIXTEENTH * 2,
+				TICKS_PER_SIXTEENTH,
+				60,
+			);
+			const [update] = resizeUpdates([original], CLIP_LENGTH, CLIP_LENGTH);
+			expect(update.changes.durationTicks).toBe(TICKS_PER_SIXTEENTH * 2);
+			expect(
+				original.startTicks + (update.changes.durationTicks ?? 0),
+			).toBeLessThanOrEqual(CLIP_LENGTH);
+		});
+	});
+
+	describe("pitchDeltaOf / tickDeltaOf", () => {
+		it("raises the pitch when the pointer moves up, and rounds to whole rows", () => {
+			expect(pitchDeltaOf(100, 100 - 14 * 3, 14)).toBe(3);
+			expect(pitchDeltaOf(100, 100 + 14 * 2, 14)).toBe(-2);
+			// Just over half a row rounds to a whole row.
+			expect(pitchDeltaOf(100, 100 - 8, 14)).toBe(1);
+			expect(pitchDeltaOf(100, 100 - 6, 14)).toBe(0);
+		});
+
+		it("converts pointer travel to ticks at the viewport's scale", () => {
+			expect(tickDeltaOf(0, 48, 0.25)).toBe(192);
+			expect(tickDeltaOf(48, 0, 0.25)).toBe(-192);
+		});
+	});
+
+	describe("selection algebra", () => {
+		it("selectOnly yields exactly that one id", () => {
+			expect([...selectOnly("evt_a" as EventId)]).toEqual(["evt_a"]);
+		});
+
+		it("toggleSelected adds an absent id and removes a present one, without mutating the input", () => {
+			const current: ReadonlySet<EventId> = new Set(["evt_a"] as EventId[]);
+			const added = toggleSelected(current, "evt_b" as EventId);
+			expect([...added].sort()).toEqual(["evt_a", "evt_b"]);
+			expect([...current]).toEqual(["evt_a"]);
+
+			const removed = toggleSelected(added, "evt_a" as EventId);
+			expect([...removed]).toEqual(["evt_b"]);
+		});
+
+		it("selectAll yields every note in the clip", () => {
+			const clip = fixtureClip();
+			expect([...selectAll(clip)].sort()).toEqual(
+				noteEvents(clip)
+					.map((n) => n.id as string)
+					.sort(),
+			);
+		});
+	});
+
+	describe("marqueeRect", () => {
+		it("normalizes a drag in any direction to the same rectangle", () => {
+			const downRight = marqueeRect(10, 20, 50, 80);
+			const upLeft = marqueeRect(50, 80, 10, 20);
+			expect(downRight).toEqual({
+				left: 10,
+				right: 50,
+				top: 20,
+				bottom: 80,
+			});
+			expect(upLeft).toEqual(downRight);
+		});
+	});
+
+	describe("notesInRect", () => {
+		it("sweeps only the notes the rectangle actually covers", () => {
+			const clip = fixtureClip();
+			const events = noteEvents(clip);
+			const first = events[0]; // pitch 60, tick 0
+			// A band over pitch 60's row only, spanning the first 16th.
+			const rowTop = (VIEWPORT.topPitch - 60) * VIEWPORT.rowHeight;
+			const swept = notesInRect(clip, VIEWPORT, {
+				left: 0,
+				right: TICKS_PER_SIXTEENTH * VIEWPORT.pixelsPerTick,
+				top: rowTop + 1,
+				bottom: rowTop + VIEWPORT.rowHeight - 1,
+			});
+			expect([...swept]).toEqual([first.id]);
+		});
+
+		it("sweeps every note when the rectangle covers the whole clip", () => {
+			const clip = fixtureClip();
+			const swept = notesInRect(clip, VIEWPORT, {
+				left: 0,
+				right: CLIP_LENGTH * VIEWPORT.pixelsPerTick,
+				top: 0,
+				bottom: 128 * VIEWPORT.rowHeight,
+			});
+			expect(swept.size).toBe(noteEvents(clip).length);
+		});
+
+		it("sweeps nothing for an empty rectangle away from every note", () => {
+			const clip = fixtureClip();
+			const swept = notesInRect(clip, VIEWPORT, {
+				left: 0,
+				right: 0,
+				top: 0,
+				bottom: 0,
+			});
+			expect(swept.size).toBe(0);
+		});
+	});
+});

--- a/src/editor/pianoRollGestures.ts
+++ b/src/editor/pianoRollGestures.ts
@@ -1,0 +1,215 @@
+// Pure, framework-free gesture model for the CLP-03 piano roll.
+//
+// The component (`PianoRoll.tsx`) owns pointer state, gestures, and command
+// dispatch; everything that is a *function of the clip and the viewport* lives
+// here so it can be unit-tested without a DOM. Nothing in this module mutates a
+// project — it reads a clip's note content and returns plain descriptions of the
+// change (`note.update` payload changes, selection sets, hit-test results) that
+// the component hands to the shared command layer.
+//
+// This is the same split `stepEditorModel.ts` makes for the CLP-02 step editor:
+// clip length and the `PianoRollViewport` are *arguments*, never closed-over
+// props, which is exactly what makes move/resize clamping, marquee sweeps, and
+// selection algebra provable at the lowest layer.
+
+import type { NoteChanges } from "../commands";
+import type { Clip, NoteEvent } from "../domain/entities";
+import type { EventId } from "../domain/ids";
+import { TICKS_PER_SIXTEENTH, toTicks } from "../domain/time";
+import {
+	MAX_PITCH,
+	MIN_PITCH,
+	noteIntersectsRect,
+	type PianoRollViewport,
+	snapTicks,
+} from "./pianoRollGeometry";
+
+/** One entry of a `note.update` batch: which event, and what changes. */
+export interface NoteUpdate {
+	eventId: EventId;
+	changes: NoteChanges;
+}
+
+/** A content-space rectangle, the shape `noteIntersectsRect` hit-tests against. */
+export interface ContentRect {
+	readonly left: number;
+	readonly top: number;
+	readonly right: number;
+	readonly bottom: number;
+}
+
+/** The clip's note events, or an empty list for non-note content. */
+export function noteEvents(clip: Clip): readonly NoteEvent[] {
+	return clip.content.kind === "notes" ? clip.content.events : [];
+}
+
+/** A note's MIDI pitch; a non-pitched trigger reads as middle C. */
+export function pitchOf(note: NoteEvent): number {
+	return note.trigger.kind === "pitch" ? note.trigger.pitch : 60;
+}
+
+/** Clamps a pitch into the roll's displayable MIDI range. */
+export function clampPitch(pitch: number): number {
+	if (pitch < MIN_PITCH) return MIN_PITCH;
+	if (pitch > MAX_PITCH) return MAX_PITCH;
+	return pitch;
+}
+
+/** Keeps a moved note inside the clip: start >= 0, and it never spills past the end. */
+export function clampStart(
+	startTicks: number,
+	durationTicks: number,
+	clipLengthTicks: number,
+): number {
+	const maxStart = Math.max(0, clipLengthTicks - durationTicks);
+	return Math.min(Math.max(0, startTicks), maxStart);
+}
+
+/**
+ * The `note.update` batch for a move drag: every dragged note shifts by the same
+ * snapped tick delta and the same whole number of pitch rows, each clamped
+ * independently so one note hitting a boundary never drags the others with it.
+ */
+export function moveUpdates(
+	originals: readonly NoteEvent[],
+	deltaTicks: number,
+	pitchDelta: number,
+	clipLengthTicks: number,
+): NoteUpdate[] {
+	return originals.map((original) => ({
+		eventId: original.id,
+		changes: {
+			startTicks: toTicks(
+				clampStart(
+					snapTicks(original.startTicks + deltaTicks),
+					original.durationTicks,
+					clipLengthTicks,
+				),
+			),
+			trigger: {
+				kind: "pitch" as const,
+				pitch: clampPitch(pitchOf(original) + pitchDelta),
+			},
+		},
+	}));
+}
+
+/**
+ * The `note.update` batch for a resize drag. A note never shrinks below one 16th
+ * and never grows past the clip's end.
+ */
+export function resizeUpdates(
+	originals: readonly NoteEvent[],
+	deltaTicks: number,
+	clipLengthTicks: number,
+): NoteUpdate[] {
+	return originals.map((original) => {
+		const snapped = Math.max(
+			TICKS_PER_SIXTEENTH,
+			snapTicks(original.durationTicks + deltaTicks),
+		);
+		const maxDuration = clipLengthTicks - original.startTicks;
+		return {
+			eventId: original.id,
+			changes: {
+				durationTicks: toTicks(
+					Math.max(TICKS_PER_SIXTEENTH, Math.min(snapped, maxDuration)),
+				),
+			},
+		};
+	});
+}
+
+/**
+ * How many pitch rows a pointer has travelled. Upward pointer movement (a
+ * *smaller* clientY) raises the pitch, so the sign is inverted here rather than
+ * at each call site.
+ */
+export function pitchDeltaOf(
+	pointerStartY: number,
+	clientY: number,
+	rowHeight: number,
+): number {
+	return Math.round((pointerStartY - clientY) / rowHeight);
+}
+
+/** How many ticks a pointer has travelled horizontally, before snapping. */
+export function tickDeltaOf(
+	pointerStartX: number,
+	clientX: number,
+	pixelsPerTick: number,
+): number {
+	return (clientX - pointerStartX) / pixelsPerTick;
+}
+
+// --- Selection algebra ---------------------------------------------------
+
+/** The selection containing only `id`. */
+export function selectOnly(id: EventId): ReadonlySet<EventId> {
+	return new Set([id]);
+}
+
+/** `current` with `id` added if absent, removed if present (shift+click). */
+export function toggleSelected(
+	current: ReadonlySet<EventId>,
+	id: EventId,
+): ReadonlySet<EventId> {
+	const next = new Set(current);
+	if (next.has(id)) next.delete(id);
+	else next.add(id);
+	return next;
+}
+
+/** Every note in the clip. */
+export function selectAll(clip: Clip): ReadonlySet<EventId> {
+	return new Set(noteEvents(clip).map((note) => note.id));
+}
+
+// --- Marquee -------------------------------------------------------------
+
+/**
+ * Normalizes a marquee's two corners into a rectangle, so a drag up-and-left
+ * sweeps exactly the same notes as the equivalent drag down-and-right.
+ */
+export function marqueeRect(
+	startX: number,
+	startY: number,
+	x: number,
+	y: number,
+): ContentRect {
+	return {
+		left: Math.min(startX, x),
+		right: Math.max(startX, x),
+		top: Math.min(startY, y),
+		bottom: Math.max(startY, y),
+	};
+}
+
+/**
+ * The notes a marquee rectangle sweeps. The hit test itself lives in
+ * `pianoRollGeometry`; this walks the clip and collects the ids, which is what
+ * the roll's selection signal wants.
+ */
+export function notesInRect(
+	clip: Clip,
+	viewport: PianoRollViewport,
+	rect: ContentRect,
+): ReadonlySet<EventId> {
+	const swept = new Set<EventId>();
+	for (const note of noteEvents(clip)) {
+		if (
+			noteIntersectsRect(
+				viewport,
+				{
+					startTicks: note.startTicks,
+					durationTicks: note.durationTicks,
+					pitch: pitchOf(note),
+				},
+				rect,
+			)
+		) {
+			swept.add(note.id);
+		}
+	}
+	return swept;
+}


### PR DESCRIPTION
## What & why

`src/editor/PianoRoll.tsx` was 810 lines — the largest UI file in the codebase — with **zero local components** and its entire gesture model closed over `props`. That meant none of the move/resize clamping, selection algebra, or marquee hit-testing could be tested below the component layer: every assertion about "does a note stop at the clip boundary" had to go through jsdom, synthetic pointer events, and a stubbed `getBoundingClientRect`.

This is a **pure refactor**. It splits the roll the way `stepEditorModel.ts` already splits the CLP-02 step editor: the component owns pointer state, gestures, and command dispatch; everything that is a *function of the clip and the viewport* moves into a pure module that takes clip length and `PianoRollViewport` as **arguments** instead of closing over `props`.

No issue — this is maintenance on `LOOP-011`'s landed CLP-03 slice, not new scope. It changes no contract: `src/domain`, `src/commands`, and the persistence layout are untouched, and every mutation still goes through the shared command layer (`note.add`, `note.update`, `note.remove`, `notes.duplicate`).

### New files

| File | Lines | Role |
| --- | --- | --- |
| `src/editor/pianoRollGestures.ts` | 215 | Pure gesture model — mirrors `stepEditorModel.ts` in shape and header-comment convention |
| `src/editor/PianoRollToolbar.tsx` | 123 | Duplicate/delete, selection count, in-key guide, zoom. Presentational: no state, no dispatch |
| `src/editor/PianoRollNote.tsx` | 63 | One note's body, resize handle, and velocity slider; forwards every pointer handler to the roll |
| `src/editor/pianoRollGestures.test.ts` | 290 | 23 new unit tests (see below) |

`PianoRoll.tsx` drops **810 → 638** lines and keeps the grid surface, the keyboard gutter, and all pointer/gesture/dispatch wiring.

Extracted into the pure module: `moveUpdates`, `resizeUpdates`, `clampStart`, `clampPitch`, `pitchOf`, `noteEvents`, `selectOnly`, `toggleSelected`, `selectAll`, `marqueeRect` (the corner normalization), and `notesInRect` (the marquee sweep loop), plus two conversions the component was doing inline — `pitchDeltaOf` and `tickDeltaOf`.

### Public surface preserved

The three exports consumers touch — `default PianoRoll`, `PianoRollActions`, `PianoRollProps` — are byte-identical. `TrackEditor.tsx`, `EditorView.tsx`, and `useEditorShortcuts.ts` are unmodified.

### The velocity re-entrancy guard is deliberately NOT extracted

`applyVelocity` still lives in the component, and still captures `velocityDrag` into a local `drag` and sets `drag.moved = true` **before** calling `drag.gesture.apply(...)`, never dereferencing the module-level `velocityDrag` again afterward. `apply()` synchronously notifies history listeners, which can re-render and re-enter `commitVelocity()`, nulling that reference — moving this mechanically is exactly how you reintroduce `TypeError: Cannot set properties of null (setting 'moved')`. The existing regression test (`survives a re-entrant commit triggered synchronously from within gesture.apply()`) passes unchanged.

## Walkthrough

**No UI change.** This PR changes nothing a user sees, clicks, or hears — no component, layout, styling, copy, or interaction differs. `PianoRoll.css` is untouched.

Rather than assert that from reading the diff, I verified it mechanically: I rendered the pre-refactor component (restored from `HEAD` under a temporary name) and the refactored one side by side against the same fixture clip and compared `container.innerHTML` **byte for byte**, once with the in-key guide off and once with it on (which exercises the toolbar's conditional `<Show>` block). Identical in both states — every `data-testid`, `class`, `classList`, `aria-*`, `title`, inline style, and element ordering. That scaffold was throwaway and is **not** committed.

Belt-and-braces on top of that: `PianoRoll.test.tsx` (693 lines, 17 tests) is **unmodified** — `git diff --stat` on it is empty — and it asserts the real markup contract directly (`.piano-roll-content`, `[data-event-id]`, `.pr-note.selected`, `.pr-note-velocity`, `.pr-row.out-of-key`, `.pr-playhead`, `.pr-key-guide input`, `button[aria-label="Delete selected notes"]`). No existing assertion was weakened or deleted.

## Evidence

```
$ bun run typecheck
$ tsc --noEmit
(clean)

$ bun run check:ci
$ tsc --noEmit && biome check
Checked 427 files in 585ms. No fixes applied.

$ bun run test
 Test Files  145 passed (145)
      Tests  1945 passed (1945)
```

Full suite green on the first run, including `src/audio/testAudioTeardown.test.ts` (the known local audio-device flake) — no re-run needed.

Scoped runs during development:

```
$ bunx vitest run src/editor/PianoRoll.test.tsx
 ✓ src/editor/PianoRoll.test.tsx (17 tests) 428ms

$ bunx vitest run src/editor/pianoRollGestures.test.ts
 ✓ src/editor/pianoRollGestures.test.ts (23 tests) 25ms

$ bunx vitest run src/editor/PianoRoll.test.tsx src/editor/pianoRollGestures.test.ts src/editor/EditorView.test.tsx
 Test Files  3 passed (3)
      Tests  62 passed (62)
```

### New tests (23, all in `pianoRollGestures.test.ts`)

These are the win: behavior that previously could only be reached through a synthetic pointer drag is now asserted directly.

- **`noteEvents` / `pitchOf`** — reads a note clip's events; returns empty for non-note content; falls back to middle C for a non-pitched (pad) trigger.
- **`clampPitch`** — clamps to `MIN_PITCH`/`MAX_PITCH`, passes anything inside through.
- **`clampStart`** — never negative; keeps a note's tail inside the clip; a note *longer* than the clip pins to tick 0 rather than going negative.
- **`moveUpdates`** — snaps the shifted start to the 16th grid and moves pitch by whole rows; **clamps each note independently** at both clip boundaries (one note hitting the edge must not drag the group with it); clamps a pitch driven past the MIDI range in both directions; returns one update per note, order preserved.
- **`resizeUpdates`** — snaps the new duration to the 16th grid; never shrinks below one 16th; never grows past the clip's end.
- **`pitchDeltaOf` / `tickDeltaOf`** — upward pointer travel *raises* pitch (the sign inversion), rounds to whole rows at the half-row boundary; pointer travel converts to ticks at the viewport scale.
- **Selection algebra** — `selectOnly`; `toggleSelected` adds/removes **without mutating its input**; `selectAll` covers every note.
- **`marqueeRect`** — a drag up-and-left normalizes to the same rectangle as the equivalent drag down-and-right.
- **`notesInRect`** — sweeps only the covered notes (a one-row, one-16th band picks out exactly one note); sweeps everything for a full-clip rectangle; sweeps nothing for a degenerate rectangle.

## Acceptance criteria met

Refactor-only, so the relevant gates are the definition-of-done items that apply:

- [x] **No behavior change** — verified by byte-identical rendered markup against the pre-refactor component, plus 17 unmodified component tests.
- [x] **No contract altered** — domain schema, command registry, parameter definitions, persistence layout, selection, and projections untouched.
- [x] **Mutations still go through the shared command layer** — the pure module returns plain `NoteUpdate` descriptions; only the component dispatches, and it never mutates a `Project`.
- [x] **Analytics unchanged** — `markFeatureUse()` / `logClipEdited()` stay in the component, firing at the same call sites through the typed catalog. `emits clip_edited once per completed gesture`, `emits the piano_roll feature_first_use exactly once`, and `logs nothing when analytics consent is withdrawn` all pass unmodified.
- [x] **Tests at the lowest useful layer** — the point of the change: 23 assertions moved off jsdom onto pure functions.
- [x] **Doc comments preserved**, moved with their code; the roll's header comment now also names the two extracted modules.
- [x] `bun run typecheck`, `bun run test`, `bun run check` pass.
- [x] **No unrelated churn** — no formatting, dependency, generated-file, or drive-by refactor changes. Biome's auto-fix touched only the two files this PR adds/edits (import ordering).

Browser E2E and emulator suites were not run: this PR adds no user-reachable behavior and the rendered DOM is provably identical, so those suites exercise exactly what they exercised on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)