### PR TITLE
LOOP-012 - Shared musical transformations (2 of 3): transformation panel

### DIFF
--- a/src/editor/TransformPanel.test.tsx
+++ b/src/editor/TransformPanel.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	clickTransform,
+	currentNotes,
+	pitches,
+	pitchOf,
+	setOption,
+	setUpTransformPanel as setUp,
+} from "./transformPanelHarness";
+
+afterEach(() => cleanup());
+
+/**
+ * What each of the six CLP-04 transformations does to a clip when the user
+ * clicks it. The history and analytics contract has its own suite
+ * (`TransformPanel.history.test.tsx`).
+ */
+describe("TransformPanel (CLP-04)", () => {
+	it("transposes the whole clip when nothing is selected", async () => {
+		const { session, renderPanel } = await setUp();
+		const before = pitches(session);
+		renderPanel([]);
+
+		clickTransform("Transpose");
+
+		expect(pitches(session)).toEqual(before.map((pitch) => pitch + 12));
+	});
+
+	it("transposes only the selected notes", async () => {
+		const { session, renderPanel } = await setUp();
+		const before = new Map(
+			currentNotes(session).map((event) => [event.id, pitchOf(event)]),
+		);
+		const target = currentNotes(session)[0];
+		renderPanel([target.id]);
+
+		clickTransform("Transpose");
+
+		// The selected note moved by the panel's semitone value; every other note
+		// is exactly where it was.
+		for (const event of currentNotes(session)) {
+			const expected = before.get(event.id) ?? -1;
+			expect(pitchOf(event)).toBe(
+				event.id === target.id ? expected + 12 : expected,
+			);
+		}
+	});
+
+	it("scales velocity through the shared command, clamping at the range end", async () => {
+		const { session, renderPanel } = await setUp();
+		renderPanel([]);
+
+		clickTransform("Velocity");
+
+		for (const event of currentNotes(session)) {
+			expect(event.velocity).toBeLessThanOrEqual(1);
+			expect(event.velocity).toBeGreaterThan(0);
+		}
+	});
+
+	it("quantizes onto the 16th grid", async () => {
+		const { session, renderPanel } = await setUp();
+		renderPanel([]);
+
+		clickTransform("Quantize");
+
+		for (const event of currentNotes(session)) {
+			expect(event.startTicks % 48).toBe(0);
+		}
+	});
+
+	it("duplicates every note in scope", async () => {
+		const { session, renderPanel } = await setUp();
+		const before = currentNotes(session).length;
+		renderPanel([]);
+
+		clickTransform("Duplicate");
+
+		expect(currentNotes(session)).toHaveLength(before * 2);
+	});
+
+	it("clears every note in the clip", async () => {
+		const { session, renderPanel } = await setUp();
+		renderPanel([]);
+
+		clickTransform("Clear");
+
+		expect(currentNotes(session)).toHaveLength(0);
+	});
+
+	it("disables every transformation when the clip has no notes", async () => {
+		const { session, renderPanel } = await setUp();
+		renderPanel([]);
+		clickTransform("Clear");
+		cleanup();
+		renderPanel([]);
+
+		expect(currentNotes(session)).toHaveLength(0);
+		for (const button of screen.getAllByRole("button")) {
+			expect(button).toBeDisabled();
+		}
+	});
+
+	it("surfaces a boundary rejection instead of clamping the notes", async () => {
+		const { session, renderPanel } = await setUp();
+		const before = pitches(session);
+		renderPanel([]);
+
+		// The fixture's top note is C5; repeated +24 transposes eventually leave
+		// the 0-127 range, and the command refuses rather than clamping.
+		setOption("Semitones", "24");
+		for (let index = 0; index < 4; index += 1) clickTransform("Transpose");
+
+		expect(screen.getByRole("alert").textContent).not.toBe("");
+		// The refused transformation left every note where the last accepted one
+		// put it: nothing was clamped to the edge of the range.
+		expect(pitches(session).every((pitch) => pitch <= 127)).toBe(true);
+		expect(pitches(session)).not.toEqual(before);
+	});
+});

