### PR TITLE
Fix hosted app failing with auth/invalid-api-key; verify client config at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,43 @@ jobs:
           VITE_RELEASE_SHA: ${{ github.sha }}
           FIREBASE_PROJECT_ID: ${{ vars.FIREBASE_PROJECT_ID }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-deploy-service-account.json
+          # The Firebase *client* config, read by src/firebaseConfig.ts. These
+          # are baked into the client bundle at build time, so they must be
+          # present in this step's environment -- not merely on the project.
+          # Without them `initializeApp` receives `undefined` for every field
+          # and the first Auth call fails at runtime with
+          # `auth/invalid-api-key`, which renders the app's error boundary
+          # instead of the page. That is a fully successful deploy of a broken
+          # build: only the post-deploy smoke test catches it.
+          #
+          # Public by design -- they ship to every browser that loads the app,
+          # are protected by security rules and API-key restrictions rather
+          # than secrecy, and so are stored as `vars`, not `secrets`.
+          # `verify:bundle` deliberately does not flag them (see
+          # scripts/verify-no-secrets-in-bundle.mjs).
+          #
+          # Three of these are derived from `vars.FIREBASE_PROJECT_ID` rather
+          # than stored separately. The project ID is the same value the deploy
+          # targets, and Firebase builds the auth domain and storage bucket from
+          # it by fixed convention (`<id>.firebaseapp.com`,
+          # `<id>.firebasestorage.app`), so storing them again would only create
+          # room for them to drift from the project actually being deployed to.
+          #
+          # The remaining three cannot be derived -- they are independent
+          # identifiers assigned by Firebase -- so they stay as variables. Read
+          # them from the console: Project settings -> your web app -> SDK setup.
+          #
+          # If a future environment ever needs the client to talk to a different
+          # project than the deploy targets, or Firebase changes those suffixes,
+          # that is the point to introduce explicit variables -- with the split
+          # visible here rather than implied by a duplicate.
+          VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_PROJECT_ID: ${{ vars.FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.FIREBASE_PROJECT_ID }}.firebaseapp.com
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ vars.FIREBASE_PROJECT_ID }}.firebasestorage.app
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ vars.VITE_FIREBASE_APP_ID }}
+          VITE_FIREBASE_MEASUREMENT_ID: ${{ vars.VITE_FIREBASE_MEASUREMENT_ID }}
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}

--- a/docs/runbooks/alpha-milestone-0.md
+++ b/docs/runbooks/alpha-milestone-0.md
@@ -134,14 +134,33 @@ browsers is not stored as if it were confidential.
 
 | Name | Kind | Value |
 | --- | --- | --- |
-| `FIREBASE_PROJECT_ID` | Variable | The project ID from part 1. |
+| `FIREBASE_PROJECT_ID` | Variable | The project ID from part 1 — where the deploy *ships to*. |
 | `FIREBASE_DEPLOY_SERVICE_ACCOUNT` | **Secret** | The full service-account JSON, inline. |
+| `VITE_FIREBASE_API_KEY` | Variable | Firebase console → Project settings → your web app → SDK setup. Public by design. |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | Variable | Same panel. |
+| `VITE_FIREBASE_APP_ID` | Variable | Same panel. |
+| `VITE_FIREBASE_MEASUREMENT_ID` | Variable | Same panel. GA4; the app degrades cleanly without it. |
 | `VITE_SENTRY_DSN` | Variable | The DSN from part 2. Public by design. |
 | `SENTRY_ORG` | Variable | Org slug. |
 | `SENTRY_PROJECT` | Variable | Project slug. |
 | `SENTRY_AUTH_TOKEN` | **Secret** | The auth token from part 2. |
 
