### PR TITLE
Add CONTRIBUTING.md as the local development guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,15 +17,16 @@ VITE_FIREBASE_MEASUREMENT_ID=
 # Firebase. Useful for local UI development without a Firebase project.
 # VITE_MOCK_BACKEND=true
 
-# --- Local Firebase Emulator (FND-009; docs/testing.md "Browser E2E suite
-# against the Firebase Emulator") -------------------------------------------
+# --- Local Firebase Emulator (FND-009) --------------------------------------
 # Points the *real* Firebase SDK at a local Firestore/Auth emulator instead of
 # either production or the in-memory mock above -- distinct from
 # VITE_MOCK_BACKEND, and what proves persistence across a real page reload.
 # `bun run test:browser:emulator` sets both automatically from the running
-# emulator; only set these by hand to point a manual `bun run dev` at an
-# emulator you started yourself (`firebase emulators:start --only
-# firestore,auth --project demo-solid-groove`). Never set in a deployment.
+# emulator; set them by hand to point a manual `bun run dev` at an emulator you
+# started yourself. Doing that also needs VITE_FIREBASE_PROJECT_ID / _API_KEY /
+# _APP_ID set to any non-empty values, since the placeholder fallbacks above
+# apply only in mock mode. CONTRIBUTING.md, "Running against the Firebase
+# Emulator", has the whole recipe. Never set in a deployment.
 # VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
 # VITE_AUTH_EMULATOR_HOST=127.0.0.1:9099
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ bun run test:browser:emulator  # Browser E2E suite against a local Firestore/Aut
 bun run test:browser:install  # One-time: download Playwright's browser binaries
 ```
 
-See [`docs/testing.md`](./docs/testing.md) for what each suite covers, how CI gates on them, and the shared test helpers (`src/shared/id.ts`, `src/shared/clock.ts`, `src/testing/fixtures.ts`).
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for local setup, the three backends the app can run against (mock, Firebase Emulator, real project), and the day-to-day loop; [`docs/testing.md`](./docs/testing.md) for what each suite covers, how CI gates on them, and the shared test helpers (`src/shared/id.ts`, `src/shared/clock.ts`, `src/testing/fixtures.ts`).
 
 ## Code Style Guidelines
 
@@ -342,33 +342,13 @@ See [`docs/testing.md`](./docs/testing.md) for what each suite covers, how CI ga
 - Use `src/shared/id.ts`'s `createId`/`createSeededIdFactory` for entity IDs and `src/shared/clock.ts`'s `Clock` for anything that needs the current time, rather than calling `nanoid()`/`Date.now()` directly, so tests can be deterministic
 - Use `src/testing/fixtures.ts`'s builders (`buildProject`, `buildTrack`, ...) instead of hand-writing fixture literals in new tests
 
-### Set up a null ALSA device before running tests that touch an `AudioContext`
+### `bun run test` needs an audio output device
 
-**Do this once per machine/container before `bun run test`.** Importing `tone` creates a real (non-offline) global `AudioContext` as a side effect, and `node-web-audio-api`'s `cpal` backend refuses to create one when the host has no default output device. Containers, CI runners, and headless VMs have no `/dev/snd`, so any suite that reaches Tone (e.g. `src/audio/ToneInstrument.test.ts`) fails at import time with:
+Importing `tone` creates a real global `AudioContext`, and `node-web-audio-api`'s `cpal` backend refuses to create one on a host with no default output device (containers, CI runners, headless VMs), so any suite that reaches Tone fails at import time with `InvalidStateError: cpal backend error during default_output_config: DeviceUnavailable`.
 
-```
-InvalidStateError: cpal backend error during default_output_config: DeviceUnavailable
-```
+That is an environment problem, not a test bug — **do not "fix" it by mocking Tone, skipping the file, or editing `src/audio/testAudioContext.ts`.** Set up a null ALSA device instead; [`CONTRIBUTING.md`](./CONTRIBUTING.md#a-null-alsa-device-on-machines-with-no-audio-hardware) has the exact steps.
 
-That is an environment problem, not a test bug — do not "fix" it by mocking Tone, skipping the file, or editing `src/audio/testAudioContext.ts`. Point ALSA's default PCM at its built-in `null` device instead (it discards every sample and needs no audio hardware and no `snd-dummy` kernel module):
-
-```bash
-# Only if the ALSA runtime library is missing (check: dpkg -l libasound2t64)
-sudo apt-get update && sudo apt-get install -y libasound2t64
-
-cat > "$HOME/.asoundrc" <<'EOF'
-pcm.!default {
-    type null
-}
-ctl.!default {
-    type null
-}
-EOF
-```
-
-Use `/etc/asound.conf` (same contents) instead when the suite runs as a different user than the one whose `$HOME` you wrote to. A machine with real audio hardware needs none of this. `.github/workflows/ci.yml`'s `checks` job runs exactly these steps before `bun run test`; see [`docs/testing.md`](./docs/testing.md#unit-and-component-tests) for the full background.
-
-**This applies to `bun run test` only — not to the browser suites.** The problem it solves is specific to `node-web-audio-api` under Node, whose `cpal` backend refuses to *construct* a context without a default output device. A real browser constructs one regardless: in the emulator browser suite, Firefox reports a fresh `AudioContext` at `state="suspended"` on a runner with no `/dev/snd` at all. So if a *browser* test fails around audio, a null ALSA device will not help and its absence is not the cause — this exact wrong turn has already cost a CI round. See [`docs/testing.md`](./docs/testing.md#playback-is-asserted-in-chromium-only--a-known-tracked-gap) for what is actually known about that failure, and `LOOP-003` (#43) for the product-side gap behind it.
+**It applies to `bun run test` only — not the browser suites.** A real browser constructs a context regardless: Firefox reports `state="suspended"` on a runner with no `/dev/snd` at all. So if a *browser* test fails around audio, a null ALSA device will not help and its absence is not the cause — this exact wrong turn has already cost a CI round. See [`docs/testing.md`](./docs/testing.md#playback-is-asserted-in-chromium-only--a-known-tracked-gap), and `LOOP-003` (#43) for the product-side gap behind it.
 
 ## Important Configuration Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,252 @@
+# Contributing to Solid Groove
+
+How to get the app running locally, which backend to run it against, and the
+day-to-day loop of checks before you open a pull request.
+
+| You want to | Read |
+| --- | --- |
+| Get the app running | "Setup" and "Running the app" below |
+| Drive the app by hand against a real backend | "Running against the Firebase Emulator" below |
+| Know which test suite covers what, and how CI gates | [`docs/testing.md`](./docs/testing.md) |
+| Know the stack, code style, and architecture boundaries | [`CLAUDE.md`](./CLAUDE.md) |
+| Know what to build and what "done" means | [`docs/prd.md`](./docs/prd.md) and the [GitHub issues](https://github.com/afternoon/solid-groove/issues) |
+
+## Setup
+
+```sh
+bun install
+cp .env.example .env
+```
+
+This project uses **Bun** as its package manager and runtime. Never run
+`npm install` — `package-lock.json` conflicts with Bun's resolution and is
+gitignored for that reason.
+
+What you put in `.env` depends on which backend you want; see the next section.
+`bun run dev` regenerates the starter sound library first (via `predev`), so the
+first run is slower than later ones.
+
+### Prerequisites by task
+
+| Doing this | Needs |
+| --- | --- |
+| Running the app, unit/component tests | Bun only |
+| Anything with the Firebase Emulator | A JDK (the emulator runs on the JVM) — CI installs Temurin 21 |
+| Browser E2E suites | `bun run test:browser:install` once, and outbound access to `cdn.playwright.dev` |
+| `bun run test` on a machine with no audio hardware | A null ALSA output device — see below |
+
+On macOS, `brew install openjdk@21` installs a JDK without needing `sudo`
+(unlike the Temurin cask). It is keg-only, so put it on your `PATH` for the
+shell that runs the emulator:
+
+```sh
+export PATH="$(brew --prefix openjdk@21)/bin:$PATH"
+```
+
+### A null ALSA device, on machines with no audio hardware
+
+Do this once per machine or container before `bun run test`. Importing `tone`
+creates a real (non-offline) global `AudioContext` as a side effect, and
+`node-web-audio-api`'s `cpal` backend refuses to create one when the host has no
+default output device. Containers, CI runners, and headless VMs have no
+`/dev/snd`, so any suite that reaches Tone fails at import time with:
+
+```
+InvalidStateError: cpal backend error during default_output_config: DeviceUnavailable
+```
+
+That is an environment problem, not a test bug — do not "fix" it by mocking
+Tone, skipping the file, or editing `src/audio/testAudioContext.ts`. Point
+ALSA's default PCM at its built-in `null` device instead, which discards every
+sample and needs neither audio hardware nor the `snd-dummy` kernel module:
+
+```bash
+# Only if the ALSA runtime library is missing (check: dpkg -l libasound2t64)
+sudo apt-get update && sudo apt-get install -y libasound2t64
+
+cat > "$HOME/.asoundrc" <<'EOF'
+pcm.!default {
+    type null
+}
+ctl.!default {
+    type null
+}
+EOF
+```
+
+Use `/etc/asound.conf` (same contents) when the suite runs as a different user
+than the one whose `$HOME` you wrote to. A machine with real audio hardware
+needs none of this, and `.github/workflows/ci.yml`'s `checks` job runs exactly
+these steps.
+
+**This applies to `bun run test` only — not to the browser suites.** The problem
+is specific to `node-web-audio-api` under Node, whose `cpal` backend refuses to
+*construct* a context without a default output device. A real browser constructs
+one regardless: in the emulator browser suite, Firefox reports a fresh
+`AudioContext` at `state="suspended"` on a runner with no `/dev/snd` at all. So
+if a *browser* test fails around audio, a null ALSA device will not help and its
+absence is not the cause — this exact wrong turn has already cost a CI round.
+See [`docs/testing.md`](./docs/testing.md#playback-is-asserted-in-chromium-only--a-known-tracked-gap)
+for what is actually known about that failure.
+
+## Running the app
+
+There are three backends you can run against. They are selected entirely by
+environment variables — the application code is identical in all three.
+
+| Mode | Backend | Use it for |
+| --- | --- | --- |
+| **Mock** | In-memory fake, never touches the Firebase SDK | Everyday UI work. No Firebase project, no emulator, no JDK. |
+| **Emulator** | The *real* Firebase SDK against a local Firestore + Auth emulator | Anything touching persistence, auth, or security rules |
+| **Real project** | A Firebase project you own | Rarely needed; the alpha's only hosted environment is production |
+
+### Mock backend (the default for UI work)
+
+Set `VITE_MOCK_BACKEND=true` in `.env`, then:
+
+```sh
+bun run dev     # http://localhost:3000
+```
+
+Every page load gets a fresh, empty store, so this mode **cannot** show you
+anything about persistence — a reload always starts over. That is the one thing
+it is structurally unable to prove, and the reason the emulator mode below
+exists.
+
+### Running against the Firebase Emulator
+
+This points the real Firebase SDK at a local Firestore + Auth emulator, so a
+genuine page reload round-trips through real persistence and real security
+rules. It is distinct from `VITE_MOCK_BACKEND`, which swaps in a fake instead.
+
+Start the emulator in one terminal and leave it running:
+
+```sh
+firebase emulators:start --only firestore,auth --project demo-solid-groove
+```
+
+The `demo-` project-ID prefix is Firebase's convention for emulator-only work:
+no real GCP project, no login, and no credentials are involved, and the CLI
+refuses to reach any non-emulated service for it.
+
+Then start the dev server in a second terminal, pointed at it:
+
+```sh
+VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 \
+VITE_AUTH_EMULATOR_HOST=127.0.0.1:9099 \
+VITE_FIREBASE_PROJECT_ID=demo-solid-groove \
+VITE_FIREBASE_API_KEY=demo-key \
+VITE_FIREBASE_APP_ID=demo-app \
+bun run dev
+```
+
+Open <http://localhost:3000>, click "Start in your browser", and you are an
+anonymous Firebase user in the emulator. Create a project, edit it, and reload
+the page — the edit comes back from Firestore.
+
+Some notes on the recipe, each of which is a real trap:
+
+- **`VITE_MOCK_BACKEND` must not be `true`.** Leave it unset or set it to
+  anything else; the code tests for the exact string `"true"`. If you have it
+  set in `.env` for everyday work, override it on the command line.
+- **The three `VITE_FIREBASE_*` values are required, and their contents do not
+  matter.** `src/firebaseConfig.ts` only substitutes placeholder values in mock
+  mode, so outside it `initializeApp` receives `undefined` and fails. Any
+  non-empty strings work against an emulator.
+- **Use `127.0.0.1`, not `localhost`.** Both emulators listen on `127.0.0.1`
+  only, so on a host where `localhost` resolves to `::1` first the connection is
+  refused. This is also the form `firebase.json` and the Playwright emulator
+  config use.
+- **The Emulator UI is off.** `firebase.json` sets `emulators.ui.enabled` to
+  `false`. To browse the data, either flip that flag or query the emulator's
+  REST API directly with the owner bearer token, which bypasses security rules:
+
+  ```sh
+  curl -s -H "Authorization: Bearer owner" \
+    "http://127.0.0.1:8080/v1/projects/demo-solid-groove/databases/(default)/documents/projects"
+  ```
+
+  Without that header the request is subject to `firestore.rules` and is
+  correctly denied — a `PERMISSION_DENIED` from plain `curl` means the rules are
+  working, not that the write failed.
+- **Emulator data is in memory.** Stopping the emulator discards everything. Use
+  `--import`/`--export-on-exit` if you want a scenario to survive a restart.
+- **The first project you open is slow.** Vite pre-bundles `tone` when the
+  editor first mounts, which force-reloads the page. Give the first
+  dashboard→editor navigation a few seconds before concluding something is
+  broken; see [`docs/testing.md`](./docs/testing.md#why-this-suite-warms-the-dev-server-first).
+
+### Against a real Firebase project
+
+Fill in the `VITE_FIREBASE_*` values in `.env` from the Firebase console
+(Project Settings → General → Your apps) and run `bun run dev`. You rarely want
+this: the alpha's only hosted environment is production, deployment runs from CI
+rather than a developer machine, and the automated suites must never write to it
+(PRD `OPS-01`). Prefer the emulator.
+
+## The day-to-day loop
+
+```sh
+bun run dev            # dev server
+bun run test:watch     # unit + component tests, watching
+```
+
+Before pushing:
+
+```sh
+bun run check          # tsc --noEmit && biome check --write  (auto-fixes)
+bun run test           # unit + component suites
+```
+
+`bun run check` is the local form; CI runs `check:ci`, which is the same checks
+without `--write` so a violation fails loudly instead of being silently
+rewritten in the runner.
+
+Run the heavier suites when your change touches what they cover — browser,
+Firebase, audio, performance, or export behavior:
+
+```sh
+bun run test:emulator          # Firestore rules + repository contract
+bun run test:browser           # Playwright, mock backend
+bun run test:browser:emulator  # Playwright against a real (emulated) backend
+```
+
+Both emulator suites start and stop their own emulator via
+`firebase emulators:exec`, so do **not** have one already running on those ports
+when you launch them. [`docs/testing.md`](./docs/testing.md) is the reference for
+what each suite covers and how CI gates on them.
+
+### Other commands
+
+```sh
+bun run build          # production build
+bun run start          # serve a production build
+bun run clean          # delete build/dev caches and test output
+bun run library        # print the sound-library workflow and on-disk state
+```
+
+Reach for `bun run clean` when the dev server serves something that disagrees
+with your checkout — most recognisably, a route that matches but renders a blank
+page with no error in either the console or the terminal. Vite's pre-bundling
+cache lives inside `node_modules/` and survives `git checkout`, `bun install`,
+and dev-server restarts. [`docs/testing.md`](./docs/testing.md#bun-run-clean-and-the-stale-cache-failure-it-exists-for)
+has the full symptom list.
+
+## Opening a pull request
+
+The rules that govern scope, size, and landing order live in
+[`CLAUDE.md`](./CLAUDE.md#task-tracking-and-landing-work) — read that section
+before starting a task, not after. In short:
+
+- Work is tracked as **GitHub issues**; the issue is the specification and the
+  live record, and readiness is its native `blocked_by` graph.
+- A PR is **one reviewable unit of purpose** and at most **400 changed lines**.
+  A larger task ships as a stack of such PRs.
+- Tests for a slice ship **in the same PR** as that slice.
+- Any change that alters the UI includes a **walkthrough** in the PR body; see
+  [`.github/pull_request_template.md`](./.github/pull_request_template.md).
+- Don't edit `docs/prd.md` unless the task genuinely revises product behavior.
+
+The full definition of done, including the analytics and privacy requirements
+every user-facing change carries, is in
+[`CLAUDE.md`](./CLAUDE.md#definition-of-done-for-every-task).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Let's build it!
 
 | Document | What it covers |
 | --- | --- |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Local development: setup, running against mock/emulator/real backends, and the pre-PR checks |
 | [`CLAUDE.md`](./CLAUDE.md) | Stack, project structure, commands, and code style |
 | [`docs/prd.md`](./docs/prd.md) | Product requirements — authoritative for scope and acceptance criteria |
 | [GitHub issues](https://github.com/afternoon/solid-groove/issues) | Implementation tasks, dependencies, and per-task acceptance criteria (one issue per task). `CLAUDE.md` describes how work is tracked and landed |
@@ -27,11 +28,11 @@ Let's build it!
 
 ```sh
 bun install