--- a/src/editor/TransformPanel.tsx
+++ b/src/editor/TransformPanel.tsx
@@ -1,0 +1,187 @@
+import { createMemo, createSignal, For, type JSX } from "solid-js";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
+import { bucketOf } from "../analytics/buckets";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import type { Clip, Project } from "../domain/entities";
+import { createFactoryContext } from "../domain/factories";
+import type { EventId } from "../domain/ids";
+import {
+	buildTransform,
+	canTransform,
+	DEFAULT_TRANSFORM_OPTIONS,
+	resolveTransformScope,
+	TRANSFORM_KINDS,
+	TRANSFORM_LABELS,
+	type TransformKind,
+	type TransformOptions,
+	transformedEventCount,
+} from "./transformModel";
+
+/** Mints event IDs for the copies `notes.duplicate` creates (see StepEditor). */
+const factoryContext = createFactoryContext();
+
+export interface TransformPanelProps {
+	readonly clip: Clip;
+	readonly project: Project;
+	/** The editor's current note selection; empty means "the whole clip". */
+	readonly selectedIds: readonly EventId[];
+	dispatch(
+		commands: RawCommandInput | readonly RawCommandInput[],
+	): TransactionResult | undefined;
+	/** Which editor hosts the panel, for `clip_edited`'s `editor` parameter. */
+	readonly editor: "step" | "piano_roll";
+	/** Defaults to the application's singleton; injectable for tests. */
+	readonly analytics?: Analytics;
+}
+
+/**
+ * The CLP-04 musical-transformation panel: transpose, velocity scale, quantize,
+ * duplicate, clear, and seeded rhythmic variation for the current selection.
+ *
+ * Every button dispatches one of the six already-registered `notes.*` commands
+ * (`src/commands/definitions/transforms.ts`) — the same ones the assistant
+ * calls, with the same validation, generated inverse, and summary. The panel
+ * adds no mutation path of its own (PRD section 9.6), which is what gives it
+ * two properties the CLP-04 criteria turn on: one transformation is one
+ * transaction (so undo is atomic and redo exact, `vary` included, its
+ * randomness coming from the payload's seed rather than `Math.random`), and a
+ * boundary case is a rejection rather than a clamp — surfaced to the user
+ * instead of silently applying a partial result.
+ */
+export default function TransformPanel(
+	props: TransformPanelProps,
+): JSX.Element {
+	const analytics = () => props.analytics ?? defaultAnalytics;
+	const [options, setOptions] = createSignal<TransformOptions>(
+		DEFAULT_TRANSFORM_OPTIONS,
+	);
+	const [error, setError] = createSignal<string | null>(null);
+
+	const scope = createMemo(() =>
+		resolveTransformScope(props.clip, props.selectedIds),
+	);
+	const enabled = createMemo(() => canTransform(scope()));
+
+	function scopeLabel(): string {
+		const { count, isWholeClip } = scope();
+		if (count === 0) return "no notes";
+		const noun = count === 1 ? "note" : "notes";
+		return isWholeClip ? `all ${count} ${noun}` : `${count} selected ${noun}`;
+	}
+
+	function applyTransform(kind: TransformKind): void {
+		const current = scope();
+		if (!canTransform(current)) return;
+		const command = buildTransform(kind, {
+			project: props.project,
+			clip: props.clip,
+			scope: current,
+			ids: factoryContext.ids,
+			options: options(),
+		});
+		const count = transformedEventCount(kind, current, props.clip);
+		// `feature_first_use` is marked before the dispatch: reaching for a
+		// transformation is the feature being used, whether or not the command
+		// accepts this particular payload.
+		analytics().logFeatureFirstUse(
+			props.editor === "step" ? "step_editor" : "piano_roll",
+		);
+		const result = props.dispatch(command as RawCommandInput);
+		if (result && !result.ok) {
+			// A rejected transformation changed nothing, so it is not an edit and
+			// emits no `clip_edited`. The reason comes from the command layer.
+			setError(result.issues.map((issue) => issue.message).join("; "));
+			return;
+		}
+		setError(null);
+		analytics().log("clip_edited", {
+			editor: props.editor,
+			event_count_bucket: bucketOf("event_count", count),
+		});
+	}
+
+	return (
+		<section class="transform-panel" aria-label="Musical transformations">
+			<div class="transform-row">
+				<For each={TRANSFORM_KINDS}>
+					{(kind) => (
+						<button
+							type="button"
+							class="transform-button"
+							onClick={() => applyTransform(kind)}
+							disabled={!enabled()}
+							aria-label={`${TRANSFORM_LABELS[kind]} ${
+								kind === "clear" ? "clip" : scopeLabel()
+							}`}
+						>
+							{TRANSFORM_LABELS[kind]}
+						</button>
+					)}
+				</For>
+			</div>
+			<div class="transform-row transform-options">
+				<NumberOption
+					label="Semitones"
+					step={1}
+					value={options().semitones}
+					onValue={(value) =>
+						setOptions((c) => ({ ...c, semitones: Math.round(value) }))
+					}
+				/>
+				<NumberOption
+					label="Velocity x"
+					step={0.05}
+					value={options().velocityFactor}
+					onValue={(value) =>
+						value > 0 && setOptions((c) => ({ ...c, velocityFactor: value }))
+					}
+				/>
+				<label class="transform-option">
+					<span>Vary seed</span>
+					<input
+						type="text"
+						value={options().seed}
+						onInput={(event) => {
+							const seed = event.currentTarget.value;
+							if (seed.length > 0) setOptions((c) => ({ ...c, seed }));
+						}}
+					/>
+				</label>
+			</div>
+			<p class="transform-scope" aria-live="polite">
+				Applies to {scopeLabel()}
+			</p>
+			{/* A rejection is shown, not swallowed: the command refuses to clamp a
+			    note out of range, so the user needs to know why nothing moved. */}
+			<p class="transform-error" role="alert">
+				{error() ?? ""}
+			</p>
+		</section>
+	);
+}
+
+/** One labelled numeric option. Non-numeric input is ignored, never coerced. */
+function NumberOption(props: {
+	readonly label: string;
+	readonly step: number;
+	readonly value: number;
+	onValue(value: number): void;
+}): JSX.Element {
+	return (
+		<label class="transform-option">
+			<span>{props.label}</span>
+			<input
+				type="number"
+				step={props.step}
+				value={props.value}
+				onInput={(event) => {
+					const value = Number(event.currentTarget.value);
+					if (Number.isFinite(value)) props.onValue(value);
+				}}
+			/>
+		</label>
+	);
+}

