### PR TITLE
Refactor: extract EditorView view-model and StepEditor stroke machine

### DIFF
--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -15,8 +15,7 @@ import { setParameter } from "../commands/definitions/parameters";
 import type { NoteTrigger } from "../domain/entities";
 import type { EventId } from "../domain/ids";
 import { SONG_TEMPO } from "../domain/parameters";
-import { formatBarsBeatsSixteenths, TICKS_PER_QUARTER } from "../domain/time";
-import type { SampleChoice } from "../instrument/SamplerPanel";
+import { TICKS_PER_QUARTER } from "../domain/time";
 import type { PreviewEngine } from "../library/audition";
 import LibraryBrowser from "../library/LibraryBrowser";
 import { ToneAuditionEngine } from "../library/toneAuditionEngine";
@@ -24,6 +23,7 @@ import { getProjectRepository } from "../projectRepositoryClient";
 import ShortcutGuide from "../shortcuts/ShortcutGuide";
 import DrumMachinePanel from "./DrumMachinePanel";
 import EditorHeader from "./EditorHeader";
+import * as model from "./editorViewModel";
 import LoopInfo from "./LoopInfo";
 import Mixer from "./Mixer";
 import type { PianoRollActions } from "./PianoRoll";
@@ -78,27 +78,15 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	const [libraryOpen, setLibraryOpen] = createSignal(false);
 	const [packBrowserOpen, setPackBrowserOpen] = createSignal(false);
 
-	/**
-	 * The packs this editing session has added on top of the ones the project
-	 * already depends on.
-	 *
-	 * `metadata.packDependencies` is *derived* from the assets a project uses
-	 * (`derivePackDependencies`), so it answers "which packs does this project
-	 * need to open?" — not "which packs has the user put on their shelf?". The
-	 * second is a new piece of project state and a new command, which is a domain
-	 * contract change and its own task (see the LOOP-013 follow-up); until that
-	 * lands, an added pack lives for the session, which is enough for the browser
-	 * to show it and for the user to work out of it.
-	 */
+	// The packs this editing session has added on top of the project's own
+	// derived dependencies; see `model.addedPackIds` for why they live for the
+	// session only.
 	const [sessionPackIds, setSessionPackIds] = createSignal<readonly string[]>(
 		[],
 	);
-	const addedPackIds = createMemo<readonly string[]>(() => {
-		const fromProject = (project()?.metadata.packDependencies ?? []).map(
-			(dependency) => dependency.packId,
-		);
-		return [...new Set([...fromProject, ...sessionPackIds()])];
-	});
+	const addedPackIds = createMemo(() =>
+		model.addedPackIds(project(), sessionPackIds()),
+	);
 
 	// A fresh audition engine per panel mount, built off the shared runtime the
 	// first time each opening browses. `LibraryBrowser`'s `useLibraryBrowser`
@@ -131,34 +119,14 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		);
 	};
 
-	const playheadLabel = createMemo(() => {
-		const bbs = formatBarsBeatsSixteenths(audio.positionTicks());
-		// Show a 1-based bar:beat for a musician, dropping the sixteenth fraction.
-		const [bars, beats] = bbs.split(":");
-		return `${Number(bars) + 1}.${Number(beats) + 1}`;
-	});
+	const playheadLabel = createMemo(() =>
+		model.playheadLabel(audio.positionTicks()),
+	);
 
-	const track = createMemo(() => project()?.song.tracks[0] ?? null);
-	// The first drum-machine track, if any, gets its instrument panel. The
-	// `FND-009` starter is sampler-only; this surfaces the `LOOP-005` drum
-	// machine wherever a project has one (e.g. the drum-machine fixture).
-	const drumTrack = createMemo(
-		() =>
-			project()?.song.tracks.find(
-				(candidate) => candidate.instrument?.kind === "drumMachine",
-			) ?? null,
-	);
-	const sampleAssets = createMemo(() =>
-		(project()?.song.assets ?? []).filter((asset) => asset.kind === "sample"),
-	);
-	const clip = createMemo(() => {
-		const currentProject = project();
-		const currentTrack = track();
-		if (!currentProject || !currentTrack) return null;
-		return (
-			currentProject.clips.find((c) => c.trackId === currentTrack.id) ?? null
-		);
-	});
+	const track = createMemo(() => model.editedTrack(project()));
+	const drumTrack = createMemo(() => model.drumTrack(project()));
+	const sampleAssets = createMemo(() => model.sampleAssets(project()));
+	const clip = createMemo(() => model.editedClip(project()));
 
 	// The step editor's live playback-step indicator (CLP-02): which 16th step of
 	// the edited clip the playhead is currently passing, wrapped within the clip's
@@ -180,30 +148,9 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		setSelectedNoteIds([]);
 	}
 
-	// Every tempo-labelled loop clip in the project, paired with its resolved
-	// asset (or null when the asset is missing) — LOOP-006 renders one loop-info
-	// panel per loop so a user can tell a tempo-following loop from a pitched
-	// one-shot and read the alpha's stretch behaviour honestly.
-	const loopClips = createMemo(() => {
-		const currentProject = project();
-		if (!currentProject) return [];
-		return currentProject.clips.flatMap((c) => {
-			if (c.content.kind !== "audioLoop") return [];
-			const assetId = c.content.assetId;
-			const asset =
-				currentProject.song.assets.find((a) => a.id === assetId) ?? null;
-			return [{ clip: c, asset }];
-		});
-	});
-	// The instrument of the slice's first track, and the audition note it plays.
-	const instrument = createMemo(() => track()?.instrument ?? null);
-	// A synth track holding a note clip gets the CLP-03 piano roll instead of the
-	// FND-009 step grid: pitched notes want two dimensions (pitch x time), which
-	// the 16-step grid cannot show.
-	const showPianoRoll = createMemo(() => {
-		const c = clip();
-		return instrument()?.kind === "synth" && c?.content.kind === "notes";
-	});
+	const loopClips = createMemo(() => model.loopClips(project()));
+	const instrument = createMemo(() => model.editedInstrument(project()));
+	const showPianoRoll = createMemo(() => model.showPianoRoll(project()));
 
 	const { shortcuts, editorContexts, keyHint } = useEditorShortcuts({
 		audio,
@@ -217,14 +164,9 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		packBrowserOpen,
 	});
 
-	// The track id, only when it carries an instrument this slice renders a panel
-	// for (sampler or synth). The drum machine's panel lands with LOOP-005.
-	const instrumentPanelTrackId = createMemo(() => {
-		const kind = instrument()?.kind;
-		return kind === "sampler" || kind === "synth"
-			? (track()?.id ?? null)
-			: null;
-	});
+	const instrumentPanelTrackId = createMemo(() =>
+		model.instrumentPanelTrackId(project()),
+	);
 	const AUDITION_PITCH = 60; // Middle C
 	const AUDITION_DURATION_TICKS = TICKS_PER_QUARTER;
 	function auditionInstrument(): void {
@@ -244,27 +186,13 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		);
 	}
 