-- [ ] Set all six. **Scope matters more than it looks**: a job only receives an
+The `VITE_FIREBASE_*` values are the Firebase **client** config — what the built
+app talks to, as opposed to `FIREBASE_PROJECT_ID`, which is where the deploy
+ships. Only the four above are stored: the client's project ID, auth domain, and
+storage bucket are derived from `FIREBASE_PROJECT_ID` in `ci.yml` (Firebase names
+the latter two `<id>.firebaseapp.com` and `<id>.firebasestorage.app` by
+convention), so no value is written down twice and none can drift from the
+project actually being deployed to.
+
+They are inlined into the browser bundle at build time, so they must be set
+*before* the deploy that is meant to use them — setting them afterwards changes
+nothing until something rebuilds. Leaving them unset does not fail the deploy: it
+ships an app that loads and then dies on its first Auth call with
+`auth/invalid-api-key`. `bun run verify:client-config` runs in `predeploy` to
+turn that into a build failure instead.
+
+- [ ] Set all of them. **Scope matters more than it looks**: a job only receives an
       environment's variables and secrets if it declares that environment, and an
       environment-scoped `vars.*` lookup from a job that does not resolves to the
       empty string with no error. Setting these at repository scope instead

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -189,7 +189,7 @@ The alpha has exactly one hosted environment: the **production** Firebase projec
 bun run deploy
 ```
 
-`predeploy` (`bun run build && bun run verify:bundle`) runs first automatically — the same pattern `predev`/`prebuild` already use for sample generation — so `bun run deploy` alone is the whole pipeline: build, scan the output for secrets, then `firebase deploy --only hosting,firestore,storage --project "$FIREBASE_PROJECT_ID"`. Firestore rules/indexes and Storage rules deploy in that same command as the application; if either fails, the whole command exits non-zero and nothing ships out of step with what shipped before it.
+`predeploy` (`bun run build && bun run verify:bundle && bun run verify:client-config`) runs first automatically — the same pattern `predev`/`prebuild` already use for sample generation — so `bun run deploy` alone is the whole pipeline: build, scan the output for secrets, then `firebase deploy --only hosting,firestore,storage --project "$FIREBASE_PROJECT_ID"`. Firestore rules/indexes and Storage rules deploy in that same command as the application; if either fails, the whole command exits non-zero and nothing ships out of step with what shipped before it.
 
 This needs `FIREBASE_PROJECT_ID` and Google Application Default Credentials (`GOOGLE_APPLICATION_CREDENTIALS` pointing at a service-account key, exactly like `library:upload`) in the environment. `.env.example` documents both, and neither belongs in a real developer's `.env` — they exist only as CI secrets/variables (see below). A local run of `bun run deploy` is possible in principle (e.g. a break-glass rollback), but is not the normal path and is never exercised by a developer in the ordinary course of work.
 
@@ -204,7 +204,7 @@ That `environment:` declaration is load-bearing: a job that does not name an env
 Once the project and its secrets exist, `deploy`:
 
 1. Writes the `FIREBASE_DEPLOY_SERVICE_ACCOUNT` secret to a runner-local temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it (never committed, never logged).
-2. Runs `bun run deploy` with `VITE_RELEASE_SHA` pinned to `github.sha` — the exact commit being deployed. `predeploy` builds and re-runs `verify:bundle` against that build before `firebase deploy --only hosting,firestore,storage` ships it.
+2. Runs `bun run deploy` with `VITE_RELEASE_SHA` pinned to `github.sha` — the exact commit being deployed, alongside the `VITE_FIREBASE_*` client config that gets inlined into the bundle. `predeploy` builds and re-runs `verify:bundle` and `verify:client-config` against that build before `firebase deploy --only hosting,firestore,storage` ships it.
 3. Marks the release deployed in Sentry (`sentry-cli releases deploys … new --env alpha`), after the deploy succeeded so a release that never shipped is never recorded as live. Skipped when the Sentry variables are unset. See "Source maps and release registration" below.
 4. Installs Chromium and runs `bun run smoke:hosted` against `https://$FIREBASE_PROJECT_ID.web.app`. A failing smoke test fails the job — the deploy is not considered successful until it passes (PRD OPS-01).
 
@@ -212,7 +212,8 @@ Required GitHub Actions configuration, all of it scoped to the **`prod` environm
 
 | Name | Kind | Purpose |
 | --- | --- | --- |