--- a/src/editor/transformPanelHarness.tsx
+++ b/src/editor/transformPanelHarness.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import { noteEventsOf } from "../commands";
+import type { NoteEvent } from "../domain/entities";
+import { createPianoRollFixtureProject } from "../domain/fixtures";
+import type { EventId } from "../domain/ids";
+import { createInMemoryProjectRepository } from "../persistence/inMemoryProjectRepository";
+import { createManualClock } from "../shared/clock";
+import { memoryStorage } from "../testing/storage";
+import { EditorSession } from "./EditorSession";
+import TransformPanel from "./TransformPanel";
+
+/**
+ * Shared harness for the `TransformPanel` suites (test-only): a real
+ * `EditorSession` over an in-memory repository, so a transformation goes
+ * through the actual command layer, transaction, and undo history rather than
+ * a stub, and one recording transport shared by the session and the panel, so
+ * a test can assert the whole event stream a user action produced.
+ */
+export async function setUpTransformPanel(
+	options: { analyticsEnabled?: boolean } = {},
+) {
+	const repository = createInMemoryProjectRepository();
+	const project = createPianoRollFixtureProject();
+	const created = await repository.createProject(project);
+	if (!created.ok) throw new Error("fixture failed to create");
+
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	if (options.analyticsEnabled === false) consent.optOut();
+
+	const session = new EditorSession({
+		repository,
+		project,
+		clock: createManualClock(1_000),
+		analytics: new Analytics({ transport, consent, storage: memoryStorage() }),
+		deviceStorage: memoryStorage(),
+	});
+
+	const panelAnalytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+	panelAnalytics.setAccountType("anonymous");
+
+	function renderPanel(selectedIds: readonly EventId[] = []) {
+		return render(() => (
+			<TransformPanel
+				clip={session.project.clips[0]}
+				project={session.project}
+				selectedIds={selectedIds}
+				dispatch={session.dispatch.bind(session)}
+				editor="piano_roll"
+				analytics={panelAnalytics}
+			/>
+		));
+	}
+
+	return { repository, session, transport, renderPanel };
+}
+
+export function currentNotes(session: EditorSession): readonly NoteEvent[] {
+	return noteEventsOf(session.project.clips[0]) ?? [];
+}
+
+export function pitchOf(event: NoteEvent): number {
+	return event.trigger.kind === "pitch" ? event.trigger.pitch : -1;
+}
+
+export function pitches(session: EditorSession): number[] {
+	return currentNotes(session)
+		.map(pitchOf)
+		.sort((a, b) => a - b);
+}
+
+/** Clicks the panel button whose visible label is `label`. */
+export function clickTransform(label: string): void {
+	const button = screen
+		.getAllByRole("button")
+		.find((candidate) => candidate.textContent === label);
+	if (!button) throw new Error(`no ${label} button`);
+	fireEvent.click(button);
+}
+
+/** Types into one of the panel's labelled option inputs. */
+export function setOption(label: string, value: string): void {
+	fireEvent.input(screen.getByLabelText(label, { exact: false }), {
+		target: { value },
+	});
+}


