### PR TITLE
Start error monitoring in a tab that never paints (#174)

### DIFF
--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -551,6 +551,25 @@ describe("afterFirstPaint", () => {
 		afterFirstPaint(after);
 		await vi.waitFor(() => expect(after).toHaveBeenCalled());
 	});
+
+	// `FND-001c` (#174): a background tab never paints, so
+	// `requestAnimationFrame` is not called until it is foregrounded -- which
+	// may be never. Gating monitoring on a frame meant a session opened in a
+	// background tab (a restored window, a middle-click, a deep link opened
+	// behind the current page) loaded no SDK at all and reported no crash.
+	// The idle callback is what must still get there.
+	it("runs the task in a tab that never paints", async () => {
+		const rafSpy = vi
+			.spyOn(globalThis, "requestAnimationFrame")
+			.mockImplementation(() => 0);
+		try {
+			const task = vi.fn();
+			afterFirstPaint(task);
+			await vi.waitFor(() => expect(task).toHaveBeenCalled());
+		} finally {
+			rafSpy.mockRestore();
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -238,6 +238,31 @@ export function initTelemetry(options: InitTelemetryOptions): Telemetry {
 }
 
 /**
+ * Why monitoring is not running, recorded on the page for diagnosis.
+ *
+ * `FND-001c` (#174): the three ways this can fail — no DSN, a vendor import
+ * that never resolves, an `init()` that throws — all failed *silently and
+ * identically*, so a deployed build that was not reporting errors could not be
+ * told apart from one that had nothing to report. That indistinguishability is
+ * what made the original defect take a full investigation to place.
+ *
+ * It must still fail *open*: a blocked SDK is an expected, correct outcome for
+ * some sessions (ADR 0001), so this records a status rather than surfacing
+ * anything to the user or reporting anywhere. It carries no user data — only
+ * which branch was taken.
+ */
+type MonitoringStatus = "started" | "no-dsn" | "load-failed";
+
+function recordMonitoringStatus(status: MonitoringStatus): void {
+	try {
+		(globalThis as { __sgMonitoring?: MonitoringStatus }).__sgMonitoring =
+			status;
+	} catch {
+		// Diagnosis is best-effort and must never be the thing that breaks startup.
+	}
+}
+
+/**
  * Loads the Sentry sink and attaches it to the reporting boundary.
  *
  * The dynamic `import()` is what keeps the SDK out of the entry chunk, so it
@@ -255,8 +280,14 @@ async function startMonitoring(
 		const { SentrySink } = await import("./monitoring/sentrySink");
 		const sink = new SentrySink({ release: RELEASE_SHA });
 		const started = await sink.start();
-		if (!started) return async () => {};
+		if (!started) {
+			// `SentrySink.start()` resolves false only when no DSN is configured;
+			// every other failure throws and lands in the catch below.
+			recordMonitoringStatus("no-dsn");
+			return async () => {};
+		}
 		reporter.addSink(sink);
+		recordMonitoringStatus("started");
 		return async () => {
 			reporter.removeSink(sink);
 			await sink.stop();
@@ -265,6 +296,7 @@ async function startMonitoring(
 		// A blocked or failed SDK load is expected for some sessions (ADR 0001:
 		// "Ad and tracker blockers block sentry.io"). Errors still reach the GA4
 		// `exception` counter, and the resulting undercount is documented.
+		recordMonitoringStatus("load-failed");
 		return async () => {};
 	}
 }
@@ -275,13 +307,49 @@ async function startMonitoring(
  * Two nested `requestAnimationFrame` callbacks land after the first paint has
  * been committed; `requestIdleCallback` then waits for the main thread to be
  * free, with a timeout so a permanently busy thread does not starve it.
+ *
+ * ## A tab that never paints must still get there (`FND-001c`, #174)
+ *
+ * `requestAnimationFrame` does not fire while a document is hidden, and a tab
+ * can start that way and stay that way indefinitely — a restored window, a
+ * middle-clicked link, a deep link opened behind the current page. Waiting on
+ * a frame alone meant such a session loaded no monitoring SDK *at all*: the
+ * sink chunk was never even fetched, so a crash in front of a real user went
+ * unreported, and the whole thing looked like a configuration failure from
+ * outside because every documented gate had passed.
+ *
+ * So the frame path is *raced* against an idle deadline rather than trusted as
+ * the only route. Whichever arrives first wins and the other is ignored; on a
+ * visible tab that is still the frame path, so the "after first paint" budget
+ * (PRD section 10) is unchanged for the sessions it was written for.
  */
 export function afterFirstPaint(task: () => void): void {
+	let done = false;
 	const run = () => {
+		if (done) return;
+		done = true;
 		try {
 			task();
 		} catch {
 			// Telemetry startup must never break the app that just painted.
+		}
+	};
+
+	const idle = (
+		globalThis as {
+			requestIdleCallback?: (
+				cb: () => void,
+				options?: { timeout: number },
+			) => number;
+		}
+	).requestIdleCallback;
+
+	/** Waits for a free main thread, but never longer than the timeout. */
+	const whenIdle = () => {
+		if (typeof idle === "function") {
+			idle(run, { timeout: 3_000 });
+		} else {
+			setTimeout(run, 0);
 		}
 	};
 
@@ -291,22 +359,14 @@ export function afterFirstPaint(task: () => void): void {
 	}
 
 	requestAnimationFrame(() => {
-		requestAnimationFrame(() => {
-			const idle = (
-				globalThis as {
-					requestIdleCallback?: (
-						cb: () => void,
-						options?: { timeout: number },
-					) => number;
-				}
-			).requestIdleCallback;
-			if (typeof idle === "function") {
-				idle(run, { timeout: 3_000 });
-			} else {
-				setTimeout(run, 0);
-			}
-		});
+		requestAnimationFrame(whenIdle);
 	});
+
+	// The backstop for a document that is hidden now or becomes hidden before
+	// the second frame lands. Deliberately not a `visibilitychange` listener:
+	// the tab may never be foregrounded, and monitoring that only starts if the
+	// user happens to look at the page is not monitoring.
+	whenIdle();
 }
 
 /** Maps a pathname onto the surface it belongs to. */


### PR DESCRIPTION
Closes #174.

## The defect

`afterFirstPaint` gated the Sentry sink behind two nested `requestAnimationFrame` callbacks. **A hidden document never paints, so rAF never fires there** — and a tab can start hidden and stay hidden indefinitely: a restored window, a middle-clicked link, a deep link opened behind the current page. Such a session loaded no monitoring SDK at all — the sink chunk was never even fetched — so a crash in front of a real user went unreported.

## Why the issue's diagnosis pointed elsewhere

The report's three symptoms are all real, but they hold **only for a tab that is not in front**, which is why every documented gate passed and the cause looked like configuration. Checked on the deployed release `8336d9d` at `/dashboard`:

| | hidden tab | foreground tab |
|---|---|---|
| `window.__SENTRY__` | `undefined` | `object` |
| `sentrySink-*.js` fetched | no | yes |
| captured error → ingest | never sent | **HTTP 200** |

Measured directly in the hidden tab: `requestAnimationFrame` did **not** fire, `requestIdleCallback` **did**. That is the whole defect.

Two of the issue's suggested leads are falsified, and worth recording so nobody re-walks them:

- **The DSN does reach the sink chunk.** A production build inlines it into `sentrySink-*.js`; it appears in `devBackend-*.js` too because both chunks embed the same `import.meta.env` object. Not the cause.
- **Sentry is not broken on the deployed build.** In a foreground tab the full path — global handler → scrubber → sink → ingest — returns 200, and Release Health session envelopes were already flowing.

`performance.getEntriesByType('resource')` also lags on ingest requests, so it reports false negatives; a probe that trusts it can conclude "nothing was sent" when 200s are in flight. Worth knowing for the next investigation.

## The fix

The frame path is now **raced** against the idle deadline rather than trusted as the only route — first arrival wins, the other is ignored. A visible tab still starts on the frame path, so the PRD section 10 after-first-paint budget is unchanged for the sessions it was written for.

Also addresses the issue's "unfalsifiable from a deployed build" half: monitoring now records **why** it is not running (`started` / `no-dsn` / `load-failed`). Those three previously failed silently and identically, which is exactly what made a build that was not reporting errors indistinguishable from one with nothing to report. It still fails open (ADR 0001 — a blocked SDK is a correct outcome for some sessions) and carries no user data, only which branch was taken.

## Evidence

- **Test fails before, passes after.** `afterFirstPaint > runs the task in a tab that never paints` stubs rAF to never invoke its callback; it failed on the unmodified implementation and passes now. The two existing `afterFirstPaint` tests are untouched and still pass.
- **Verified in a real browser in the actual failing condition.** Production build served locally, loaded in a genuinely hidden tab where rAF provably never fired: `__sgMonitoring: "started"`, both chunks fetched, `window.__SENTRY__` live, and a dispatched uncaught error arrived at the sink transport as `FND-001c hidden-tab verification` alongside the session envelope.
- `bun run typecheck`, `bun run check`, `bun run test` (2011 tests, 149 files) all pass.
- `bun run test:browser`: 50 passed, 1 failed — `smoke.spec.ts` "starts from the keyboard, with visible focus" on **webkit**. **Pre-existing and unrelated**: it fails identically on unmodified `main` (verified by running that one test in the main checkout).

## User-visible change

None. This is startup wiring — no UI is added, removed, or restyled, so there is no walkthrough to record. The observable difference is that a session opened in a background tab now reports its crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)