### PR TITLE
Refactor: break LibraryBrowser/PackBrowser coupling, extract shared library UI

### DIFF
--- a/src/library/AssetRow.tsx
+++ b/src/library/AssetRow.tsx
@@ -1,0 +1,74 @@
+import { HiSolidPlay, HiSolidPlus, HiSolidStop } from "solid-icons/hi";
+import { type JSX, Show } from "solid-js";
+import { LOAD_REASON_LABELS } from "./loadReasons";
+import type { LibraryAsset } from "./manifest";
+// `.library-row`, `.library-audition` and `.library-insert` are defined in the
+// panel's stylesheet, and CSS arrives through per-component side-effect imports.
+// This row renders inside the pack browser too, which does not import that
+// sheet — so it must be imported here, by the component that owns these class
+// names, rather than relied on from whichever view happened to mount first.
+import "./LibraryBrowser.css";
+
+/** One auditionable sound. Shared by the panel tree and the pack browser. */
+export default function AssetRow(props: {
+	asset: LibraryAsset;
+	active: boolean;
+	error: string | null;
+	/** Shown in the pack browser, where a result can come from any pack. */
+	showPack?: boolean;
+	onPlay: () => void;
+	onStop: () => void;
+	onInsert?: () => void;
+}): JSX.Element {
+	return (
+		<li
+			class="library-row"
+			classList={{
+				"library-row-active": props.active,
+				"library-row-error": props.error !== null,
+			}}
+		>
+			<button
+				type="button"
+				class="library-audition"
+				aria-label={
+					props.active
+						? `Stop ${props.asset.name}`
+						: `Audition ${props.asset.name}`
+				}
+				aria-pressed={props.active}
+				onClick={() => (props.active ? props.onStop() : props.onPlay())}
+			>
+				<Show when={props.active} fallback={<HiSolidPlay size={12} />}>
+					<HiSolidStop size={12} />
+				</Show>
+			</button>
+			<div class="library-row-meta">
+				<span class="library-row-name">{props.asset.name}</span>
+				<Show when={props.showPack || props.error}>
+					<span class="library-row-tags">
+						<Show when={props.showPack}>
+							{props.asset.role} · {props.asset.packName}
+						</Show>
+						<Show when={props.error}>
+							<span class="library-row-error-text">
+								{props.showPack ? " · " : ""}
+								{LOAD_REASON_LABELS[props.error ?? ""] ?? "Could not load."}
+							</span>
+						</Show>
+					</span>
+				</Show>
+			</div>
+			<Show when={props.onInsert}>
+				<button
+					type="button"
+					class="library-insert"
+					aria-label={`Insert ${props.asset.name}`}
+					onClick={() => props.onInsert?.()}
+				>
+					<HiSolidPlus size={12} />
+				</button>
+			</Show>
+		</li>
+	);
+}