### PR DESCRIPTION
## What & why

Adds the transformation panel UI for CLP-04. 2 of 3, builds on #1 (`claude/loop-012`).

The six transformation commands have existed since FND-003, but only `notes.duplicate` had a user-facing path (the piano roll's toolbar). Transpose, velocity scale, quantize, clear, and seeded variation had none, so CLP-04's "available to both the UI and the assistant" was only half true.

This adds the panel that closes that gap. It builds on the scope/build model from the previous PR and dispatches the existing commands unchanged, so the UI and the assistant share one validated mutation path rather than the panel growing a second one.

Two behaviors the CLP-04 criteria turn on, implemented and tested here:
- A rejected transformation is surfaced, not swallowed. The commands refuse to clamp — a transpose leaving the 0-127 range is an error with a reason — so the panel shows that reason and emits no `clip_edited`, because nothing was edited.
- Every button is disabled when the clip has no notes in scope, rather than dispatching a transaction certain to fail.

Analytics goes through the existing `clip_edited` key with the hosting editor and an event-count bucket; no new event name is introduced, since a transformation is an editing gesture the PRD OPS-02 table already covers.

The panel is not mounted yet and ships without styling — the wiring that puts it on screen, its stylesheet, and the history/analytics suite are the next PR (3 of 3).

Refs #52

Relevant PRD requirement: CLP-04.

## Walkthrough

No UI change yet — the panel component exists and is tested via its own headless harness (`transformPanelHarness.tsx`) but is not mounted into the app. It's shown live from the entrypoint in PR 3, where it actually appears in the editor.

## Evidence

Branch passed an Opus review round in the implementation workflow.

```
bun run typecheck
bun run test
bun run check
```
all passing on this branch (see `src/editor/TransformPanel.test.tsx` for the 401-line slice's coverage: refusal surfacing, disabled-when-empty-scope, and payload dispatch).

## Acceptance criteria met

- [x] UI actions call assistant-compatible commands with deterministic summaries and inverses — the panel dispatches the same registered commands the assistant would use, unchanged.
- [ ] Boundary clamping, empty selection, mixed event types, seeded output, atomic undo, and redo are tested — refusal surfacing and empty-scope disabling are covered here; atomic undo/redo and seeded-output stability under a live, reactive project are covered in PR 3 (`TransformPanel.history.test.tsx`).

---

_Generated by [Claude Code](https://claude.ai/code)_