-| `FIREBASE_PROJECT_ID` | Environment **variable** | The production project ID. Not sensitive. Consumed by the deploy step and the hosted smoke test's URL; it is *not* the job's `if:` gate — see above for why an environment-scoped variable cannot be one. |
+| `FIREBASE_PROJECT_ID` | Environment **variable** | The production project ID — the project `firebase deploy` ships *to*. Not sensitive. Consumed by the deploy step and the hosted smoke test's URL; it is *not* the job's `if:` gate — see above for why an environment-scoped variable cannot be one. |
+| `VITE_FIREBASE_API_KEY`, `VITE_FIREBASE_MESSAGING_SENDER_ID`, `VITE_FIREBASE_APP_ID`, `VITE_FIREBASE_MEASUREMENT_ID` | Environment **variables** | The Firebase *client* config (Firebase console → Project settings → your web app), read by `src/firebaseConfig.ts` and **inlined into the client bundle at build time**. Public by design — they ship to every browser, and are protected by security rules and API-key restrictions rather than secrecy. Only these four are stored: `VITE_FIREBASE_PROJECT_ID`, `VITE_FIREBASE_AUTH_DOMAIN`, and `VITE_FIREBASE_STORAGE_BUCKET` are derived from `FIREBASE_PROJECT_ID` in `ci.yml` by Firebase's naming convention, so one value is never written down twice. With them unset the build still succeeds and deploys, then fails in the browser with `auth/invalid-api-key`; `verify:client-config` exists to turn that into a build failure. |
 | `FIREBASE_DEPLOY_SERVICE_ACCOUNT` | Environment **secret** | Inline service-account JSON with Hosting, Firestore rules/indexes, and Storage rules deploy permissions. Distinct from any credential `library:upload`/CNT-000 uses, so the deploy pipeline's IAM scope doesn't have to match a different task's. |
 | `VITE_SENTRY_DSN` | Environment **variable** | The client DSN (`FND-001c`). **Public by design**: it ships in the client bundle, because a browser SDK cannot submit an event without it. It identifies an ingest endpoint and grants nothing else — the same standing as the Firebase Web API key. Stored as a variable, not a secret, so nothing pretends otherwise. |
 | `SENTRY_ORG` | Environment **variable** | Sentry organization slug. Not sensitive. |
@@ -222,6 +223,12 @@ Required GitHub Actions configuration, all of it scoped to the **`prod` environm
 ### Release SHA
 
 `app.config.ts` stamps the deployed git commit SHA into `import.meta.env.VITE_RELEASE_SHA` at build time (`src/release.ts` reads it, `src/components/ReleaseBadge.tsx` renders it). Resolution order: an explicit `VITE_RELEASE_SHA` (what the `deploy` job sets), then `GITHUB_SHA` (set automatically in every Actions run, including the unconditional `build` job), then `git rev-parse HEAD` for a local build, then the `"unknown"` sentinel if even `git` fails — stamping must never be able to block a build. `FND-001c` reads `RELEASE_SHA` to attach the release to every analytics and error event.
+
+### The client bundle carries a usable Firebase config
+
+`scripts/verify-client-config.mjs` is the mirror image of the secret scan below: that one fails when something private *is* in the bundle, this one fails when something public is *missing* from it. `src/firebaseConfig.ts` reads `import.meta.env.VITE_FIREBASE_*`, which Vite inlines at build time; with those unset outside mock mode every field becomes `undefined`, the build still succeeds, the secret scan still passes, and `firebase deploy` still reports success — then the first Auth call in the browser throws `auth/invalid-api-key` and the app renders its error boundary instead of the page.
+
+That is exactly what shipped on `d65077c`, where a fully green deploy put an app live that could not start a session; the post-deploy smoke test was the only thing that caught it, after the fact. A missing build-time constant is a build defect, so `predeploy` now fails on it before `firebase deploy` runs. The check asserts the presence and shape of the four fields whose absence breaks startup (`apiKey`, `authDomain`, `projectId`, `appId`) — it cannot tell a valid key from a revoked one, which remains the smoke test's job.
 
 ### No secret reaches the client bundle
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
 		"check:ci": "tsc --noEmit && biome check",
 		"verify:bundle": "node scripts/verify-no-secrets-in-bundle.mjs",
 		"verify:budget": "node scripts/verify-bundle-budget.mjs",