-cp .env.example .env   # fill in your Firebase project's values
+cp .env.example .env
 bun run dev
 ```
 
-Without a Firebase project of your own, set `VITE_MOCK_BACKEND=true` in `.env` instead — the app runs entirely against in-memory mock services (the same mode the browser E2E suite uses), so local UI work needs no Firebase project at all.
+Set `VITE_MOCK_BACKEND=true` in `.env` to run against in-memory mock services, which needs no Firebase project at all. [`CONTRIBUTING.md`](./CONTRIBUTING.md) covers that and the other two backends — a local Firebase Emulator, or a real project — along with the day-to-day development loop.
 
 ## Deployment
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@
 
 Related documents: [Product requirements](./prd.md) ([9.1](./prd.md#91-committed-alpha-stack), [10](./prd.md#10-non-functional-requirements), [14](./prd.md#14-test-strategy-and-definition-of-done))
 
-This document is the map of "which suite do I run, and how." It does not restate `CLAUDE.md`'s stack/style conventions.
+This document is the map of "which suite do I run, and how." It does not restate `CLAUDE.md`'s stack/style conventions, and it is not the local setup guide — [`CONTRIBUTING.md`](../CONTRIBUTING.md) covers installing prerequisites, running the app against the mock backend or a local Firebase Emulator, and the pre-PR loop.
 
 ## Suites at a glance
 
@@ -33,7 +33,7 @@ Config: `vitest.config.ts`. `vite-plugin-solid` sets `test.environment: "jsdom"`
 
 `src/audio/InstrumentGraph.test.ts`, `src/audio/TrackAudioGraph.test.ts`, `src/audio/DeviceChain.test.ts`, and `src/audio/ProjectAudioGraph.test.ts` additionally render real audio via `node-web-audio-api` (see `src/audio/testAudioContext.ts`). Importing `tone` creates a real (non-offline) global `AudioContext` as a side effect, and `node-web-audio-api`'s `cpal` backend needs to find *some* default output device to satisfy that, even though the tests themselves only render through `Tone.Offline`. On a machine with no audio hardware (`/dev/snd` absent — every GitHub-hosted runner, most containers), that context creation throws `InvalidStateError: ... DeviceUnavailable` and the whole file fails before any test runs.
 
-`.github/workflows/ci.yml`'s `checks` job works around this without needing real hardware or a kernel module: it installs the ALSA runtime library (`libasound2t64`) and points `~/.asoundrc` at ALSA's built-in `null` PCM as the default output device (discards every sample, touches no hardware). That gives `cpal` a device to find. Running the same suite locally on a machine with no audio device needs the same `~/.asoundrc` (see the CI step for the exact config) — machines with real audio hardware need no workaround.
+`.github/workflows/ci.yml`'s `checks` job works around this without needing real hardware or a kernel module: it installs the ALSA runtime library (`libasound2t64`) and points `~/.asoundrc` at ALSA's built-in `null` PCM as the default output device (discards every sample, touches no hardware). That gives `cpal` a device to find. Running the same suite locally on a machine with no audio device needs the same `~/.asoundrc` — [`CONTRIBUTING.md`](../CONTRIBUTING.md#a-null-alsa-device-on-machines-with-no-audio-hardware) has the exact config to copy. Machines with real audio hardware need no workaround.
 
 These suites always dispose the instrument/graph they build once the offline render resolves. Without that, repeated back-to-back offline renders in the same process left native audio nodes bound to torn-down `OfflineAudioContext`s undisposed, which showed up as rare, wildly out-of-range sample values (filter-energy assertions occasionally comparing against values like `1e30`) once the suite could actually run past context creation. Always dispose the built instrument/graph after consuming its rendered buffer in new tests that follow this pattern.
 


### PR DESCRIPTION
1 of 2. Supersedes #164, which shared a branch with the follow-up and so could not show its own diff. #170 stacks on this.

## What

Adds `CONTRIBUTING.md` as the entry point for local development, and documents the one workflow that had no written instructions anywhere: **driving the app by hand against the Firebase Emulator**.

`docs/testing.md` covered the two automated emulator suites (`test:emulator`, `test:browser:emulator`), both of which start and stop their own emulator. Neither helps when you want to click around the real app against real persistence and real security rules. The README offered only a real Firebase project or the mock backend, and the mock is structurally unable to show anything about persistence, since every page load gets a fresh empty store.

## The recipe is verified, not inferred

I ran it end to end rather than deriving it from `playwright.emulator.config.ts`: started the emulator, ran the dev server against it, signed in anonymously (user appeared in the Auth emulator), created a project, toggled a step, confirmed the notes reached the Firestore clip document, then **reloaded the page and saw the edit come back**. That last step is the one the mock backend cannot prove.

Traps the exercise surfaced, all documented:

- The three `VITE_FIREBASE_*` values are required outside mock mode and their contents don't matter — `initializeApp` otherwise receives `undefined`. My first answer to the user omitted this.
- The Emulator UI is disabled in `firebase.json`, so browsing data means the REST API with the owner bearer token.
- A plain `curl` against that API returns `PERMISSION_DENIED` — that is `firestore.rules` working, not a failed write.
- `127.0.0.1`, not `localhost`: both emulators listen on the IPv4 loopback only (confirmed with `lsof`).

**#170 removes the first two of those traps outright** by making emulator mode imply its own configuration, so they stop being things a developer has to know.

## Duplication removed

- **The null-ALSA setup block** was verbatim in `CLAUDE.md`, while `docs/testing.md` explained the reasoning and deferred the actual config to "see the CI step" — so the copy-pasteable steps existed in exactly one place, and it wasn't the testing doc. The steps now live in `CONTRIBUTING.md` and both files link to them. `CLAUDE.md` keeps the two warnings that are load-bearing for an agent: don't "fix" the error by mocking Tone, and it does not apply to the browser suites.
- **README getting-started** no longer restates the mock-backend explanation.
- **`.env.example`**'s emulator block pointed at a partial command; it now points at the full recipe.

`docs/testing.md` remains the suite-and-CI reference and now says so explicitly, so the two documents frame each other instead of overlapping.

## UI walkthrough

No user-visible change — documentation and `.env.example` comments only.

## Evidence

- `bun run check` — clean.
- `src/shortcuts/docs.test.ts` — 6/6 (the docs-drift gate).
- All internal markdown links and anchors across the touched files resolve, checked with a script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)