--- a/src/library/LibraryBrowser.tsx
+++ b/src/library/LibraryBrowser.tsx
@@ -2,10 +2,7 @@ import {
 	HiSolidChevronDown,
 	HiSolidChevronRight,
 	HiSolidExclamationTriangle,
-	HiSolidPlay,
-	HiSolidPlus,
 	HiSolidSquares2x2,
-	HiSolidStop,
 } from "solid-icons/hi";
 import {
 	createEffect,
@@ -19,8 +16,10 @@ import {
 } from "solid-js";
 import type { Analytics } from "../analytics/analytics";
 import TapeLoader from "../components/TapeLoader";
+import AssetRow from "./AssetRow";
 import type { PreviewEngine } from "./audition";
 import type { LibraryClient } from "./libraryClient";
+import { LOAD_REASON_LABELS } from "./loadReasons";
 import type { LibraryAsset, LibraryPackSummary } from "./manifest";
 import PackBrowser from "./PackBrowser";
 import type { LibraryTreeGroup, LibraryTreePack } from "./tree";
@@ -49,13 +48,6 @@ export interface LibraryBrowserProps {
 	 */
 	readonly onPackBrowserOpenChange?: (open: boolean) => void;
 }
-
-export const LOAD_REASON_LABELS: Record<string, string> = {
-	network: "Check your connection.",
-	not_found: "This library is unavailable.",
-	corrupt: "The library data could not be read.",
-	timeout: "The library took too long to load.",
-};
 
 /**
  * The library panel: a narrow, always-available column beside the workspace
@@ -339,69 +331,5 @@ function Chevron(props: { expanded: boolean }): JSX.Element {
 				<HiSolidChevronDown size={12} />
 			</Show>
 		</span>
-	);
-}
-
-/** One auditionable sound. Shared by the panel tree and the pack browser. */
-export function AssetRow(props: {
-	asset: LibraryAsset;
-	active: boolean;
-	error: string | null;
-	/** Shown in the pack browser, where a result can come from any pack. */
-	showPack?: boolean;
-	onPlay: () => void;
-	onStop: () => void;
-	onInsert?: () => void;
-}): JSX.Element {
-	return (
-		<li
-			class="library-row"
-			classList={{
-				"library-row-active": props.active,
-				"library-row-error": props.error !== null,
-			}}
-		>
-			<button
-				type="button"
-				class="library-audition"
-				aria-label={
-					props.active
-						? `Stop ${props.asset.name}`
-						: `Audition ${props.asset.name}`
-				}
-				aria-pressed={props.active}
-				onClick={() => (props.active ? props.onStop() : props.onPlay())}
-			>
-				<Show when={props.active} fallback={<HiSolidPlay size={12} />}>
-					<HiSolidStop size={12} />
-				</Show>
-			</button>
-			<div class="library-row-meta">
-				<span class="library-row-name">{props.asset.name}</span>
-				<Show when={props.showPack || props.error}>
-					<span class="library-row-tags">
-						<Show when={props.showPack}>
-							{props.asset.role} · {props.asset.packName}
-						</Show>
-						<Show when={props.error}>
-							<span class="library-row-error-text">
-								{props.showPack ? " · " : ""}
-								{LOAD_REASON_LABELS[props.error ?? ""] ?? "Could not load."}
-							</span>
-						</Show>
-					</span>
-				</Show>
-			</div>
-			<Show when={props.onInsert}>
-				<button
-					type="button"
-					class="library-insert"
-					aria-label={`Insert ${props.asset.name}`}
-					onClick={() => props.onInsert?.()}
-				>
-					<HiSolidPlus size={12} />
-				</button>
-			</Show>
-		</li>
 	);
 }

--- a/src/library/LibraryFacets.tsx
+++ b/src/library/LibraryFacets.tsx
@@ -1,0 +1,121 @@
+import { createMemo, For, type JSX, Show } from "solid-js";
+import type { LibraryAssetType } from "./manifest";
+import type { PackKind } from "./search";
+import type { useLibraryBrowser } from "./useLibraryBrowser";
+// The facet cluster's own layout (`.library-facets`, `.library-facet-group`),
+// its chips and its clear button live in the modal's stylesheet, while the
+// search input it shares with the panel (`.library-search`) lives in the
+// panel's. CSS arrives through per-component side-effect imports, so this
+// component imports both rather than depending on which view mounted first.
+// Order matters as well as presence: `.pack-browser-detail .library-search`
+// overrides the panel's base `.library-search`, so the panel sheet must come
+// first, exactly as it did when these views imported one another.
+import "./LibraryBrowser.css";
+import "./PackBrowser.css";
+
+export const TYPE_LABELS: Record<LibraryAssetType, string> = {
+	"one-shot": "One-shots",
+	loop: "Loops",
+	preset: "Presets",
+};
+
+export const KIND_LABELS: Record<PackKind, string> = {
+	factory: "Factory",
+	"third-party": "Third-party",
+	user: "Yours",
+};
+
+/** The active-facet controls, computed from the assets actually present. */
+export function FacetBar(props: {
+	browser: ReturnType<typeof useLibraryBrowser>;
+}): JSX.Element {
+	const { browser } = props;
+	const anyFilter = createMemo(() => {
+		const filter = browser.filter();
+		return (
+			filter.genres.length > 0 ||
+			filter.roles.length > 0 ||
+			filter.characters.length > 0 ||
+			filter.types.length > 0 ||
+			filter.query.trim() !== ""
+		);
+	});
+	return (
+		<div class="library-facets">
+			<input
+				type="search"
+				class="library-search"
+				placeholder="Search sounds"
+				aria-label="Search sounds"
+				value={browser.filter().query}
+				onInput={(event) => browser.setQuery(event.currentTarget.value)}
+			/>
+			<FacetGroup
+				label="Type"
+				values={browser.facets().types}
+				active={browser.filter().types}
+				display={(type) => TYPE_LABELS[type as LibraryAssetType]}
+				onToggle={(type) => browser.toggleType(type as LibraryAssetType)}
+			/>
+			<FacetGroup
+				label="Genre"
+				values={browser.facets().genres}
+				active={browser.filter().genres}
+				onToggle={(genre) => browser.toggleGenre(genre)}
+			/>
+			<FacetGroup
+				label="Role"
+				values={browser.facets().roles}
+				active={browser.filter().roles}
+				onToggle={(role) => browser.toggleRole(role)}
+			/>
+			<FacetGroup
+				label="Character"
+				values={browser.facets().characters}
+				active={browser.filter().characters}
+				onToggle={(character) => browser.toggleCharacter(character)}
+			/>
+			<Show when={anyFilter()}>
+				<button
+					type="button"
+					class="library-clear"
+					onClick={() => browser.clearFilters()}
+				>
+					Clear filters
+				</button>
+			</Show>
+		</div>
+	);
+}
+
+export function FacetGroup(props: {
+	label: string;
+	values: readonly string[];
+	active: readonly string[];
+	display?: (value: string) => string;
+	onToggle: (value: string) => void;
+}): JSX.Element {
+	return (
+		<Show when={props.values.length > 0}>
+			<fieldset class="library-facet-group">
+				<legend class="library-facet-label">{props.label}</legend>
+				<For each={props.values}>
+					{(value) => {
+						const isActive = createMemo(() => props.active.includes(value));
+						return (
+							<button
+								type="button"
+								class="library-chip"
+								classList={{ "library-chip-active": isActive() }}
+								aria-pressed={isActive()}
+								onClick={() => props.onToggle(value)}
+							>
+								{props.display ? props.display(value) : value}
+							</button>
+						);
+					}}
+				</For>
+			</fieldset>
+		</Show>
+	);
+}

--- a/src/library/PackBrowser.tsx
+++ b/src/library/PackBrowser.tsx
@@ -6,7 +6,6 @@ import {
 import {
 	createEffect,
 	createMemo,
-	createSignal,
 	For,
 	type JSX,
 	onMount,
@@ -19,30 +18,16 @@ import {
 import TapeLoader from "../components/TapeLoader";
 import type { ShortcutContext, ShortcutHandlers } from "../shortcuts";
 import { useShortcuts } from "../shortcuts";
-import { AssetRow, LOAD_REASON_LABELS } from "./LibraryBrowser";
-import type {
-	LibraryAsset,
-	LibraryAssetType,
-	LibraryPackSummary,
-} from "./manifest";
-import { EMPTY_PACK_FILTER, filterPacks, type PackKind } from "./search";
+import AssetRow from "./AssetRow";
+import { FacetBar } from "./LibraryFacets";
+import { LOAD_REASON_LABELS } from "./loadReasons";
+import type { LibraryAsset, LibraryPackSummary } from "./manifest";
+import PackList from "./PackList";
 import type { useLibraryBrowser } from "./useLibraryBrowser";
 import "./PackBrowser.css";
 
 /** A modal suppresses every other shortcut context while it is open (PRD KEY-01). */
 const DIALOG_CONTEXTS: readonly ShortcutContext[] = ["dialog"];
-
-const TYPE_LABELS: Record<LibraryAssetType, string> = {
-	"one-shot": "One-shots",
-	loop: "Loops",
-	preset: "Presets",
-};
-
-const KIND_LABELS: Record<PackKind, string> = {
-	factory: "Factory",
-	"third-party": "Third-party",
-	user: "Yours",
-};
 
 export interface PackBrowserProps {
 	readonly browser: ReturnType<typeof useLibraryBrowser>;
@@ -68,13 +53,15 @@ export interface PackBrowserProps {
  * in the KEY-01 registry, dispatched by the shared controller like every other
  * mapping, which is what keeps the combination written down once.
  *
- * Facets live here, not in the panel: filtering by genre, role and character
- * needs the width, and the panel is 250px.
+ * Facets live on this surface, not in the panel: filtering by genre, role and
+ * character needs the width, and the panel is 250px. This component is the
+ * dialog frame and the choice of what the detail pane shows; the rail that
+ * narrows and picks a pack is {@link PackList}, and the facet controls the
+ * detail pane filters with are `LibraryFacets`.
  */
 export default function PackBrowser(props: PackBrowserProps): JSX.Element {
 	const { browser } = props;
 	const analytics = props.analytics ?? defaultAnalytics;
-	const [packFilter, setPackFilter] = createSignal(EMPTY_PACK_FILTER);
 
 	useShortcuts({
 		handlers: (): ShortcutHandlers => ({
@@ -103,10 +90,6 @@ export default function PackBrowser(props: PackBrowserProps): JSX.Element {
 		void browser.selectPack(first.slug);
 	});
 
-	const visiblePacks = createMemo(() =>
-		filterPacks(browser.packs(), packFilter()),
-	);
-
 	const selectedPack = createMemo<LibraryPackSummary | null>(() => {
 		const slug = browser.selectedPackSlug();
 		if (slug === null) return null;
@@ -115,22 +98,6 @@ export default function PackBrowser(props: PackBrowserProps): JSX.Element {
 
 	const isAdded = (pack: LibraryPackSummary) =>
 		props.addedPackIds.includes(pack.id);
-
-	function toggleKind(kind: PackKind): void {
-		setPackFilter((prev) => ({
-			...prev,
-			kinds: prev.kinds.includes(kind)
-				? prev.kinds.filter((existing) => existing !== kind)
-				: [...prev.kinds, kind],
-		}));
-	}
-
-	const kinds = createMemo<PackKind[]>(() => {
-		const present = new Set(browser.packs().map((pack) => pack.kind));
-		return (["factory", "third-party", "user"] as const).filter((kind) =>
-			present.has(kind),
-		);
-	});
 
 	return (
 		<div class="pack-browser">
@@ -168,101 +135,7 @@ export default function PackBrowser(props: PackBrowserProps): JSX.Element {
 				</header>
 
 				<div class="pack-browser-body">
-					<nav class="pack-browser-list" aria-label="Packs">
-						<input
-							type="search"
-							class="pack-browser-search"
-							placeholder="Search packs"
-							aria-label="Search packs"
-							value={packFilter().query}
-							onInput={(event) =>
-								setPackFilter((prev) => ({
-									...prev,
-									query: event.currentTarget.value,
-								}))
-							}
-						/>
-						<div class="pack-browser-kinds">
-							<For each={kinds()}>
-								{(kind) => {
-									const active = createMemo(() =>
-										packFilter().kinds.includes(kind),
-									);
-									return (
-										<button
-											type="button"
-											class="library-chip"
-											classList={{ "library-chip-active": active() }}
-											aria-pressed={active()}
-											onClick={() => toggleKind(kind)}
-										>
-											{KIND_LABELS[kind]}
-										</button>
-									);
-								}}
-							</For>
-						</div>
-						<ul class="pack-browser-packs">
-							<li>
-								<button
-									type="button"
-									class="pack-browser-pack"
-									classList={{
-										"pack-browser-pack-active":
-											browser.selectedPackSlug() === null,
-									}}
-									aria-pressed={browser.selectedPackSlug() === null}
-									onClick={() => void browser.selectPack(null)}
-								>
-									<span class="pack-browser-pack-name">All sounds</span>
-									<span class="pack-browser-pack-meta">Every pack</span>
-								</button>
-							</li>
-							<For each={visiblePacks()}>
-								{(pack) => {
-									const failed = createMemo(() =>
-										browser
-											.packErrors()
-											.some((error) => error.packSlug === pack.slug),
-									);
-									return (
-										<li>
-											<button
-												type="button"
-												class="pack-browser-pack"
-												classList={{
-													"pack-browser-pack-active":
-														browser.selectedPackSlug() === pack.slug,
-													"pack-browser-pack-failed": failed(),
-												}}
-												aria-pressed={browser.selectedPackSlug() === pack.slug}
-												onClick={() => void browser.selectPack(pack.slug)}
-											>
-												<span class="pack-browser-pack-name">{pack.name}</span>
-												<span class="pack-browser-pack-meta">
-													{pack.publisher} ·{" "}
-													{failed()
-														? "unavailable"
-														: `${pack.assetCount} sounds`}
-												</span>
-												<Show when={isAdded(pack)}>
-													<span class="pack-browser-pack-added">
-														<HiSolidCheckCircle size={14} />
-														<span class="visually-hidden">Added</span>
-													</span>
-												</Show>
-											</button>
-										</li>
-									);
-								}}
-							</For>
-							<Show when={visiblePacks().length === 0}>
-								<li class="pack-browser-no-packs">
-									No packs match. Clear the search to see them all.
-								</li>
-							</Show>
-						</ul>
-					</nav>
+					<PackList browser={browser} isAdded={isAdded} />
 
 					<section class="pack-browser-detail" aria-label="Pack">
 						<Show
@@ -430,101 +303,6 @@ function Results(props: {
 					</For>
 				</ul>
 			</Show>
-		</Show>
-	);
-}
-
-/** The active-facet controls, computed from the assets actually present. */
-function FacetBar(props: {
-	browser: ReturnType<typeof useLibraryBrowser>;
-}): JSX.Element {
-	const { browser } = props;
-	const anyFilter = createMemo(() => {
-		const filter = browser.filter();
-		return (
-			filter.genres.length > 0 ||
-			filter.roles.length > 0 ||
-			filter.characters.length > 0 ||
-			filter.types.length > 0 ||
-			filter.query.trim() !== ""
-		);
-	});
-	return (
-		<div class="library-facets">
-			<input
-				type="search"
-				class="library-search"
-				placeholder="Search sounds"
-				aria-label="Search sounds"
-				value={browser.filter().query}
-				onInput={(event) => browser.setQuery(event.currentTarget.value)}
-			/>
-			<FacetGroup
-				label="Type"
-				values={browser.facets().types}
-				active={browser.filter().types}
-				display={(type) => TYPE_LABELS[type as LibraryAssetType]}
-				onToggle={(type) => browser.toggleType(type as LibraryAssetType)}
-			/>
-			<FacetGroup
-				label="Genre"
-				values={browser.facets().genres}
-				active={browser.filter().genres}
-				onToggle={(genre) => browser.toggleGenre(genre)}
-			/>
-			<FacetGroup
-				label="Role"
-				values={browser.facets().roles}
-				active={browser.filter().roles}
-				onToggle={(role) => browser.toggleRole(role)}
-			/>
-			<FacetGroup
-				label="Character"
-				values={browser.facets().characters}
-				active={browser.filter().characters}
-				onToggle={(character) => browser.toggleCharacter(character)}
-			/>
-			<Show when={anyFilter()}>
-				<button
-					type="button"
-					class="library-clear"
-					onClick={() => browser.clearFilters()}
-				>
-					Clear filters
-				</button>
-			</Show>
-		</div>
-	);
-}
-
-function FacetGroup(props: {
-	label: string;
-	values: readonly string[];
-	active: readonly string[];
-	display?: (value: string) => string;
-	onToggle: (value: string) => void;
-}): JSX.Element {
-	return (
-		<Show when={props.values.length > 0}>
-			<fieldset class="library-facet-group">
-				<legend class="library-facet-label">{props.label}</legend>
-				<For each={props.values}>
-					{(value) => {
-						const isActive = createMemo(() => props.active.includes(value));
-						return (
-							<button
-								type="button"
-								class="library-chip"
-								classList={{ "library-chip-active": isActive() }}
-								aria-pressed={isActive()}
-								onClick={() => props.onToggle(value)}
-							>
-								{props.display ? props.display(value) : value}
-							</button>
-						);
-					}}
-				</For>
-			</fieldset>
 		</Show>
 	);
 }

--- a/src/library/PackList.tsx
+++ b/src/library/PackList.tsx
@@ -1,0 +1,139 @@
+import { HiSolidCheckCircle } from "solid-icons/hi";
+import { createMemo, createSignal, For, type JSX, Show } from "solid-js";
+import { KIND_LABELS } from "./LibraryFacets";
+import type { LibraryPackSummary } from "./manifest";
+import { EMPTY_PACK_FILTER, filterPacks, type PackKind } from "./search";
+import type { useLibraryBrowser } from "./useLibraryBrowser";
+import "./PackBrowser.css";
+
+/**
+ * The pack browser's left rail: every pack, narrowed by name and by kind, plus
+ * the cross-pack "All sounds" way in.
+ *
+ * Its filter is deliberately local. Narrowing *this list* is navigation — it
+ * decides which packs are offered, never which sounds a chosen pack shows — so
+ * it is separate from the asset filter `useLibraryBrowser` owns, and it reads
+ * the index alone: filtering by name or kind fetches no manifest
+ * (sample-library section 12).
+ */
+export default function PackList(props: {
+	browser: ReturnType<typeof useLibraryBrowser>;
+	/** Whether the project already has a pack, so an added pack says so. */
+	isAdded: (pack: LibraryPackSummary) => boolean;
+}): JSX.Element {
+	const { browser } = props;
+	const [packFilter, setPackFilter] = createSignal(EMPTY_PACK_FILTER);
+
+	const visiblePacks = createMemo(() =>
+		filterPacks(browser.packs(), packFilter()),
+	);
+
+	function toggleKind(kind: PackKind): void {
+		setPackFilter((prev) => ({
+			...prev,
+			kinds: prev.kinds.includes(kind)
+				? prev.kinds.filter((existing) => existing !== kind)
+				: [...prev.kinds, kind],
+		}));
+	}
+
+	const kinds = createMemo<PackKind[]>(() => {
+		const present = new Set(browser.packs().map((pack) => pack.kind));
+		return (["factory", "third-party", "user"] as const).filter((kind) =>
+			present.has(kind),
+		);
+	});
+
+	return (
+		<nav class="pack-browser-list" aria-label="Packs">
+			<input
+				type="search"
+				class="pack-browser-search"
+				placeholder="Search packs"
+				aria-label="Search packs"
+				value={packFilter().query}
+				onInput={(event) =>
+					setPackFilter((prev) => ({
+						...prev,
+						query: event.currentTarget.value,
+					}))
+				}
+			/>
+			<div class="pack-browser-kinds">
+				<For each={kinds()}>
+					{(kind) => {
+						const active = createMemo(() => packFilter().kinds.includes(kind));
+						return (
+							<button
+								type="button"
+								class="library-chip"
+								classList={{ "library-chip-active": active() }}
+								aria-pressed={active()}
+								onClick={() => toggleKind(kind)}
+							>
+								{KIND_LABELS[kind]}
+							</button>
+						);
+					}}
+				</For>
+			</div>
+			<ul class="pack-browser-packs">
+				<li>
+					<button
+						type="button"
+						class="pack-browser-pack"
+						classList={{
+							"pack-browser-pack-active": browser.selectedPackSlug() === null,
+						}}
+						aria-pressed={browser.selectedPackSlug() === null}
+						onClick={() => void browser.selectPack(null)}
+					>
+						<span class="pack-browser-pack-name">All sounds</span>
+						<span class="pack-browser-pack-meta">Every pack</span>
+					</button>
+				</li>
+				<For each={visiblePacks()}>
+					{(pack) => {
+						const failed = createMemo(() =>
+							browser
+								.packErrors()
+								.some((error) => error.packSlug === pack.slug),
+						);
+						return (
+							<li>
+								<button
+									type="button"
+									class="pack-browser-pack"
+									classList={{
+										"pack-browser-pack-active":
+											browser.selectedPackSlug() === pack.slug,
+										"pack-browser-pack-failed": failed(),
+									}}
+									aria-pressed={browser.selectedPackSlug() === pack.slug}
+									onClick={() => void browser.selectPack(pack.slug)}
+								>
+									<span class="pack-browser-pack-name">{pack.name}</span>
+									<span class="pack-browser-pack-meta">
+										{pack.publisher} ·{" "}
+										{failed() ? "unavailable" : `${pack.assetCount} sounds`}
+									</span>
+									<Show when={props.isAdded(pack)}>
+										<span class="pack-browser-pack-added">
+											<HiSolidCheckCircle size={14} />
+											<span class="visually-hidden">Added</span>
+										</span>
+									</Show>
+								</button>
+							</li>
+						);
+					}}
+				</For>
+				<Show when={visiblePacks().length === 0}>
+					<li class="pack-browser-no-packs">
+						No packs match. Clear the search to see them all.
+					</li>
+				</Show>
+			</ul>
+		</nav>
+	);
+}

--- a/src/library/loadReasons.ts
+++ b/src/library/loadReasons.ts
@@ -1,0 +1,16 @@
+/**
+ * What a library load failure is called when a person reads it.
+ *
+ * A failure reason is classified once, at the fetch boundary
+ * (`libraryClient.ts`), and named here — so the pack index, a pack manifest,
+ * and a single asset audition all report the same cause in the same words no
+ * matter which surface noticed it. Keyed loosely by `string` because the same
+ * table serves reasons that arrive already widened to `string` (an asset error,
+ * a pack error's `reason`); every lookup site supplies its own fallback.
+ */
+export const LOAD_REASON_LABELS: Record<string, string> = {
+	network: "Check your connection.",
+	not_found: "This library is unavailable.",
+	corrupt: "The library data could not be read.",
+	timeout: "The library took too long to load.",
+};


### PR DESCRIPTION
## What

`src/library/PackBrowser.tsx` imported `AssetRow` and `LOAD_REASON_LABELS` back out of its sibling view `src/library/LibraryBrowser.tsx`. Two sibling views importing UI from each other is the smell — neither owned the shared pieces, so the panel was load-bearing for the modal's rows.

This lifts what both use into modules of their own:

| New module | What it owns |
| --- | --- |
| `AssetRow.tsx` (74) | The shared auditionable-sound row |
| `loadReasons.ts` (16) | `LOAD_REASON_LABELS` — the one place a load failure is named |
| `LibraryFacets.tsx` (121) | `FacetBar` + `FacetGroup` + the `TYPE_LABELS`/`KIND_LABELS` tables |
| `PackList.tsx` (134) | The modal's left rail, which takes its own pack filter with it |

Both views now import from the shared modules instead of from each other.

`LibraryBrowser.tsx` 407 → 335, `PackBrowser.tsx` 572 → 330.

`PackList` was worth extracting because it is a clean boundary: it owned `packFilter` entirely and nothing else in `PackBrowser` read that signal, so the state moved with the markup. The scrim and dialog header stayed put — pulling those out would separate `aria-labelledby="pack-browser-title"` from the element it labels for no gain.

## UI walkthrough

**No user-visible change.** This is a pure refactor: no behavior change, no DOM change, no visual change. Every `data-testid`, `aria-*` attribute and CSS class name is preserved exactly, `Escape` still closes the dialog through `view.close_surface` in the KEY-01 shortcut registry (no component-owned `keydown` listener was added), and analytics still fire through the typed catalog — `PackBrowser.test.tsx` asserts the `pack_browser` `feature_first_use` key fires exactly once.

## The CSS side-effect-import hazard, and how it was verified

`AssetRow`'s styles (`.library-row`, `.library-audition`, `.library-insert`) live in `LibraryBrowser.css`, and CSS is loaded via per-component side-effect imports. A new `AssetRow.tsx` that did not import that sheet would silently lose the pack browser's row styling — a real visual regression that the DOM-only tests cannot catch.

Handled by having each new component import the sheets that define the class names it renders:

- `AssetRow.tsx` imports `LibraryBrowser.css`.
- `LibraryFacets.tsx` imports **both** — `.library-search` comes from the panel sheet, while `.library-facets` / `.library-facet-group` / `.library-chip` / `.library-clear` come from the modal sheet. Panel sheet first, preserving the order that lets `.pack-browser-detail .library-search` override the base `.library-search`.
- `PackList.tsx` imports `PackBrowser.css`.

**Evidence — the built stylesheet was diffed, not just eyeballed.** I ran `bun run build` on `main` and on this branch and compared the editor route's emitted CSS bundle (`.output/public/_build/assets/_id_-*.css`):

- Identical size, **35185 bytes** both times.
- Parsed into top-level rules: **305 rules before, 305 after, and the two sets are equal** — no rule was dropped, added, or altered. That is the direct refutation of the hazard: had a stylesheet gone missing from the graph, rules would have disappeared from this bundle.
- The two library stylesheets do swap position, since `AssetRow`/`LibraryFacets` now pull `LibraryBrowser.css` in earlier. Source order only matters for equal-specificity rules that can match the same element, so I enumerated those: of the swapped pairs, the only one that could match a common element *and* share a property was `.pack-browser-results .library-row` vs `.library-row:hover` — and those have **different** specificity ((0,1,1) vs (0,2,0)), so specificity, not source order, decides between them. The swap is inert.

## Tests

No existing assertion was weakened or deleted.

- `bunx vitest run src/library/` — **102 passing**, matching the pre-refactor baseline exactly (9 files, 102 tests).
- `bun run typecheck` — passes.
- `bun run check` — passes, 427 files, no fixes applied.
- `bun run test` — 1921/1922 passing. The single failure is `src/audio/testAudioTeardown.test.ts` (`cpal backend error ... coreaudio`), the known local audio-device-contention flake. Confirmed unrelated: it reproduces on a **completely clean tree** with `git stash -u` and none of this branch's changes present, and this branch touches only `src/library/`, which that test does not import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