-		"predeploy": "bun run build && bun run verify:bundle",
+		"verify:client-config": "node scripts/verify-client-config.mjs",
+		"predeploy": "bun run build && bun run verify:bundle && bun run verify:client-config",
 		"deploy": "firebase deploy --only hosting,firestore,storage --non-interactive --project \"$FIREBASE_PROJECT_ID\"",
 		"smoke:hosted": "playwright test --config=playwright.smoke.config.ts"
 	},

--- a/scripts/verify-client-config.mjs
+++ b/scripts/verify-client-config.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+//
+// Fails the build when the deployed client bundle carries no Firebase client
+// configuration.
+//
+// Why this exists: `src/firebaseConfig.ts` reads `import.meta.env.VITE_FIREBASE_*`
+// and falls back to `undefined` outside mock mode, so a build with those
+// variables unset succeeds, passes `verify:bundle`, and deploys cleanly -- and
+// then every Auth call fails in the browser with `auth/invalid-api-key`,
+// rendering the app's error boundary instead of the page. That happened on
+// d65077c: the deploy job reported success and shipped an app that could not
+// start a session. Only the post-deploy smoke test caught it, after the broken
+// build was already live.
+//
+// A missing build-time constant is a build defect, not a runtime one, so it
+// should fail before `firebase deploy` runs rather than after. This runs in
+// `predeploy` (see package.json), between `build` and `verify:bundle`.
+//
+// Deliberately narrow: it asserts the *presence and shape* of values Vite
+// inlined into the bundle. It cannot tell a valid API key from a revoked one --
+// that is the post-deploy smoke test's job, and the two are complementary.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const BUILD_DIR = ".output/public";
+
+// Only the fields whose absence breaks app startup. `databaseURL` (unused, the
+// project has no Realtime Database) and `measurementId` (analytics-only, and
+// the app degrades cleanly without it) are deliberately not required.
+const REQUIRED = [
+	{ key: "apiKey", pattern: /^AIza[\w-]{35}$/ },
+	{ key: "authDomain", pattern: /\.firebaseapp\.com$/ },
+	{ key: "projectId", pattern: /^[a-z0-9-]+$/ },
+	{ key: "appId", pattern: /^\d+:\d+:web:[a-f0-9]+$/ },
+];
+
+function collectJsFiles(dir) {
+	const out = [];
+	for (const entry of readdirSync(dir)) {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) out.push(...collectJsFiles(path));
+		else if (entry.endsWith(".js")) out.push(path);
+	}
+	return out;
+}
+
+let files;
+try {
+	files = collectJsFiles(BUILD_DIR);
+} catch {
+	console.error(
+		`verify-client-config: cannot read "${BUILD_DIR}". Run \`bun run build\` first.`,
+	);
+	process.exit(1);
+}
+
+// Vite inlines `import.meta.env.X` as a literal, so the built config object
+// reads `apiKey:"AIza..."` when set and `apiKey:void 0` when not. Scan every
+// chunk: which one holds the config depends on how the bundler split it.
+const haystack = files.map((f) => readFileSync(f, "utf8")).join("\n");
+
+const failures = [];
+for (const { key, pattern } of REQUIRED) {
+	const match = haystack.match(new RegExp(`${key}\\s*:\\s*"([^"]*)"`));
+	if (!match) {
+		failures.push(
+			`${key}: not present in the bundle (built as \`undefined\` -- VITE_FIREBASE_${key
+				.replace(/([A-Z])/g, "_$1")
+				.toUpperCase()} was unset at build time)`,
+		);
+	} else if (!pattern.test(match[1])) {
+		failures.push(`${key}: present but malformed (does not match ${pattern})`);
+	}
+}
+
+if (failures.length > 0) {
+	console.error(
+		`verify-client-config: the built client in "${BUILD_DIR}" has no usable Firebase configuration.\n`,
+	);
+	for (const failure of failures) console.error(`  - ${failure}`);
+	console.error(
+		"\nThis build would deploy successfully and then fail in the browser with\n" +
+			"`auth/invalid-api-key`. Set the VITE_FIREBASE_* variables on the `prod`\n" +
+			'GitHub environment (see docs/testing.md "Deploy"), then rebuild.\n' +
+			"Note that a job only receives an environment's variables if it declares\n" +
+			"`environment: prod`.",
+	);
+	process.exit(1);
+}
+
+console.log(
+	`verify-client-config: Firebase client configuration present in "${BUILD_DIR}".`,
+);


