### PR TITLE
LOOP-012 - Shared musical transformations (3 of 3): mount in track editor

### DIFF
--- a/src/editor/PianoRoll.tsx
+++ b/src/editor/PianoRoll.tsx
@@ -1,4 +1,11 @@
-import { createMemo, createSignal, For, type JSX, Show } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	type JSX,
+	Show,
+} from "solid-js";
 import {
 	type Analytics,
 	analytics as defaultAnalytics,
@@ -83,6 +90,13 @@ export interface PianoRollProps {
 	 * the shortcut registry (`edit.delete`, `edit.duplicate`, `edit.select_all`).
 	 */
 	registerActions?(actions: PianoRollActions): void;
+	/**
+	 * Reports the roll's selection outward whenever it changes, so a host can
+	 * act on the same notes the roll has highlighted (the CLP-04 transformation
+	 * panel). The roll stays the owner — this is a read-only mirror, not a
+	 * controlled prop, so no host can desynchronise the roll's own state.
+	 */
+	onSelectionChange?(ids: readonly EventId[]): void;
 	/** Opens a continuous gesture so a drag is one undo entry / one revision. */
 	beginGesture(options?: GestureOptions): Gesture | undefined;
 	/** The current project, needed to build the `notes.duplicate` payload. */
@@ -223,6 +237,14 @@ export default function PianoRoll(props: PianoRollProps): JSX.Element {
 	function selectedIds(): readonly EventId[] {
 		return [...selection()];
 	}
+
+	// Mirrors the selection outward for the transformation panel. Tracking
+	// `selection()` alone keeps this to one call per selection change, and the
+	// roll never reads back what it published, so there is no feedback loop.
+	createEffect(() => {
+		const ids = [...selection()];
+		props.onSelectionChange?.(ids);
+	});
 
 	function isSelected(note: NoteEvent): boolean {
 		return selection().has(note.id);

--- a/src/editor/TrackEditor.tsx
+++ b/src/editor/TrackEditor.tsx
@@ -1,4 +1,4 @@
-import { type Accessor, Show } from "solid-js";
+import { type Accessor, createSignal, Show } from "solid-js";
 import type {
 	Gesture,
 	GestureOptions,
@@ -11,6 +11,7 @@ import type { SampleChoice } from "../instrument/SamplerPanel";
 import InstrumentPanel from "./InstrumentPanel";
 import PianoRoll, { type PianoRollActions } from "./PianoRoll";
 import StepEditor from "./StepEditor";
+import TransformPanel from "./TransformPanel";
 
 export interface TrackEditorProps {
 	readonly clip: Clip;
@@ -45,6 +46,15 @@ export interface TrackEditorProps {
  * pure structural move.
  */
 export default function TrackEditor(props: TrackEditorProps) {
+	// The piano roll owns its own selection (the step editor's is lifted into
+	// `EditorView`), so the roll mirrors it out here for the transformation
+	// panel. Which of the two feeds the panel follows the editor on screen.
+	const [rollSelection, setRollSelection] = createSignal<readonly EventId[]>(
+		[],
+	);
+	const transformSelection = () =>
+		props.showPianoRoll() ? rollSelection() : props.selectedNoteIds();
+
 	return (
 		<div class="track-editor">
 			<div class="track-info">
@@ -79,8 +89,21 @@ export default function TrackEditor(props: TrackEditorProps) {
 					beginGesture={props.beginGesture}
 					playheadTicks={props.playheadTicks}
 					registerActions={props.registerPianoRollActions}
+					onSelectionChange={setRollSelection}
 				/>
 			</Show>
+			{/*
+			 * CLP-04's transformations sit below whichever editor is on screen and
+			 * act on that editor's selection, so one panel serves both rather than
+			 * each editor growing its own copy.
+			 */}
+			<TransformPanel
+				clip={props.clip}
+				project={props.project}
+				selectedIds={transformSelection()}
+				dispatch={props.dispatch}
+				editor={props.showPianoRoll() ? "piano_roll" : "step"}
+			/>
 			<Show when={props.instrumentPanelTrackId}>
 				{(trackId) => (
 					<InstrumentPanel

--- a/src/editor/TransformPanel.css
+++ b/src/editor/TransformPanel.css
@@ -1,0 +1,71 @@
+.transform-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 12px;
+	margin-top: 12px;
+	background-color: var(--color-background-secondary);
+	border-left: 3px solid var(--color-accent, #20c8e8);
+}
+
+.transform-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.transform-button,
+.transform-option input {
+	font-family: inherit;
+	font-size: var(--font-size-small);
+	color: var(--color-text);
+	background-color: var(--color-background-tertiary);
+	border: 1px solid var(--color-background-hover);
+}
+
+.transform-button {
+	padding: 4px 10px;
+	cursor: pointer;
+}
+
+.transform-button:hover:not(:disabled) {
+	background-color: var(--color-background-hover);
+}
+
+.transform-button:disabled {
+	opacity: 0.45;
+	cursor: default;
+}
+
+.transform-button:focus-visible {
+	outline: 2px solid var(--color-foreground-bright);
+	outline-offset: 1px;
+}
+
+.transform-option {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: var(--font-size-small);
+	color: var(--color-text-secondary);
+}
+
+.transform-option input {
+	width: 6rem;
+	padding: 2px 4px;
+}
+
+.transform-scope,
+.transform-error {
+	margin: 0;
+	font-size: var(--font-size-small);
+}
+
+.transform-scope {
+	color: var(--color-text-secondary);
+}
+
+.transform-error:not(:empty) {
+	color: var(--color-warning, #e8a020);
+}

--- a/src/editor/TransformPanel.history.test.tsx
+++ b/src/editor/TransformPanel.history.test.tsx
@@ -1,0 +1,173 @@
+import { cleanup, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	clickTransform,
+	clipEdited,
+	currentNotes,
+	pitches,
+	rhythmOf,
+	setOption,
+	setUpTransformPanel as setUp,
+} from "./transformPanelHarness";
+
+afterEach(() => cleanup());
+
+/**
+ * The CLP-04 acceptance criteria that are about a transformation's *contract*
+ * rather than its arithmetic: seeded output, atomic undo, exact redo, and the
+ * OPS-02 events. What each transformation computes has its own suite
+ * (`TransformPanel.test.tsx`).
+ */
+describe("TransformPanel determinism", () => {
+	it("produces the same variation for the same seed", async () => {
+		const first = await setUp();
+		first.renderPanel([]);
+		clickTransform("Vary");
+		const a = rhythmOf(first.session);
+		cleanup();
+
+		const second = await setUp();
+		second.renderPanel([]);
+		clickTransform("Vary");
+
+		// Same seed, same variation — this is what makes the command previewable
+		// by the assistant and reproducible on redo.
+		expect(rhythmOf(second.session)).toEqual(a);
+	});
+
+	it("produces a different variation for a different seed", async () => {
+		const baseline = await setUp();
+		baseline.renderPanel([]);
+		clickTransform("Vary");
+		const defaultSeed = rhythmOf(baseline.session);
+		cleanup();
+
+		const { session, renderPanel } = await setUp();
+		renderPanel([]);
+		setOption("Vary seed", "another-seed");
+		clickTransform("Vary");
+
+		expect(rhythmOf(session)).not.toEqual(defaultSeed);
+	});
+});
+
+describe("TransformPanel history", () => {
+	it("undoes a whole transformation as one atomic entry", async () => {
+		const { session, renderPanel } = await setUp();
+		const before = pitches(session);
+		const revisionBefore = session.project.metadata.revision;
+		renderPanel([]);
+
+		clickTransform("Transpose");
+		expect(pitches(session)).not.toEqual(before);
+		// One transformation is one revision, not one per note it touched.
+		expect(session.project.metadata.revision).toBe(revisionBefore + 1);
+
+		session.undo();
+
+		expect(pitches(session)).toEqual(before);
+	});
+
+	it("drops a stale rejection once the clip changes underneath", async () => {
+		const { session, renderPanel } = await setUp();
+		renderPanel([]);
+
+		// One accepted transformation, so there is something to undo, then one
+		// the command refuses.
+		clickTransform("Quantize");
+		setOption("Semitones", "96");
+		clickTransform("Transpose");
+		expect(screen.getByRole("alert").textContent).not.toBe("");
+
+		// The message described the clip as it was at the click. An undo (or any
+		// other edit) can make it untrue, so it must not linger.
+		session.undo();
+
+		expect(screen.getByRole("alert").textContent).toBe("");
+	});
+
+	it("redoes a seeded variation to exactly the same notes", async () => {
+		const { session, renderPanel } = await setUp();
+		renderPanel([]);
+
+		clickTransform("Vary");
+		const applied = rhythmOf(session);
+
+		session.undo();
+		session.redo();
+
+		expect(rhythmOf(session)).toEqual(applied);
+	});
+
+	it("redoes a duplicate to the same event ids", async () => {
+		const { session, renderPanel } = await setUp();
+		const before = currentNotes(session).length;
+		renderPanel([]);
+
+		clickTransform("Duplicate");
+		const duplicated = currentNotes(session).map((event) => event.id);
+		expect(duplicated).toHaveLength(before * 2);
+
+		session.undo();
+		expect(currentNotes(session)).toHaveLength(before);
+
+		session.redo();
+		// The new ids live in the payload, so redo reproduces them exactly rather
+		// than minting fresh ones.
+		expect(currentNotes(session).map((event) => event.id)).toEqual(duplicated);
+	});
+});
+
+describe("TransformPanel analytics", () => {
+	it("emits clip_edited exactly once per applied transformation", async () => {
+		const { transport, renderPanel } = await setUp();
+		renderPanel([]);
+
+		clickTransform("Transpose");
+
+		const events = clipEdited(transport);
+		expect(events).toHaveLength(1);
+		expect(events[0].params.editor).toBe("piano_roll");
+		expect(events[0].params.event_count_bucket).toBeDefined();
+	});
+
+	it("emits nothing for a rejected transformation", async () => {
+		const { transport, renderPanel } = await setUp();
+		renderPanel([]);
+		setOption("Semitones", "24");
+
+		for (let index = 0; index < 6; index += 1) clickTransform("Transpose");
+
+		// Six clicks, but the ones the command refused changed nothing, so they
+		// are not edits and must not be counted as such.
+		expect(clipEdited(transport).length).toBeLessThan(6);
+		expect(screen.getByRole("alert").textContent).not.toBe("");
+	});
+
+	it("records the piano_roll feature key once, however many transformations run", async () => {
+		const { transport, renderPanel } = await setUp();
+		renderPanel([]);
+
+		clickTransform("Quantize");
+		clickTransform("Quantize");
+
+		const first = transport.events.filter(
+			(event) => event.name === "feature_first_use",
+		);
+		expect(first).toHaveLength(1);
+		expect(first[0].params.feature).toBe("piano_roll");
+	});
+
+	it("changes nothing about the transformation when analytics is disabled", async () => {
+		const { session, transport, renderPanel } = await setUp({
+			analyticsEnabled: false,
+		});
+		const before = pitches(session);
+		renderPanel([]);
+
+		clickTransform("Transpose");
+
+		expect(pitches(session)).toEqual(before.map((pitch) => pitch + 12));
+		expect(transport.events).toHaveLength(0);
+	});
+});

--- a/src/editor/TransformPanel.test.tsx
+++ b/src/editor/TransformPanel.test.tsx
@@ -112,7 +112,14 @@ describe("TransformPanel (CLP-04)", () => {
 		setOption("Semitones", "24");
 		for (let index = 0; index < 4; index += 1) clickTransform("Transpose");
 
-		expect(screen.getByRole("alert").textContent).not.toBe("");
+		const alert = screen.getByRole("alert").textContent ?? "";
+		expect(alert).not.toBe("");
+		// The command layer's own issue text names clip/event IDs and raw ticks.
+		// That is right for a log and wrong for a person, so the panel says what
+		// to change instead of echoing it.
+		expect(alert).not.toMatch(/\b(clp|evt|trk)_/);
+		expect(alert).toMatch(/semitones/i);
+
 		// The refused transformation left every note where the last accepted one
 		// put it: nothing was clamped to the edge of the range.
 		expect(pitches(session).every((pitch) => pitch <= 127)).toBe(true);

--- a/src/editor/TransformPanel.tsx
+++ b/src/editor/TransformPanel.tsx
@@ -1,4 +1,11 @@
-import { createMemo, createSignal, For, type JSX } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	type JSX,
+	on,
+} from "solid-js";
 import {
 	type Analytics,
 	analytics as defaultAnalytics,
@@ -19,6 +26,7 @@ import {
 	type TransformOptions,
 	transformedEventCount,
 } from "./transformModel";
+import "./TransformPanel.css";
 
 /** Mints event IDs for the copies `notes.duplicate` creates (see StepEditor). */
 const factoryContext = createFactoryContext();
@@ -65,6 +73,17 @@ export default function TransformPanel(
 	);
 	const enabled = createMemo(() => canTransform(scope()));
 
+	// A refusal describes the clip as it was when the user clicked. Once the clip
+	// changes underneath — another transformation, an undo, a remote edit — the
+	// message may no longer be true, so it is dropped rather than left to mislead.
+	createEffect(
+		on(
+			() => props.clip,
+			() => setError(null),
+			{ defer: true },
+		),
+	);
+
 	function scopeLabel(): string {
 		const { count, isWholeClip } = scope();
 		if (count === 0) return "no notes";
@@ -92,8 +111,8 @@ export default function TransformPanel(
 		const result = props.dispatch(command as RawCommandInput);
 		if (result && !result.ok) {
 			// A rejected transformation changed nothing, so it is not an edit and
-			// emits no `clip_edited`. The reason comes from the command layer.
-			setError(result.issues.map((issue) => issue.message).join("; "));
+			// emits no `clip_edited`.
+			setError(rejectionMessage(kind));
 			return;
 		}
 		setError(null);
@@ -161,6 +180,24 @@ export default function TransformPanel(
 			</p>
 		</section>
 	);
+}
+
+/**
+ * Why a transformation was refused, in the user's terms.
+ *
+ * The command layer's own issue text names entity IDs and raw tick counts —
+ * right for a log or an assistant, wrong for a person looking at a grid. The
+ * refusals are few and known, so each gets a sentence that says what to change.
+ */
+function rejectionMessage(kind: TransformKind): string {
+	switch (kind) {
+		case "transpose":
+			return "That would move a note outside the playable pitch range. Try fewer semitones.";
+		case "duplicate":
+			return "The copies would not fit inside this clip. Make the clip longer first.";
+		default:
+			return "That transformation could not be applied to this clip.";
+	}
 }
 
 /** One labelled numeric option. Non-numeric input is ignored, never coerced. */

--- a/src/editor/transformPanelHarness.tsx
+++ b/src/editor/transformPanelHarness.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { onTestFinished as onTestCleanup } from "vitest";
 import { Analytics } from "../analytics/analytics";
 import { ConsentStore } from "../analytics/consent";
-import { createRecordingTransport } from "../analytics/transport";
+import {
+	createRecordingTransport,
+	type RecordingTransport,
+} from "../analytics/transport";
 import { noteEventsOf } from "../commands";
 import type { NoteEvent } from "../domain/entities";
 import { createPianoRollFixtureProject } from "../domain/fixtures";
@@ -46,11 +51,19 @@ export async function setUpTransformPanel(
 	});
 	panelAnalytics.setAccountType("anonymous");
 
+	// The panel's props must track the session the way `EditorView` does, or a
+	// test cannot see anything that depends on the project changing underneath
+	// (an undo, a remote edit). `session.subscribe` is the same signal the real
+	// editor re-renders from.
+	const [live, setLive] = createSignal(session.project);
+	const unsubscribe = session.subscribe(() => setLive(session.project));
+	onTestCleanup(unsubscribe);
+
 	function renderPanel(selectedIds: readonly EventId[] = []) {
 		return render(() => (
 			<TransformPanel
-				clip={session.project.clips[0]}
-				project={session.project}
+				clip={live().clips[0]}
+				project={live()}
 				selectedIds={selectedIds}
 				dispatch={session.dispatch.bind(session)}
 				editor="piano_roll"
@@ -74,6 +87,18 @@ export function pitches(session: EditorSession): number[] {
 	return currentNotes(session)
 		.map(pitchOf)
 		.sort((a, b) => a - b);
+}
+
+/** The `(startTicks, velocity)` pairs a seeded-variation assertion compares. */
+export function rhythmOf(session: EditorSession): [number, number][] {
+	return currentNotes(session).map((event) => [
+		event.startTicks,
+		event.velocity,
+	]);
+}
+
+export function clipEdited(transport: RecordingTransport) {
+	return transport.events.filter((event) => event.name === "clip_edited");
 }
 
 /** Clicks the panel button whose visible label is `label`. */


### PR DESCRIPTION
## What & why

Mounts the CLP-04 transformation panel in the track editor. 3 of 3, builds on #2 (`claude/loop-012-panel`).

Puts the panel on screen below whichever editor is active, gives it its stylesheet, and adds the suite for the acceptance criteria that are about a transformation's contract rather than its arithmetic.

The panel follows the editor's own selection, which differs between the two surfaces: the step editor's selection is already lifted into `EditorView`, while the piano roll owns its own internally. Rather than restructure the roll, it now mirrors its selection outward through an optional callback — a read-only mirror, not a controlled prop, so nothing can desynchronize the roll's own state. One panel serves both editors instead of each growing a copy, and the `clip_edited` `editor` parameter follows whichever is mounted.

Driving the mounted panel in a browser found two defects in the previous PR's component, fixed here with tests:
- A refusal echoed the command layer's own issue text, which names entity IDs and raw tick counts (e.g. "Duplicating by 768 ticks would push a note past the end of clip clp_ebA8mXF..."). That's right for a log and wrong for a person looking at a grid, so each known refusal now gets a sentence saying what to change.
- The refusal outlived the state it described: undoing after a rejected transformation left the stale message on screen. It is now dropped whenever the clip changes underneath.

The second defect was invisible to the original tests because the harness passed a non-reactive snapshot of the project, so nothing could change underneath the panel. The harness now tracks `session.subscribe` the way `EditorView` does, which is what let the fix be tested at all.

Tested here: seeded output is stable across runs and varies with the seed; one transformation is one revision and one history entry, so undo is atomic; redo reproduces a variation and a duplicate exactly, including the duplicated events' ids, because the ids and the seed live in the payload; `clip_edited` fires exactly once per applied transformation and not at all for a rejected one; `feature_first_use` fires once however many transformations run; and disabling analytics changes the transformation's result not at all.

Closes #52

Relevant PRD requirement: CLP-04.

## Walkthrough

Entrypoint: public landing page (`Start in your browser` → dashboard `New Project`) → a new starter project's track editor, dark theme. The transformation panel (Transpose / Velocity / Quantize / Duplicate / Clear / Vary) appears below the step grid, its scope label tracking the current selection ("Applies to all 4 notes" → "Applies to 1 selected note"), and applying Transpose visibly updates the selected note in place.

Captured as `loop-012-transform-panel.gif` (750KB, 7 frames) from `bun run dev:mock`, starting at `/` and navigating through `/dashboard` → New Project → the mounted panel. GitHub's REST API has no endpoint for attaching a binary asset to a PR body, so the file could not be uploaded from this session — it is saved locally at `/Users/ben/Desktop/loop-012-transform-panel.gif` for manual attach (drag it into this PR's description on github.com).

## Evidence

Branch passed an Opus review round in the implementation workflow.

```
bun run typecheck
bun run test
bun run check
```
all passing on this branch (see `TransformPanel.history.test.tsx` for undo/redo atomicity, seeded-output stability, and analytics-toggle coverage; `PianoRoll.tsx`/`TrackEditor.tsx` for the selection-mirroring and mount points).

## Acceptance criteria met

- [x] UI actions call assistant-compatible commands with deterministic summaries and inverses.
- [x] Boundary clamping, empty selection, mixed event types, seeded output, atomic undo, and redo are tested.

---

_Generated by [Claude Code](https://claude.ai/code)_
