### PR TITLE
Fix deploy job never running: declare environment: prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,20 +53,23 @@ VITE_FIREBASE_MEASUREMENT_ID=
 # (PRD OPS-01) -- there is no separate staging project. Deployment runs from
 # CI, never from a developer machine, so none of these belong in a real local
 # `.env`; they are documented here only so the values CI needs are named in
-# one place. Set them as GitHub Actions repository variables/secrets on
-# `afternoon/solid-groove` (Settings -> Secrets and variables -> Actions):
+# one place. Set them on the `prod` GitHub *environment* on
+# `afternoon/solid-groove` (Settings -> Environments -> prod), which is the
+# environment .github/workflows/ci.yml's `deploy` job declares:
 #
-#   FIREBASE_PROJECT_ID (repository *variable*, not secret -- a project ID
-#     is not sensitive, and .github/workflows/ci.yml's `deploy` job reads it
-#     from an `if:` condition, which only `vars` supports safely)
-#   FIREBASE_DEPLOY_SERVICE_ACCOUNT (repository *secret* -- inline service
+#   FIREBASE_PROJECT_ID (environment *variable*, not secret -- a project ID
+#     is not sensitive; consumed by the deploy step and the hosted smoke
+#     test's URL)
+#   FIREBASE_DEPLOY_SERVICE_ACCOUNT (environment *secret* -- inline service
 #     account JSON with Firebase Hosting, Firestore rules/indexes, and
 #     Storage rules deploy permissions; CI writes it to a temp file and
 #     points GOOGLE_APPLICATION_CREDENTIALS at it for a non-interactive
 #     `firebase deploy`)
 #
-# Until both are set, .github/workflows/ci.yml's `deploy` job stays a no-op
-# and every other check keeps passing -- see that file's comments.
+# Scope matters: a job only receives an environment's values if it declares
+# that environment, and an environment-scoped `vars.*` read from a job that
+# does not resolves to the empty string with no error. Setting these at
+# repository scope instead leaves the `deploy` job reading blanks.
 
 # --- Analytics and error monitoring (FND-001c; PRD OPS-02/OPS-03, ADR 0001) --
 # Two processors: Google Analytics 4 for product events, which rides the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,20 +200,25 @@ jobs:
   # in the same command, so a failing rules/index step fails the deploy
   # instead of shipping application code its deployed rules don't match.
   #