### PR DESCRIPTION
## What happened

The deploy on `d65077c` was **fully green and shipped a broken app**. Hosting, Firestore rules, Sentry release registration — all succeeded. But the deployed bundle contained:

```js
apiKey:void 0     // i.e. undefined
```

None of the `VITE_FIREBASE_*` client values were set on the `prod` environment, and `ci.yml` did not pass them to the build. `src/firebaseConfig.ts` falls back to `undefined` outside mock mode, so `initializeApp` got nothing and the first Auth call threw `auth/invalid-api-key`. The app rendered its error boundary instead of the dashboard.

Reproduced directly against the live site: clicking "Start in your browser" navigates to `/dashboard` and shows **"Something went wrong — Firebase: Error (auth/invalid-api-key)"**. The `<h1>Projects</h1>` the smoke test waits for never mounts.

**The smoke test was correct.** It caught a genuinely broken deployment, so this fixes the deployment, not the test. `e2e-hosted/smoke.spec.ts` is unchanged.

## Fix

**1. Pass the client config to the build**, deriving what can be derived rather than duplicating it:

| Variable | Source |
| --- | --- |
| `VITE_FIREBASE_PROJECT_ID` | `vars.FIREBASE_PROJECT_ID` |
| `VITE_FIREBASE_AUTH_DOMAIN` | `${{ vars.FIREBASE_PROJECT_ID }}.firebaseapp.com` |
| `VITE_FIREBASE_STORAGE_BUCKET` | `${{ vars.FIREBASE_PROJECT_ID }}.firebasestorage.app` |
| `VITE_FIREBASE_API_KEY`, `_MESSAGING_SENDER_ID`, `_APP_ID`, `_MEASUREMENT_ID` | `prod` environment variables |

The first three are the same value the deploy already targets (Firebase names the latter two by fixed convention), so storing them again would only create room for the client to drift from the project being deployed to. The remaining four are independent identifiers and are stored. Verified the derived strings match what the Firebase API reports for the web app exactly.

**2. `verify:client-config` now runs in `predeploy`.** A missing build-time constant is a build defect, but nothing caught this one — build succeeded, secret scan passed, deploy reported success. The new check fails the build before `firebase deploy` runs. It asserts presence and shape of the four fields whose absence breaks startup; it deliberately cannot tell a valid key from a revoked one, which stays the smoke test's job. The two are complementary.

## Evidence

- **Catches the real bug**: run against the actual broken bundle downloaded from `groove-35c07.web.app`, it exits 1 and names all four missing variables.
- **Passes a correct build**: full local `bun run build` with the production values, then `verify:client-config` passes and the bundle contains `authDomain:"groove-35c07.firebaseapp.com"`, `projectId:"groove-35c07"`, `storageBucket:"groove-35c07.firebasestorage.app"`, and a real `apiKey`.
- **No secret-scan regression**: `verify:bundle` still passes on that build — these public-by-design values are correctly not flagged.
- `bun run check:ci` clean (437 files). `bun run test` — **2000 tests passed across 148 files**.

## UI walkthrough

No source change to the app itself — CI config, a build-time check, and docs. The user-visible effect is that `https://groove-35c07.web.app/dashboard` stops rendering the error boundary once this deploys. Before/after against the live site:

- **Before** (`d65077c`, live now): "Something went wrong — Firebase: Error (auth/invalid-api-key)"
- **After**: the dashboard renders, which the hosted smoke test asserts as part of the deploy job.

## Note

The `prod` environment variables are already set, so this takes effect on merge. The env-var change alone would fix the site; the `predeploy` check is what stops it recurring silently.

Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)