-	// Samples the sampler panel can swap to: every `sample`-kind asset the
-	// project already carries. A richer, genre-filtered browser lands with
-	// LOOP-013; here it is a straight list of the project's own samples.
-	const sampleName = createMemo(() => {
-		const current = instrument();
-		if (current?.kind !== "sampler" || !current.assetId) return null;
-		return (
-			project()?.song.assets.find((asset) => asset.id === current.assetId)
-				?.name ?? null
-		);
-	});
-	const replacementOptions = createMemo<readonly SampleChoice[]>(() =>
-		(project()?.song.assets ?? [])
-			.filter((asset) => asset.kind === "sample")
-			.map((asset) => ({ assetId: asset.id, name: asset.name })),
+	const sampleName = createMemo(() => model.sampleName(project()));
+	const replacementOptions = createMemo(() =>
+		model.replacementOptions(project()),
 	);
-
-	const packDependencyLabel = createMemo(() => {
-		const dependency = project()?.metadata.packDependencies[0];
-		return dependency ? `${dependency.packId} @ ${dependency.version}` : null;
-	});
+	const packDependencyLabel = createMemo(() =>
+		model.packDependencyLabel(project()),
+	);
 
 	const saveStatus = createMemo(() => session.state.saveStatus);
 

--- a/src/editor/StepEditor.tsx
+++ b/src/editor/StepEditor.tsx
@@ -12,7 +12,7 @@ import {
 	analytics as defaultAnalytics,
 } from "../analytics/analytics";
 import type { Gesture, GestureOptions, RawCommandInput } from "../commands";
-import { addNotes, removeNotes, updateClip, updateNote } from "../commands";
+import { removeNotes, updateClip, updateNote } from "../commands";
 import type {
 	Clip,
 	Instrument,
@@ -25,8 +25,6 @@ import { NOTE_VELOCITY } from "../domain/parameters";
 import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
 import {
 	barCount,
-	cellKey,
-	eventCountBucket,
 	isBarStart,
 	isBeatStart,
 	lanesFor,
@@ -37,6 +35,7 @@ import {
 	stepCount,
 	stepStartTicks,
 } from "./stepEditorModel";
+import { createStroke } from "./stepStroke";
 import "./StepEditor.css";
 
 /**
@@ -65,17 +64,6 @@ export interface StepEditorProps {
 	readonly setSelectedIds?: (next: readonly EventId[]) => void;
 	/** Defaults to the application singleton; injectable for tests. */
 	readonly analytics?: Analytics;
-}
-
-type PaintMode = "add" | "erase";
-
-interface StrokeState {
-	readonly gesture: Gesture;
-	readonly mode: PaintMode;
-	/** (lane, step) cells already visited this stroke, so a drag never re-fires. */
-	readonly visited: Set<string>;
-	/** How many cells this stroke actually changed, for `event_count_bucket`. */
-	changed: number;
 }
 
 /**
@@ -140,10 +128,6 @@ export default function StepEditor(props: StepEditorProps): JSX.Element {
 		);
 	});
 
-	// The active paint/erase stroke, if a pointer is down. Held outside Solid's
-	// reactive graph: it is imperative gesture bookkeeping, not rendered state.
-	let stroke: StrokeState | null = null;
-
 	function noteForCell(lane: StepLane, step: number): NoteEvent | undefined {
 		return noteAt(props.clip, lane, step);
 	}
@@ -159,62 +143,21 @@ export default function StepEditor(props: StepEditorProps): JSX.Element {
 		};
 	}
 
-	/** Applies the stroke's mode to one cell, once. Records what it changed. */
-	function paintCell(lane: StepLane, step: number): void {
-		if (!stroke) return;
-		const key = cellKey(lane, step);
-		if (stroke.visited.has(key)) return;
-		stroke.visited.add(key);
-
-		const existing = noteForCell(lane, step);
-		if (stroke.mode === "add") {
-			if (existing) return; // Already on; nothing to add.
-			const note = newNote(lane, step);
-			stroke.gesture.apply(addNotes(props.clip.id, [note]));
-			stroke.changed += 1;
-			// A freshly painted note becomes the selection, so its velocity is
-			// immediately editable.
-			selectOnly(note.id);
-		} else {
-			if (!existing) return; // Already off; nothing to erase.
-			stroke.gesture.apply(removeNotes(props.clip.id, [existing.id]));
-			stroke.changed += 1;
-			deselect(existing.id);
-		}
-	}
-
-	function beginStroke(lane: StepLane, step: number): void {
-		if (stroke) return;
-		const gesture = props.beginGesture();
-		if (!gesture) return;
-		const existing = noteForCell(lane, step);
-		const mode: PaintMode = existing ? "erase" : "add";
-		stroke = { gesture, mode, visited: new Set(), changed: 0 };
-		paintCell(lane, step);
-	}
-
-	function endStroke(): void {
-		if (!stroke) return;
-		const active = stroke;
-		stroke = null;
-		if (active.changed === 0) {
-			active.gesture.cancel();
-			return;
-		}
-		const summary =
-			active.mode === "add"
-				? `Paint ${active.changed} step${active.changed === 1 ? "" : "s"}`
-				: `Erase ${active.changed} step${active.changed === 1 ? "" : "s"}`;
-		active.gesture.commit(summary);
-
-		// Analytics fires once per completed stroke, not per step (PRD OPS-02):
-		// the `event_count_bucket` counts the steps this stroke changed.
-		analytics().log("clip_edited", {
-			editor: "step",
-			event_count_bucket: eventCountBucket(active.changed),
-		});
-		analytics().logFeatureFirstUse("step_editor");
-	}
+	// The active paint/erase stroke, if a pointer is down. Held outside Solid's
+	// reactive graph: it is imperative gesture bookkeeping, not rendered state.
+	// The machine itself lives in `stepStroke.ts`; this component supplies the
+	// seam it reads the clip, the gesture kernel, and the selection through.
+	const stroke = createStroke({
+		get clipId() {
+			return props.clip.id;
+		},
+		beginGesture: (options) => props.beginGesture(options),
+		noteAt: noteForCell,
+		newNote,
+		analytics,
+		onNoteAdded: (id) => selectOnly(id),
+		onNoteRemoved: (id) => deselect(id),
+	});
 
 	// --- Pointer handling ---------------------------------------------------
 	//
@@ -239,12 +182,12 @@ export default function StepEditor(props: StepEditorProps): JSX.Element {
 			return;
 		}
 		event.preventDefault();
-		batch(() => beginStroke(lane, step));
+		batch(() => stroke.begin(lane, step));
 	}
 
 	function onCellPointerEnter(lane: StepLane, step: number): void {
-		if (!stroke) return;
-		batch(() => paintCell(lane, step));
+		if (!stroke.active) return;
+		batch(() => stroke.paint(lane, step));
 	}
 
 	function velocityFor(note: NoteEvent): number {
@@ -282,8 +225,8 @@ export default function StepEditor(props: StepEditorProps): JSX.Element {
 			aria-label="Step editor"
 			// Ending or cancelling a stroke anywhere the pointer is released keeps a
 			// drag that leaves the grid from committing a half-open gesture.
-			onPointerUp={() => endStroke()}
-			onPointerLeave={() => endStroke()}
+			onPointerUp={() => stroke.end()}
+			onPointerLeave={() => stroke.end()}
 		>
 			<div class="step-editor-toolbar">
 				<label class="step-editor-length">

--- a/src/editor/editorViewModel.test.ts
+++ b/src/editor/editorViewModel.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+import {
+	createDenseStepFixtureProject,
+	createDrumMachineFixtureProject,
+	createPianoRollFixtureProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { TICKS_PER_BAR, TICKS_PER_QUARTER } from "../domain/time";
+import {
+	addedPackIds,
+	drumTrack,
+	editedClip,
+	editedInstrument,
+	editedTrack,
+	instrumentPanelTrackId,
+	loopClips,
+	packDependencyLabel,
+	playheadLabel,
+	replacementOptions,
+	sampleAssets,
+	sampleName,
+	showPianoRoll,
+} from "./editorViewModel";
+
+/**
+ * `editorViewModel` is the pure half of `EditorView`: every derivation the
+ * editor's memos wrap. These exercise them directly against the reference
+ * fixtures — no rendering, no Solid — including the null-project path each one
+ * has to answer while a project is still loading.
+ */
+
+describe("addedPackIds", () => {
+	it("unions the project's derived dependencies with the session's additions", () => {
+		const project = createSliceFixtureProject();
+		const projectPackId = project.metadata.packDependencies[0].packId;
+
+		expect(addedPackIds(project, [])).toEqual([projectPackId]);
+		expect(addedPackIds(project, ["pak_session"])).toEqual([
+			projectPackId,
+			"pak_session",
+		]);
+	});
+
+	it("de-duplicates a session addition the project already depends on", () => {
+		const project = createSliceFixtureProject();
+		const projectPackId = project.metadata.packDependencies[0].packId;
+		expect(addedPackIds(project, [projectPackId])).toEqual([projectPackId]);
+	});
+
+	it("returns only the session's packs with no project open", () => {
+		expect(addedPackIds(null, [])).toEqual([]);
+		expect(addedPackIds(null, ["pak_session"])).toEqual(["pak_session"]);
+	});
+});
+
+describe("playheadLabel", () => {
+	it("shows a 1-based bar.beat, dropping the sixteenth fraction", () => {
+		// Tick 0 is the very start: bar 1, beat 1.
+		expect(playheadLabel(0)).toBe("1.1");
+		// One quarter in is still bar 1, but beat 2.
+		expect(playheadLabel(TICKS_PER_QUARTER)).toBe("1.2");
+		expect(playheadLabel(TICKS_PER_QUARTER * 3)).toBe("1.4");
+		// A whole bar in rolls over to bar 2, beat 1.
+		expect(playheadLabel(TICKS_PER_BAR)).toBe("2.1");
+		expect(playheadLabel(TICKS_PER_BAR * 4 + TICKS_PER_QUARTER * 2)).toBe(
+			"5.3",
+		);
+	});
+
+	it("ignores a sub-beat offset rather than rounding it up", () => {
+		expect(playheadLabel(TICKS_PER_QUARTER + 1)).toBe("1.2");
+	});
+});
+
+describe("editedTrack", () => {
+	it("is the project's first track", () => {
+		const project = createSliceFixtureProject();
+		expect(editedTrack(project)?.id).toBe(project.song.tracks[0].id);
+		expect(editedTrack(project)?.name).toBe("BD");
+	});
+
+	it("is null with no project open", () => {
+		expect(editedTrack(null)).toBeNull();
+	});
+});
+
+describe("drumTrack", () => {
+	it("finds the first drum-machine track", () => {
+		const project = createDrumMachineFixtureProject();
+		const found = drumTrack(project);
+		expect(found?.instrument?.kind).toBe("drumMachine");
+		expect(found?.name).toBe("Drums");
+	});
+
+	it("is null for a sampler-only project and with no project open", () => {
+		expect(drumTrack(createSliceFixtureProject())).toBeNull();
+		expect(drumTrack(null)).toBeNull();
+	});
+});
+
+describe("sampleAssets", () => {
+	it("keeps only `sample`-kind assets, dropping loops", () => {
+		const project = createDrumMachineFixtureProject();
+		// The drum fixture carries two one-shots plus one `loop`-kind asset.
+		const assets = sampleAssets(project);
+		expect(assets.map((asset) => asset.name)).toEqual([
+			"909 Bass Drum",
+			"909 Clap",
+		]);
+		expect(assets.every((asset) => asset.kind === "sample")).toBe(true);
+	});
+
+	it("is empty with no project open", () => {
+		expect(sampleAssets(null)).toEqual([]);
+	});
+});
+
+describe("editedClip", () => {
+	it("is the clip on the edited track", () => {
+		const project = createSliceFixtureProject();
+		const clip = editedClip(project);
+		expect(clip?.id).toBe(project.clips[0].id);
+		expect(clip?.trackId).toBe(project.song.tracks[0].id);
+	});
+
+	it("picks the drum track's clip, not the audio track's loop", () => {
+		const project = createDrumMachineFixtureProject();
+		const clip = editedClip(project);
+		expect(clip?.content.kind).toBe("notes");
+		expect(clip?.trackId).toBe(project.song.tracks[0].id);
+	});
+
+	it("is null with no project open", () => {
+		expect(editedClip(null)).toBeNull();
+	});
+});
+
+describe("editedInstrument", () => {
+	it("is the first track's instrument", () => {
+		expect(editedInstrument(createSliceFixtureProject())?.kind).toBe("sampler");
+		expect(editedInstrument(createDrumMachineFixtureProject())?.kind).toBe(
+			"drumMachine",
+		);
+		expect(editedInstrument(createPianoRollFixtureProject())?.kind).toBe(
+			"synth",
+		);
+	});
+
+	it("is null with no project open", () => {
+		expect(editedInstrument(null)).toBeNull();
+	});
+});
+
+describe("loopClips", () => {
+	it("pairs each audio-loop clip with its resolved asset", () => {
+		const project = createDrumMachineFixtureProject();
+		const entries = loopClips(project);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].clip.content.kind).toBe("audioLoop");
+		expect(entries[0].asset?.name).toBe("Break loop");
+		expect(entries[0].asset?.kind).toBe("loop");
+	});
+
+	it("reports a null asset when the loop's asset is missing", () => {
+		const project = createDrumMachineFixtureProject();
+		const withoutAssets = {
+			...project,
+			song: { ...project.song, assets: [] },
+		};
+		expect(loopClips(withoutAssets)[0].asset).toBeNull();
+	});
+
+	it("is empty for a project with no loops, and with no project open", () => {
+		expect(loopClips(createSliceFixtureProject())).toEqual([]);
+		expect(loopClips(null)).toEqual([]);
+	});
+});
+
+describe("sampleName", () => {
+	it("names the sample the edited sampler is loaded with", () => {
+		expect(sampleName(createSliceFixtureProject())).toBe("909 Bass Drum");
+	});
+
+	it("is null when the edited instrument is not a sampler", () => {
+		expect(sampleName(createDrumMachineFixtureProject())).toBeNull();
+		expect(sampleName(createPianoRollFixtureProject())).toBeNull();
+		expect(sampleName(null)).toBeNull();
+	});
+});
+
+describe("replacementOptions", () => {
+	it("offers every `sample`-kind asset as an id/name choice", () => {
+		const project = createDenseStepFixtureProject();
+		expect(replacementOptions(project).map((choice) => choice.name)).toEqual([
+			"909 Bass Drum",
+			"909 Snare",
+			"909 Closed Hat",
+		]);
+		expect(replacementOptions(project)[0].assetId).toBe(
+			project.song.assets[0].id,
+		);
+	});
+
+	it("excludes loop assets, matching sampleAssets", () => {
+		const project = createDrumMachineFixtureProject();
+		expect(replacementOptions(project)).toHaveLength(
+			sampleAssets(project).length,
+		);
+	});
+
+	it("is empty with no project open", () => {
+		expect(replacementOptions(null)).toEqual([]);
+	});
+});
+
+describe("packDependencyLabel", () => {
+	it("labels the project's first pack dependency as `id @ version`", () => {
+		const project = createSliceFixtureProject();
+		const dependency = project.metadata.packDependencies[0];
+		expect(packDependencyLabel(project)).toBe(
+			`${dependency.packId} @ ${dependency.version}`,
+		);
+	});
+
+	it("is null for a project with no pack dependency, and with none open", () => {
+		// The piano-roll fixture is the synth-only, pack-free fixture.
+		expect(createPianoRollFixtureProject().metadata.packDependencies).toEqual(
+			[],
+		);
+		expect(packDependencyLabel(createPianoRollFixtureProject())).toBeNull();
+		expect(packDependencyLabel(null)).toBeNull();
+	});
+});
+
+describe("showPianoRoll", () => {
+	it("is true for a synth track holding a note clip", () => {
+		expect(showPianoRoll(createPianoRollFixtureProject())).toBe(true);
+	});
+
+	it("is false for a sampler or drum-machine note clip, which get the step grid", () => {
+		expect(showPianoRoll(createSliceFixtureProject())).toBe(false);
+		expect(showPianoRoll(createDrumMachineFixtureProject())).toBe(false);
+	});
+
+	it("is false for a synth track with no clip", () => {
+		const project = createPianoRollFixtureProject();
+		expect(showPianoRoll({ ...project, clips: [] })).toBe(false);
+	});
+
+	it("is false with no project open", () => {
+		expect(showPianoRoll(null)).toBe(false);
+	});
+});
+
+describe("instrumentPanelTrackId", () => {
+	it("names the track for a sampler or a synth", () => {
+		const sampler = createSliceFixtureProject();
+		expect(instrumentPanelTrackId(sampler)).toBe(sampler.song.tracks[0].id);
+		const synth = createPianoRollFixtureProject();
+		expect(instrumentPanelTrackId(synth)).toBe(synth.song.tracks[0].id);
+	});
+
+	it("is null for a drum machine, whose panel is DrumMachinePanel", () => {
+		expect(
+			instrumentPanelTrackId(createDrumMachineFixtureProject()),
+		).toBeNull();
+	});
+
+	it("is null with no project open", () => {
+		expect(instrumentPanelTrackId(null)).toBeNull();
+	});
+});

--- a/src/editor/editorViewModel.ts
+++ b/src/editor/editorViewModel.ts
@@ -1,0 +1,172 @@
+import type {
+	Asset,
+	Clip,
+	Instrument,
+	Project,
+	Track,
+} from "../domain/entities";
+import type { TrackId } from "../domain/ids";
+import { formatBarsBeatsSixteenths } from "../domain/time";
+import type { SampleChoice } from "../instrument/SamplerPanel";
+
+/**
+ * Pure, framework-free derivations behind `EditorView`.
+ *
+ * `EditorView` is a composition root: it owns the session, the audio wiring,
+ * and the layout, and every one of these is a plain function of the open
+ * `Project` (plus, where noted, one piece of session or transport state). They
+ * live here rather than as inline `createMemo` bodies so each can be unit
+ * tested without rendering the editor; the component keeps a one-line memo
+ * wrapper around each so reactivity is unchanged.
+ *
+ * Nothing here mutates a project — the operations that do (`applyTempo`,
+ * `auditionInstrument`, `deleteSelection`) need the session's `dispatch` and
+ * the audio graph, so they stay in the component.
+ */
+
+/** One tempo-labelled loop clip paired with the asset it resolves to. */
+export interface LoopClipEntry {
+	readonly clip: Clip;
+	readonly asset: Asset | null;
+}
+
+/**
+ * The packs this editing session has added on top of the ones the project
+ * already depends on.
+ *
+ * `metadata.packDependencies` is *derived* from the assets a project uses
+ * (`derivePackDependencies`), so it answers "which packs does this project
+ * need to open?" — not "which packs has the user put on their shelf?". The
+ * second is a new piece of project state and a new command, which is a domain
+ * contract change and its own task (see the LOOP-013 follow-up); until that
+ * lands, an added pack lives for the session, which is enough for the browser
+ * to show it and for the user to work out of it.
+ */
+export function addedPackIds(
+	project: Project | null,
+	sessionPackIds: readonly string[],
+): readonly string[] {
+	const fromProject = (project?.metadata.packDependencies ?? []).map(
+		(dependency) => dependency.packId,
+	);
+	return [...new Set([...fromProject, ...sessionPackIds])];
+}
+
+/**
+ * The transport position as a musician reads it. Shows a 1-based bar:beat,
+ * dropping the sixteenth fraction.
+ */
+export function playheadLabel(positionTicks: number): string {
+	const bbs = formatBarsBeatsSixteenths(positionTicks);
+	const [bars, beats] = bbs.split(":");
+	return `${Number(bars) + 1}.${Number(beats) + 1}`;
+}
+
+/** The track this slice edits: the project's first. */
+export function editedTrack(project: Project | null): Track | null {
+	return project?.song.tracks[0] ?? null;
+}
+
+/**
+ * The first drum-machine track, if any, gets its instrument panel. The
+ * `FND-009` starter is sampler-only; this surfaces the `LOOP-005` drum
+ * machine wherever a project has one (e.g. the drum-machine fixture).
+ */
+export function drumTrack(project: Project | null): Track | null {
+	return (
+		project?.song.tracks.find(
+			(candidate) => candidate.instrument?.kind === "drumMachine",
+		) ?? null
+	);
+}
+
+/** Every `sample`-kind asset the project carries. */
+export function sampleAssets(project: Project | null): readonly Asset[] {
+	return (project?.song.assets ?? []).filter(
+		(asset) => asset.kind === "sample",
+	);
+}
+
+/** The clip on the edited track, if it has one. */
+export function editedClip(project: Project | null): Clip | null {
+	const track = editedTrack(project);
+	if (!project || !track) return null;
+	return project.clips.find((c) => c.trackId === track.id) ?? null;
+}
+
+/** The instrument of the slice's first track, and the audition note it plays. */
+export function editedInstrument(project: Project | null): Instrument | null {
+	return editedTrack(project)?.instrument ?? null;
+}
+
+/**
+ * Every tempo-labelled loop clip in the project, paired with its resolved
+ * asset (or null when the asset is missing) — LOOP-006 renders one loop-info
+ * panel per loop so a user can tell a tempo-following loop from a pitched
+ * one-shot and read the alpha's stretch behaviour honestly.
+ */
+export function loopClips(project: Project | null): readonly LoopClipEntry[] {
+	if (!project) return [];
+	return project.clips.flatMap((c) => {
+		if (c.content.kind !== "audioLoop") return [];
+		const assetId = c.content.assetId;
+		const asset = project.song.assets.find((a) => a.id === assetId) ?? null;
+		return [{ clip: c, asset }];
+	});
+}
+
+/** The name of the sample the edited track's sampler is loaded with. */
+export function sampleName(project: Project | null): string | null {
+	const current = editedInstrument(project);
+	if (current?.kind !== "sampler" || !current.assetId) return null;
+	return (
+		project?.song.assets.find((asset) => asset.id === current.assetId)?.name ??
+		null
+	);
+}
+
+/**
+ * Samples the sampler panel can swap to: every `sample`-kind asset the
+ * project already carries. A richer, genre-filtered browser lands with
+ * LOOP-013; here it is a straight list of the project's own samples.
+ */
+export function replacementOptions(
+	project: Project | null,
+): readonly SampleChoice[] {
+	return sampleAssets(project).map((asset) => ({
+		assetId: asset.id,
+		name: asset.name,
+	}));
+}
+
+/** The project's first pack dependency, labelled for display. */
+export function packDependencyLabel(project: Project | null): string | null {
+	const dependency = project?.metadata.packDependencies[0];
+	return dependency ? `${dependency.packId} @ ${dependency.version}` : null;
+}
+
+/**
+ * A synth track holding a note clip gets the CLP-03 piano roll instead of the
+ * FND-009 step grid: pitched notes want two dimensions (pitch x time), which
+ * the 16-step grid cannot show.
+ */
+export function showPianoRoll(project: Project | null): boolean {
+	const clip = editedClip(project);
+	return (
+		editedInstrument(project)?.kind === "synth" &&
+		clip?.content.kind === "notes"
+	);
+}
+
+/**
+ * The track id, only when it carries an instrument this slice renders a panel
+ * for (sampler or synth). The drum machine's panel lands with LOOP-005.
+ */
+export function instrumentPanelTrackId(
+	project: Project | null,
+): TrackId | null {
+	const kind = editedInstrument(project)?.kind;
+	return kind === "sampler" || kind === "synth"
+		? (editedTrack(project)?.id ?? null)
+		: null;
+}

--- a/src/editor/stepStroke.test.ts
+++ b/src/editor/stepStroke.test.ts
@@ -1,0 +1,424 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import { CommandHistory } from "../commands";
+import type { NoteEvent, Project } from "../domain/entities";
+import {
+	createDrumMachineFixtureProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { createSeededIdFactory } from "../domain/ids";
+import { NOTE_VELOCITY } from "../domain/parameters";
+import { TICKS_PER_SIXTEENTH } from "../domain/time";
+import { memoryStorage } from "../testing/storage";
+import {
+	eventCountBucket,
+	lanesFor,
+	noteAt,
+	type StepLane,
+	stepStartTicks,
+} from "./stepEditorModel";
+import { createStroke, strokeSummary } from "./stepStroke";
+
+/**
+ * The CLP-02 stroke machine, driven directly over a real `CommandHistory` —
+ * no DOM, no Solid. The seam supplies a deterministic note-ID factory, so the
+ * notes a stroke paints are reproducible between runs.
+ */
+function harness(project: Project) {
+	const history = new CommandHistory(project);
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+	analytics.setAccountType("anonymous");
+
+	const clipId = project.clips[0].id;
+	const track = project.song.tracks.find(
+		(candidate) => candidate.id === project.clips[0].trackId,
+	);
+	const lanes = lanesFor(track?.instrument ?? null);
+
+	// A seeded factory, so two runs mint the same note ids.
+	const ids = createSeededIdFactory("stroke-test");
+	const added: NoteEvent["id"][] = [];
+	const removed: NoteEvent["id"][] = [];
+
+	const currentClip = () => {
+		const clip = history.project.clips.find(
+			(candidate) => candidate.id === clipId,
+		);
+		if (!clip) throw new Error("clip vanished");
+		return clip;
+	};
+
+	const stroke = createStroke({
+		clipId,
+		beginGesture: (options) => history.beginGesture(options),
+		noteAt: (lane, step) => noteAt(currentClip(), lane, step),
+		newNote: (lane: StepLane, step: number): NoteEvent => ({
+			id: ids("event"),
+			trigger: lane.trigger,
+			startTicks: stepStartTicks(step) as NoteEvent["startTicks"],
+			durationTicks: TICKS_PER_SIXTEENTH as NoteEvent["durationTicks"],
+			velocity: NOTE_VELOCITY.defaultValue as NoteEvent["velocity"],
+			probability: null,
+		}),
+		analytics: () => analytics,
+		onNoteAdded: (id) => added.push(id),
+		onNoteRemoved: (id) => removed.push(id),
+	});
+
+	return {
+		stroke,
+		history,
+		transport,
+		analytics,
+		lanes,
+		currentClip,
+		added,
+		removed,
+		clipEdited: () =>
+			transport.events.filter((event) => event.name === "clip_edited"),
+		noteCount: () => {
+			const content = currentClip().content;
+			return content.kind === "notes" ? content.events.length : 0;
+		},
+		isOn: (lane: StepLane, step: number) =>
+			noteAt(currentClip(), lane, step) !== undefined,
+	};
+}
+
+describe("createStroke mode selection", () => {
+	it("starting on an empty cell paints, and adds a note", () => {
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+		// The slice clip has notes on steps 0/4/8/12; step 1 is empty.
+		expect(h.isOn(lane, 1)).toBe(false);
+
+		h.stroke.begin(lane, 1);
+		h.stroke.end();
+
+		expect(h.isOn(lane, 1)).toBe(true);
+		expect(h.history.entries).toHaveLength(1);
+		expect(h.history.entries[0].summary).toBe("Paint 1 step");
+	});
+
+	it("starting on an occupied cell erases, and removes that note", () => {
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+		expect(h.isOn(lane, 0)).toBe(true);
+
+		h.stroke.begin(lane, 0);
+		h.stroke.end();
+
+		expect(h.isOn(lane, 0)).toBe(false);
+		expect(h.history.entries[0].summary).toBe("Erase 1 step");
+	});
+
+	it("keeps the starting cell's mode for the rest of the stroke", () => {
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+		// Begin on an occupied step: the stroke is an erase, so dragging over an
+		// already-empty step must not paint it in.
+		h.stroke.begin(lane, 0);
+		h.stroke.paint(lane, 1); // empty — nothing to erase
+		h.stroke.paint(lane, 4); // occupied — erased
+		h.stroke.end();
+
+		expect(h.isOn(lane, 0)).toBe(false);
+		expect(h.isOn(lane, 1)).toBe(false); // still empty, never painted
+		expect(h.isOn(lane, 4)).toBe(false);
+		expect(h.history.entries[0].summary).toBe("Erase 2 steps");
+	});
+
+	it("reports the active stroke, and a begin while one is open is ignored", () => {
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+		expect(h.stroke.active).toBe(false);
+
+		h.stroke.begin(lane, 1);
+		expect(h.stroke.active).toBe(true);
+		// A second begin must not open a second gesture or flip the mode.
+		h.stroke.begin(lane, 0);
+		h.stroke.end();
+
+		expect(h.stroke.active).toBe(false);
+		// Step 0 stayed on: the second `begin` was a no-op, not an erase.
+		expect(h.isOn(lane, 0)).toBe(true);
+		expect(h.history.entries).toHaveLength(1);
+	});
+
+	it("paints outside an open stroke are ignored", () => {
+		const h = harness(createSliceFixtureProject());
+		const before = h.noteCount();
+		h.stroke.paint(h.lanes[0], 1);
+		expect(h.noteCount()).toBe(before);
+		expect(h.history.canUndo).toBe(false);
+	});
+});
+
+describe("createStroke drag de-duplication", () => {
+	it("visits a repeated cell only once within a stroke", () => {
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+
+		h.stroke.begin(lane, 1);
+		// A drag that wobbles back and forth re-enters the same cells.
+		h.stroke.paint(lane, 2);
+		h.stroke.paint(lane, 1);
+		h.stroke.paint(lane, 2);
+		h.stroke.paint(lane, 3);
+		h.stroke.paint(lane, 2);
+		h.stroke.end();
+
+		// Three distinct steps painted, counted once each.
+		expect(h.history.entries[0].summary).toBe("Paint 3 steps");
+		expect(h.added).toHaveLength(3);
+		expect(h.clipEdited()[0].params.event_count_bucket).toBe("1_4");
+	});
+
+	it("de-duplicates per (lane, step), so the same step on two lanes both paint", () => {
+		const h = harness(createDrumMachineFixtureProject());
+		const [bd, cp] = h.lanes;
+
+		h.stroke.begin(bd, 1);
+		h.stroke.paint(cp, 1);
+		h.stroke.paint(bd, 1); // repeat — ignored
+		h.stroke.end();
+
+		expect(h.isOn(bd, 1)).toBe(true);
+		expect(h.isOn(cp, 1)).toBe(true);
+		expect(h.history.entries[0].summary).toBe("Paint 2 steps");
+	});
+
+	it("starts a fresh visited-set on the next stroke", () => {
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+
+		h.stroke.begin(lane, 1);
+		h.stroke.end();
+		// The same cell again — now occupied, so this stroke erases it.
+		h.stroke.begin(lane, 1);
+		h.stroke.end();
+
+		expect(h.isOn(lane, 1)).toBe(false);
+		expect(h.history.entries).toHaveLength(2);
+		expect(h.history.entries[1].summary).toBe("Erase 1 step");
+	});
+});
+
+describe("createStroke commit and cancel", () => {
+	it("cancels a stroke that changed nothing: no entry, no revision, no analytics", () => {
+		// A stroke that begins on an occupied cell erases it — so to get a stroke
+		// that changes nothing, begin an erase and then have the cell report as
+		// already empty. Driving `noteAt` off the *committed* project would make
+		// that impossible, so this exercises the machine's own guard: an erase
+		// whose first cell is reported occupied, but which is then told every
+		// cell (including that one) is empty by the time it paints.
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+		const entriesBefore = h.history.entries.length;
+		const revisionBefore = h.history.project.metadata.revision;
+
+		// `paint()` outside an open stroke is a no-op, and `end()` with nothing
+		// open leaves the gesture kernel untouched.
+		h.stroke.paint(lane, 1);
+		h.stroke.end();
+
+		expect(h.history.entries).toHaveLength(entriesBefore);
+		expect(h.history.project.metadata.revision).toBe(revisionBefore);
+		expect(h.clipEdited()).toHaveLength(0);
+	});
+
+	it("an erase stroke that erases nothing cancels its gesture", () => {
+		// A hand-built seam whose cells are all empty: `begin` is told the first
+		// cell is occupied (so the stroke picks "erase"), but `noteAt` then
+		// reports nothing anywhere, so the stroke changes zero cells.
+		const project = createSliceFixtureProject();
+		const history = new CommandHistory(project);
+		const transport = createRecordingTransport();
+		const consent = new ConsentStore(memoryStorage());
+		const analytics = new Analytics({
+			transport,
+			consent,
+			storage: memoryStorage(),
+		});
+		analytics.setAccountType("anonymous");
+		const lane = lanesFor(project.song.tracks[0].instrument)[0];
+
+		let cancelled = 0;
+		let committed = 0;
+		const stroke = createStroke({
+			clipId: project.clips[0].id,
+			beginGesture: () => {
+				const gesture = history.beginGesture();
+				if (!gesture) return undefined;
+				return {
+					get active() {
+						return gesture.active;
+					},
+					apply: (commands) => gesture.apply(commands),
+					commit: (summary) => {
+						committed += 1;
+						return gesture.commit(summary);
+					},
+					cancel: () => {
+						cancelled += 1;
+						gesture.cancel();
+					},
+				};
+			},
+			// The first cell reads occupied so `begin` chooses "erase"; every read
+			// after that is empty, so nothing is ever removed.
+			noteAt: (() => {
+				let first = true;
+				return () => {
+					if (first) {
+						first = false;
+						return noteAt(project.clips[0], lane, 0);
+					}
+					return undefined;
+				};
+			})(),
+			newNote: () => {
+				throw new Error("an erase stroke must never mint a note");
+			},
+			analytics: () => analytics,
+		});
+
+		const revisionBefore = history.project.metadata.revision;
+		stroke.begin(lane, 0);
+		stroke.paint(lane, 1);
+		stroke.end();
+
+		expect(cancelled).toBe(1);
+		expect(committed).toBe(0);
+		expect(history.entries).toHaveLength(0);
+		expect(history.canUndo).toBe(false);
+		expect(history.project.metadata.revision).toBe(revisionBefore);
+		// No `clip_edited` and no `feature_first_use` for a stroke that did nothing.
+		expect(transport.events).toHaveLength(0);
+	});
+
+	it("commits a whole drag as one entry and one revision", () => {
+		const h = harness(createSliceFixtureProject());
+		const lane = h.lanes[0];
+		const startRevision = h.history.project.metadata.revision;
+
+		h.stroke.begin(lane, 1);
+		h.stroke.paint(lane, 2);
+		h.stroke.paint(lane, 3);
+		h.stroke.end();
+
+		expect(h.history.entries).toHaveLength(1);
+		// Three notes, one revision bump.
+		expect(h.history.project.metadata.revision).toBe(startRevision + 1);
+	});
+
+	it("summarises singular and plural step counts", () => {
+		expect(strokeSummary("add", 1)).toBe("Paint 1 step");
+		expect(strokeSummary("add", 5)).toBe("Paint 5 steps");
+		expect(strokeSummary("erase", 1)).toBe("Erase 1 step");
+		expect(strokeSummary("erase", 12)).toBe("Erase 12 steps");
+	});
+});
+
+describe("createStroke analytics", () => {
+	let h: ReturnType<typeof harness>;
+	beforeEach(() => {
+		h = harness(createSliceFixtureProject());
+	});
+
+	it("emits exactly one clip_edited per completed stroke, not per step", () => {
+		const lane = h.lanes[0];
+		h.stroke.begin(lane, 1);
+		h.stroke.paint(lane, 2);
+		h.stroke.paint(lane, 3);
+		h.stroke.end();
+
+		const edited = h.clipEdited();
+		expect(edited).toHaveLength(1);
+		expect(edited[0].params.editor).toBe("step");
+		// Three changed steps → the 1_4 bucket.
+		expect(edited[0].params.event_count_bucket).toBe("1_4");
+	});
+
+	it("buckets a larger stroke by the steps it actually changed", () => {
+		const lane = h.lanes[0];
+		// Steps 1,2,3,5,6,7 are empty in the slice clip (0/4/8/12 are on): six
+		// changed cells lands in the next bucket up, and the two occupied cells
+		// the drag crosses change nothing.
+		h.stroke.begin(lane, 1);
+		for (const step of [2, 3, 4, 5, 6, 7, 8]) h.stroke.paint(lane, step);
+		h.stroke.end();
+
+		const edited = h.clipEdited();
+		expect(edited).toHaveLength(1);
+		expect(edited[0].params.event_count_bucket).toBe("5_16");
+		// A smaller stroke buckets lower, so the count really is driving this.
+		expect(eventCountBucket(6)).toBe("5_16");
+		expect(eventCountBucket(3)).toBe("1_4");
+		expect(h.history.entries[0].summary).toBe("Paint 6 steps");
+	});
+
+	it("logs step_editor feature_first_use once across two strokes", () => {
+		const lane = h.lanes[0];
+		h.stroke.begin(lane, 1);
+		h.stroke.end();
+		h.stroke.begin(lane, 2);
+		h.stroke.end();
+
+		const firstUse = h.transport.events.filter(
+			(event) => event.name === "feature_first_use",
+		);
+		expect(firstUse).toHaveLength(1);
+		expect(firstUse[0].params.feature).toBe("step_editor");
+		// Two strokes, two clip_edited events.
+		expect(h.clipEdited()).toHaveLength(2);
+	});
+
+	it("emits nothing at all when analytics consent is denied", () => {
+		const project = createSliceFixtureProject();
+		const history = new CommandHistory(project);
+		const transport = createRecordingTransport();
+		const consent = new ConsentStore(memoryStorage());
+		consent.set({ productAnalytics: false });
+		const analytics = new Analytics({
+			transport,
+			consent,
+			storage: memoryStorage(),
+		});
+		const ids = createSeededIdFactory("stroke-denied");
+		const lane = lanesFor(project.song.tracks[0].instrument)[0];
+		const clip = () => history.project.clips[0];
+
+		const stroke = createStroke({
+			clipId: project.clips[0].id,
+			beginGesture: (options) => history.beginGesture(options),
+			noteAt: (l, step) => noteAt(clip(), l, step),
+			newNote: (l, step) => ({
+				id: ids("event"),
+				trigger: l.trigger,
+				startTicks: stepStartTicks(step) as NoteEvent["startTicks"],
+				durationTicks: TICKS_PER_SIXTEENTH as NoteEvent["durationTicks"],
+				velocity: NOTE_VELOCITY.defaultValue as NoteEvent["velocity"],
+				probability: null,
+			}),
+			analytics: () => analytics,
+		});
+
+		stroke.begin(lane, 1);
+		stroke.end();
+
+		// The edit still lands through the command layer…
+		expect(noteAt(clip(), lane, 1)).toBeDefined();
+		expect(history.entries).toHaveLength(1);
+		// …but with consent denied, nothing was sent.
+		expect(transport.events).toHaveLength(0);
+	});
+});

--- a/src/editor/stepStroke.ts
+++ b/src/editor/stepStroke.ts
@@ -1,0 +1,148 @@
+import type { Analytics } from "../analytics/analytics";
+import type { Gesture, GestureOptions } from "../commands";
+import { addNotes, removeNotes } from "../commands";
+import type { NoteEvent } from "../domain/entities";
+import type { ClipId } from "../domain/ids";
+import { cellKey, eventCountBucket, type StepLane } from "./stepEditorModel";
+
+/**
+ * The CLP-02 step editor's paint/erase stroke machine.
+ *
+ * A stroke is one continuous pointer gesture across the grid. It is imperative
+ * bookkeeping rather than rendered state, and it is deliberately *not* part of
+ * `stepEditorModel.ts`: that module is a pure function of the clip and
+ * instrument, whereas this one owns gesture lifetime, command dispatch, and
+ * analytics. The component (`StepEditor.tsx`) still owns pointer events and
+ * decides *when* a stroke begins, paints, and ends; everything that happens
+ * *inside* one lives here so it can be unit-tested without a DOM.
+ *
+ * Every project mutation still goes through the shared command layer (PRD
+ * section 9.6): each painted step applies immediately so audio stays live, but
+ * the whole stroke commits as a single history entry and revision (CLP-02
+ * "undo groups a single drag gesture").
+ */
+
+export type PaintMode = "add" | "erase";
+
+export interface StrokeState {
+	readonly gesture: Gesture;
+	readonly mode: PaintMode;
+	/** (lane, step) cells already visited this stroke, so a drag never re-fires. */
+	readonly visited: Set<string>;
+	/** How many cells this stroke actually changed, for `event_count_bucket`. */
+	changed: number;
+}
+
+/**
+ * Everything a stroke needs from its surroundings. Injected so the machine can
+ * be driven in a test with a fake gesture kernel, a deterministic note-ID
+ * factory, and a recording analytics client — no DOM and no Solid.
+ */
+export interface StrokeSeam {
+	/** The clip being painted into. */
+	readonly clipId: ClipId;
+	/** Opens a paint/erase stroke that commits as one history entry. */
+	beginGesture(options?: GestureOptions): Gesture | undefined;
+	/** The note already occupying a cell, if any — decides add vs erase. */
+	noteAt(lane: StepLane, step: number): NoteEvent | undefined;
+	/**
+	 * Mints the note a paint puts in a cell. Kept injectable so the note-ID
+	 * factory stays deterministic under test.
+	 */
+	newNote(lane: StepLane, step: number): NoteEvent;
+	/** The analytics client the completed stroke reports through. */
+	analytics(): Analytics;
+	/** A freshly painted note becomes the selection; an erased one leaves it. */
+	onNoteAdded?(id: NoteEvent["id"]): void;
+	onNoteRemoved?(id: NoteEvent["id"]): void;
+}
+
+export interface Stroke {
+	/** The stroke currently in progress, or null. */
+	readonly active: boolean;
+	/** Opens a stroke on the cell the pointer went down on. */
+	begin(lane: StepLane, step: number): void;
+	/** Applies the stroke's mode to one cell, once. */
+	paint(lane: StepLane, step: number): void;
+	/** Commits the stroke as one entry, or cancels an empty one. */
+	end(): void;
+}
+
+/** The history summary a committed stroke lands under. */
+export function strokeSummary(mode: PaintMode, changed: number): string {
+	const verb = mode === "add" ? "Paint" : "Erase";
+	return `${verb} ${changed} step${changed === 1 ? "" : "s"}`;
+}
+
+/**
+ * Builds the stroke machine over an injected seam. The returned object holds
+ * the one in-flight `StrokeState`; `begin`/`paint`/`end` are the only ways to
+ * move it.
+ */
+export function createStroke(seam: StrokeSeam): Stroke {
+	let stroke: StrokeState | null = null;
+
+	/** Applies the stroke's mode to one cell, once. Records what it changed. */
+	function paint(lane: StepLane, step: number): void {
+		if (!stroke) return;
+		const key = cellKey(lane, step);
+		if (stroke.visited.has(key)) return;
+		stroke.visited.add(key);
+
+		const existing = seam.noteAt(lane, step);
+		if (stroke.mode === "add") {
+			if (existing) return; // Already on; nothing to add.
+			const note = seam.newNote(lane, step);
+			stroke.gesture.apply(addNotes(seam.clipId, [note]));
+			stroke.changed += 1;
+			// A freshly painted note becomes the selection, so its velocity is
+			// immediately editable.
+			seam.onNoteAdded?.(note.id);
+		} else {
+			if (!existing) return; // Already off; nothing to erase.
+			stroke.gesture.apply(removeNotes(seam.clipId, [existing.id]));
+			stroke.changed += 1;
+			seam.onNoteRemoved?.(existing.id);
+		}
+	}
+
+	function begin(lane: StepLane, step: number): void {
+		if (stroke) return;
+		const gesture = seam.beginGesture();
+		if (!gesture) return;
+		// The cell the pointer went down on decides the whole stroke's mode:
+		// starting on an occupied step erases, starting on an empty one paints.
+		const existing = seam.noteAt(lane, step);
+		const mode: PaintMode = existing ? "erase" : "add";
+		stroke = { gesture, mode, visited: new Set(), changed: 0 };
+		paint(lane, step);
+	}
+
+	function end(): void {
+		if (!stroke) return;
+		const active = stroke;
+		stroke = null;
+		if (active.changed === 0) {
+			active.gesture.cancel();
+			return;
+		}
+		active.gesture.commit(strokeSummary(active.mode, active.changed));
+
+		// Analytics fires once per completed stroke, not per step (PRD OPS-02):
+		// the `event_count_bucket` counts the steps this stroke changed.
+		seam.analytics().log("clip_edited", {
+			editor: "step",
+			event_count_bucket: eventCountBucket(active.changed),
+		});
+		seam.analytics().logFeatureFirstUse("step_editor");
+	}
+
+	return {
+		get active(): boolean {
+			return stroke !== null;
+		},
+		begin,
+		paint,
+		end,
+	};
+}


### PR DESCRIPTION
Two pure refactors in `src/editor/`. **No behavior change and no visual change** — this is a structural split only.

## Refactor 1 — `EditorView.tsx` (427 → 355 lines)

`EditorView` was already a good composition root, delegating to `EditorHeader`, `ProjectLoadStates`, `ArrangementView`, `LibraryBrowser`, `LoopInfo`, `DrumMachinePanel`, `TrackEditor`, `Mixer`, and `ShortcutGuide`. That structure is untouched. What it *also* carried was ~190 lines of project-derivation selectors riding along as a second responsibility.

Those are now plain `(project: Project | null) => T` functions in the new **`src/editor/editorViewModel.ts`** (172 lines), each carrying its original doc comment: `addedPackIds`, `playheadLabel`, `editedTrack`, `drumTrack`, `sampleAssets`, `editedClip`, `editedInstrument`, `loopClips` (+ exported `LoopClipEntry`), `sampleName`, `replacementOptions`, `packDependencyLabel`, `showPianoRoll`, `instrumentPanelTrackId`.

They are deliberately **not** Solid memos — framework-free functions unit-test without rendering the editor. `EditorView` keeps a one-line `createMemo` wrapper around each, so the reactive graph is exactly as before. `applyTempo`, `auditionInstrument`, and `deleteSelection` stay in the component: they need `session.dispatch` and the audio graph, so they are not derivations.

The local memos `track`/`clip`/`instrument` were too generic to export at module level, so they export as `editedTrack`/`editedClip`/`editedInstrument` and are aliased back to their original local names in the component — the JSX is completely untouched.

## Refactor 2 — `StepEditor.tsx` (407 → 350 lines)

The inline paint-stroke state machine (`paintCell`, `beginStroke`, `endStroke`, `onCellPointerDown`/`onCellPointerEnter` internals, `newNote`, and the add/erase mode decision) moves to the new **`src/editor/stepStroke.ts`** (148 lines).

`createStroke()` takes an injected seam (`clipId`, `beginGesture`, `noteAt`, `newNote`, `analytics`, plus selection callbacks) and exposes `begin(lane, step)` / `paint(lane, step)` / `end()`. It owns `StrokeState`, the visited-set dedup, the mode decision, the `Paint N steps` / `Erase N steps` summaries, and the once-per-stroke `clip_edited` + `logFeatureFirstUse("step_editor")` analytics. The note-ID factory is injectable, so strokes are deterministically testable.

It went into a **new module rather than the existing `stepEditorModel.ts`** on purpose: that module's doc comment states the component "owns pointer state, gestures, and command dispatch", so a stroke machine there would contradict its stated contract. `stepEditorModel.ts` stays a pure function of the clip and instrument.

Per CLAUDE.md, every mutation still flows through the shared command layer: each painted step applies immediately so audio stays live, but the whole stroke commits as one gesture, one history entry, and one revision.

## UI walkthrough

**This PR has no user-visible change, so there is no walkthrough video.** It is a pure code-structure refactor — no markup, styling, copy, or interaction was altered.

How that was verified rather than assumed:

- **The rendered markup is provably identical.** Diffing both components for changed `class`, `classList`, `aria-*`, and `data-testid` attributes returns zero hits. Every JSX attribute is byte-identical; only the expressions feeding them moved modules.
- **The existing component tests are unchanged and all pass.** `EditorView.test.tsx` and `StepEditor.test.tsx` were not weakened, relaxed, or edited in any way. They assert the visible surface — accessible names like `"Notes, step 2, off"`, the piano-roll-vs-step-grid split, the sampler panel, tooltips, the playback-step `playing` class, transport controls, and save states — and all still pass.
- **Analytics is unchanged.** `clip_edited` still fires exactly once per completed stroke with the same `editor: "step"` and `event_count_bucket`, `feature_first_use` still fires once, and consent-denied still emits nothing. Existing assertions cover this; the new `stepStroke.test.ts` covers it again at the unit layer.

## Tests added

- **`src/editor/editorViewModel.test.ts`** — 33 tests over the reference fixtures (`createSliceFixtureProject`, `createDrumMachineFixtureProject`, `createDenseStepFixtureProject`, `createPianoRollFixtureProject`). Every derivation plus its null-project path, the `showPianoRoll` synth-vs-sampler split, `playheadLabel`'s 1-based bar.beat conversion (including bar rollover and sub-beat truncation), `sampleAssets`/`replacementOptions` excluding loop-kind assets, and `loopClips` reporting a null asset when the asset is missing.
- **`src/editor/stepStroke.test.ts`** — 16 tests driving the machine over a real `CommandHistory` with a seeded ID factory, no DOM. Covers add/erase mode selection and mode persistence across a drag, drag dedup across repeated cells (and per-`(lane, step)` so the same step on two lanes both paint), the empty-stroke cancel path (gesture cancelled, no history entry, no revision bump, no analytics), the singular/plural commit summaries, and exactly one `clip_edited` per stroke with the correct `event_count_bucket`.

## Evidence

- `bun run typecheck` — passes.
- `bun run test` — **146 files, 1971 tests, all passing**, including the previously-flaky `src/audio/testAudioTeardown.test.ts` (green this run).
- `bun run check` — passes, no fixes applied on the final run.
- `git status` shows exactly the six intended files. No changes to `PianoRoll.tsx`, `src/arrangement/`, `src/library/`, or `src/audio/`, which other work is touching concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)