-  # Gated on `vars.FIREBASE_PROJECT_ID` (a GitHub Actions repository
-  # *variable*, not a secret -- a Firebase project ID is not sensitive, and
-  # `vars` is safe to read from an `if:` condition, unlike `secrets`) so this
-  # job silently no-ops until the production project and its CI credentials
-  # actually exist, rather than failing every merge to `main` in the
-  # meantime. Provisioning the project and setting these is tracked outside
-  # this repository (this task "provisions no accounts and holds no
-  # secrets" -- see docs/testing.md "Deploy" for the full secret/variable
-  # list and how to add them).
+  # Every value this job needs -- the four `vars` and two `secrets` read
+  # below -- lives in the `prod` GitHub *environment*, so the job declares
+  # `environment: prod` to have them injected. Without that declaration a job
+  # sees only repository-scoped values, and an environment-scoped `vars`
+  # lookup silently returns the empty string.
+  #
+  # That is also why the `if:` condition below no longer gates on
+  # `vars.FIREBASE_PROJECT_ID`: GitHub evaluates a job's `if:` *before* it
+  # loads the environment, so an environment-scoped variable is always empty
+  # at gate time and would skip this job unconditionally. The branch check is
+  # the gate now. Provisioning the project and setting these values is
+  # tracked outside this repository -- see docs/testing.md "Deploy" for the
+  # full secret/variable list and how to add them.
   deploy:
     name: deploy to Firebase Hosting
     needs: [checks, browser, browser-emulator, emulator, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.FIREBASE_PROJECT_ID != ''
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: prod
     # A second deploy landing while one is mid-flight must queue behind it,
     # never run concurrently or cancel it: `firebase deploy --only
     # hosting,firestore,storage` is not atomic across tiers, and two

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Without a Firebase project of your own, set `VITE_MOCK_BACKEND=true` in `.env` i
 
 The private alpha has exactly one hosted environment — the **production** Firebase project — deployed to Firebase Hosting from CI on every merge to `main`, never from a developer machine. `bun run deploy` is the one documented command (it builds, scans the build for secrets, then ships Hosting, Firestore rules/indexes, and Storage rules together so a failing rules step fails the whole deploy); `.github/workflows/ci.yml`'s `deploy` job runs it automatically and follows it with a post-deploy smoke test against the real hosted URL. See [`docs/testing.md`](./docs/testing.md#deploy) for the full pipeline, the CI secrets/variables it needs, rollback, and how to get a local build talking to the right project.
 
-The pipeline is committed but has never run against a real project: no Firebase project or Sentry organization is provisioned yet, so the `deploy` job stays skipped and every merge to `main` is verified by the emulator and browser suites only. Provisioning them and verifying the deploy, rollback, analytics, and monitoring paths end to end is task `OPS-001` ([issue #68](https://github.com/afternoon/solid-groove/issues/68)), scheduled after Alpha Milestone 2 — see [`docs/runbooks/alpha-milestone-0.md`](./docs/runbooks/alpha-milestone-0.md).
+The `deploy` job runs on merges to `main` and reads its credentials from the `prod` GitHub environment. Verifying the deploy, rollback, analytics, and monitoring paths end to end against the hosted environment is task `OPS-001` ([issue #68](https://github.com/afternoon/solid-groove/issues/68)), scheduled after Alpha Milestone 2 — see [`docs/runbooks/alpha-milestone-0.md`](./docs/runbooks/alpha-milestone-0.md).
 
 ## Sounds
 

--- a/docs/runbooks/alpha-milestone-0.md
+++ b/docs/runbooks/alpha-milestone-0.md
@@ -33,10 +33,11 @@ Nothing here is optional or downgraded by the move — the acceptance criteria a
 - [ ] `firebase-tools` is available locally (`bunx firebase --version`) for parts
       1 and 6. Parts 3–5 need only a browser.
 
-A note on ordering: the deploy pipeline is gated on the `FIREBASE_PROJECT_ID`
-repository *variable*. Nothing deploys until you set it in part 3, so parts 1 and
-2 are safe to do in any order and at any pace — merges to `main` keep passing
-with `deploy` reported as skipped.
+A note on ordering: the deploy pipeline draws every value it needs from the
+`prod` GitHub *environment*, which you create in part 3. Nothing deploys until
+that environment exists and holds them, so parts 1 and 2 are safe to do in any
+order and at any pace — merges to `main` keep passing, with `deploy` failing
+fast on missing credentials rather than shipping anything.
 
 ## Part 1 — the Firebase project
 
@@ -113,24 +114,37 @@ reopens the self-hosting option the ADR rejected, and this part changes.
 
 ## Part 3 — GitHub Actions configuration
 
-`afternoon/solid-groove` → Settings → Secrets and variables → Actions. The
-split between variables and secrets is deliberate throughout: a value that ships
-to browsers is not stored as if it were confidential.
+- [ ] **Create the `prod` environment.** `afternoon/solid-groove` → Settings →
+      Environments → New environment, named exactly `prod`. The `deploy` job
+      declares `environment: prod`, and that name is how it finds the six values
+      below. No protection rules or branch policy are required for the alpha —
+      the job's own `if:` already restricts it to `push` events on `main` — but
+      this is where you would add a required reviewer later.
+
+Then set all six **inside that environment**, not at repository scope. The split
+between variables and secrets is deliberate throughout: a value that ships to
+browsers is not stored as if it were confidential.
 
 | Name | Kind | Value |
 | --- | --- | --- |
-| `FIREBASE_PROJECT_ID` | Variable | The project ID from part 1. Also the deploy job's `if:` gate — only `vars` can safely appear there. |
+| `FIREBASE_PROJECT_ID` | Variable | The project ID from part 1. |
 | `FIREBASE_DEPLOY_SERVICE_ACCOUNT` | **Secret** | The full service-account JSON, inline. |
 | `VITE_SENTRY_DSN` | Variable | The DSN from part 2. Public by design. |
 | `SENTRY_ORG` | Variable | Org slug. |
 | `SENTRY_PROJECT` | Variable | Project slug. |
 | `SENTRY_AUTH_TOKEN` | **Secret** | The auth token from part 2. |
 
-- [ ] Set all six. Partial configuration degrades cleanly rather than breaking:
-      without `FIREBASE_PROJECT_ID` the whole `deploy` job stays skipped; without
-      the `SENTRY_*` values the deploy still ships and source maps are still
+- [ ] Set all six. **Scope matters more than it looks**: a job only receives an
+      environment's variables and secrets if it declares that environment, and an
+      environment-scoped `vars.*` lookup from a job that does not resolves to the
+      empty string with no error. Setting these at repository scope instead
+      leaves the `deploy` job reading blanks.
+- [ ] Partial configuration degrades cleanly rather than breaking: without the
+      `SENTRY_*` values the deploy still ships and source maps are still
       generated and still withheld from Hosting — they are simply not uploaded,
-      so stack traces stay minified.
+      so stack traces stay minified. `FIREBASE_PROJECT_ID` and
+      `FIREBASE_DEPLOY_SERVICE_ACCOUNT` are not optional; with either missing the
+      deploy step fails rather than silently skipping.
 
 ## Part 4 — the first deploy
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -197,7 +197,9 @@ This needs `FIREBASE_PROJECT_ID` and Google Application Default Credentials (`GO
 
 `.github/workflows/ci.yml`'s `build` job runs `bun run build`, `bun run verify:bundle`, and `bun run verify:budget` unconditionally, on every push and PR, with no credentials at all — proving the production build succeeds, ships no secret, and keeps the error-monitoring SDK off the interactive path on every change, long before a real deploy is possible.
 
-The `deploy` job runs only when `github.ref == 'refs/heads/main'` on a `push` event **and** the `FIREBASE_PROJECT_ID` repository variable is set. That gate is deliberate: this task ("FND-001b") provisions no Firebase project, CI service account, or any other credential — it builds the pipeline and leaves it inert until a real project exists. Until then, `deploy` reports as skipped and every other job keeps gating merges normally.
+The `deploy` job runs only when `github.ref == 'refs/heads/main'` on a `push` event, and declares `environment: prod` so the GitHub environment of that name supplies its variables and secrets.
+
+That `environment:` declaration is load-bearing: a job that does not name an environment sees only repository-scoped values, and an environment-scoped `vars.*` lookup silently evaluates to the empty string rather than failing. For the same reason the `if:` condition deliberately does **not** gate on `vars.FIREBASE_PROJECT_ID` — GitHub evaluates a job's `if:` *before* loading its environment, so an environment-scoped variable is always empty at gate time and would skip the job on every merge. Before the `prod` environment existed the job was gated on that variable to stay inert until a real project was provisioned; the environment now serves that role, and deleting it (or removing its values) is what makes the deploy stop.
 
 Once the project and its secrets exist, `deploy`:
 
@@ -206,16 +208,16 @@ Once the project and its secrets exist, `deploy`:
 3. Marks the release deployed in Sentry (`sentry-cli releases deploys … new --env alpha`), after the deploy succeeded so a release that never shipped is never recorded as live. Skipped when the Sentry variables are unset. See "Source maps and release registration" below.
 4. Installs Chromium and runs `bun run smoke:hosted` against `https://$FIREBASE_PROJECT_ID.web.app`. A failing smoke test fails the job — the deploy is not considered successful until it passes (PRD OPS-01).
 
-Required GitHub Actions configuration (`afternoon/solid-groove` → Settings → Secrets and variables → Actions), named but never set by this task:
+Required GitHub Actions configuration, all of it scoped to the **`prod` environment** (`afternoon/solid-groove` → Settings → Environments → `prod`), named but never set by this task. Setting any of these at repository scope instead has no effect on the `deploy` job, which reads them through `environment: prod`:
 
 | Name | Kind | Purpose |
 | --- | --- | --- |
-| `FIREBASE_PROJECT_ID` | Repository **variable** | The production project ID. Not sensitive — used in the `deploy` job's `if:` condition, which only `vars` (not `secrets`) can safely appear in. |
-| `FIREBASE_DEPLOY_SERVICE_ACCOUNT` | Repository **secret** | Inline service-account JSON with Hosting, Firestore rules/indexes, and Storage rules deploy permissions. Distinct from any credential `library:upload`/CNT-000 uses, so the deploy pipeline's IAM scope doesn't have to match a different task's. |
-| `VITE_SENTRY_DSN` | Repository **variable** | The client DSN (`FND-001c`). **Public by design**: it ships in the client bundle, because a browser SDK cannot submit an event without it. It identifies an ingest endpoint and grants nothing else — the same standing as the Firebase Web API key. Stored as a variable, not a secret, so nothing pretends otherwise. |
-| `SENTRY_ORG` | Repository **variable** | Sentry organization slug. Not sensitive. |
-| `SENTRY_PROJECT` | Repository **variable** | Sentry project slug. Not sensitive. |
-| `SENTRY_AUTH_TOKEN` | Repository **secret** | Creates releases and uploads source maps (`project:releases`, `org:read`). This is the one genuinely secret Sentry value — it can rewrite what your error data says. **CI only**: it never belongs in a developer `.env`, and `verify:bundle` fails the build if it ever appears in the output. |
+| `FIREBASE_PROJECT_ID` | Environment **variable** | The production project ID. Not sensitive. Consumed by the deploy step and the hosted smoke test's URL; it is *not* the job's `if:` gate — see above for why an environment-scoped variable cannot be one. |
+| `FIREBASE_DEPLOY_SERVICE_ACCOUNT` | Environment **secret** | Inline service-account JSON with Hosting, Firestore rules/indexes, and Storage rules deploy permissions. Distinct from any credential `library:upload`/CNT-000 uses, so the deploy pipeline's IAM scope doesn't have to match a different task's. |
+| `VITE_SENTRY_DSN` | Environment **variable** | The client DSN (`FND-001c`). **Public by design**: it ships in the client bundle, because a browser SDK cannot submit an event without it. It identifies an ingest endpoint and grants nothing else — the same standing as the Firebase Web API key. Stored as a variable, not a secret, so nothing pretends otherwise. |
+| `SENTRY_ORG` | Environment **variable** | Sentry organization slug. Not sensitive. |
+| `SENTRY_PROJECT` | Environment **variable** | Sentry project slug. Not sensitive. |
+| `SENTRY_AUTH_TOKEN` | Environment **secret** | Creates releases and uploads source maps (`project:releases`, `org:read`). This is the one genuinely secret Sentry value — it can rewrite what your error data says. **CI only**: it never belongs in a developer `.env`, and `verify:bundle` fails the build if it ever appears in the output. |
 
 ### Release SHA
 


### PR DESCRIPTION
## What

The `deploy` job has been skipping on every merge to `main` despite its variables and secrets being set. They were set on the **`prod` GitHub environment**, but the job never declared `environment: prod`, so it only ever saw repository-scoped values — of which there are none. `vars.FIREBASE_PROJECT_ID` evaluated to `''` and the `if:` gate skipped the job silently.

## Why declaring the environment isn't enough on its own

GitHub evaluates a job-level `if:` **before** it loads the job's environment. An environment-scoped variable is therefore always empty at gate time, so keeping `vars.FIREBASE_PROJECT_ID != ''` in the condition would skip the job unconditionally even with `environment: prod` present. The gate is now the branch check alone.

That variable was originally the gate so the pipeline stayed inert until a real project was provisioned. The `prod` environment now serves that role: deleting it, or clearing its values, is what stops the deploy.

The step-level `if:` on "Mark the release as deployed in Sentry" is deliberately **unchanged** — step conditions are evaluated after the environment loads, so `vars.SENTRY_ORG` / `vars.SENTRY_PROJECT` resolve correctly there.

## Docs

`docs/testing.md`, `docs/runbooks/alpha-milestone-0.md`, `README.md`, and `.env.example` all documented the old repository-variable gate and instructed setting these at repository scope — which is exactly the wrong turn that caused this. All four now describe the `prod` environment and call out that the scope mismatch fails silently rather than erroring.

## UI walkthrough

No user-visible change — CI configuration and documentation only.

## Evidence

- `.github/workflows/ci.yml` parses; `jobs.deploy` reads `environment: prod` with `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`. `needs` and the `deploy-production` concurrency group are unchanged.
- Verified against the live repo config: `prod` holds all four variables (`FIREBASE_PROJECT_ID`, `SENTRY_ORG`, `SENTRY_PROJECT`, `VITE_SENTRY_DSN`) and both secrets (`FIREBASE_DEPLOY_SERVICE_ACCOUNT`, `SENTRY_AUTH_TOKEN`); repository scope holds zero variables.
- `bun run check:ci` passes — 436 files checked, no errors — rebased on `main` at 6bb7536.

## Note

This changes CI configuration, so the real proof is the next merge to `main`: `deploy` should run rather than report as skipped. Worth watching that run — this PR cannot demonstrate it from a PR event, since the job is gated on `push` to `main`.

Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)