### PR TITLE
LOOP-009 - Shared device-node kit behind DeviceChain's factory seam

### DIFF
--- a/src/audio/DeviceChain.ts
+++ b/src/audio/DeviceChain.ts
@@ -21,6 +21,20 @@ export interface DeviceNode {
 	readonly output: Tone.ToneAudioNode;
 	update(device: Device): void;
 	dispose(): void;
+	/**
+	 * How much gain the device is removing right now, in dB (0 when it is not
+	 * reducing). Only a dynamics device implements it; a panel polls it for a
+	 * gain-reduction meter (PRD FX-01) and it is never the source of an
+	 * analytics event, so metering adds no per-frame telemetry.
+	 */
+	gainReductionDb?(): number;
+	/**
+	 * Resolves once any asynchronously-built resource this device needs is in
+	 * place. Only the reverb implements it (its impulse response is generated
+	 * off the audio thread). Live playback never awaits it — a node keeps its
+	 * previous impulse until the new one lands — but an offline render must.
+	 */
+	ready?(): Promise<void>;
 }
 
 export type DeviceNodeFactory = (device: Device) => DeviceNode;

--- a/src/audio/devices/deviceNode.test.ts
+++ b/src/audio/devices/deviceNode.test.ts
@@ -1,0 +1,162 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Device } from "../../domain/entities";
+import type { DeviceId } from "../../domain/ids";
+import { installWebAudioGlobals, rms } from "../testAudioContext";
+
+// Must run before Tone is imported — see AudioRuntime.test.ts for why.
+installWebAudioGlobals();
+
+let Tone: typeof import("tone");
+let deviceNode: typeof import("./deviceNode");
+let types: typeof import("./types");
+
+beforeAll(async () => {
+	Tone = await import("tone");
+	deviceNode = await import("./deviceNode");
+	types = await import("./types");
+});
+
+const context = { scope: null as never, tempo: () => 120 };
+
+/**
+ * The simplest possible core: a fixed gain, so every assertion below is about
+ * the shared wrapper and not any real device's DSP. `overdrive` is borrowed
+ * only as a device *type* — its registered parameters include `wet` and
+ * `output`.
+ */
+function halfGainCore(): import("./types").DeviceCore {
+	const gain = new Tone.Gain(0.5);
+	return {
+		input: gain,
+		output: gain,
+		apply() {
+			// Nothing of its own — the wrapper is what is under test.
+		},
+		dispose() {
+			gain.dispose();
+		},
+	};
+}
+
+function device(parameters: Record<string, number>, bypassed = false): Device {
+	return {
+		id: "dev_wrapper" as DeviceId,
+		type: "overdrive",
+		order: 0,
+		bypassed,
+		parameters,
+		preset: null,
+	};
+}
+
+function build(d: Device) {
+	return deviceNode.buildDeviceNode(d, context, halfGainCore);
+}
+
+/** Renders a steady sine through one wrapped device and returns the settled
+ * second half of the mono channel, past the smoothing ramp at the head. */
+async function render(d: Device): Promise<Float32Array> {
+	const buffer = await Tone.Offline(() => {
+		const node = build(d);
+		const osc = new Tone.Oscillator({ type: "sine", frequency: 220 });
+		osc.connect(node.input);
+		node.output.toDestination();
+		osc.start(0);
+	}, 0.4);
+	const data = buffer.getChannelData(0);
+	return data.subarray(Math.floor(data.length / 2));
+}
+
+describe("readDeviceParameters", () => {
+	it("fills in each definition's default for a key the sparse map omits", () => {
+		const values = types.readDeviceParameters(
+			[
+				{
+					id: "overdrive.drive",
+					label: "Drive",
+					unit: "normalized",
+					min: 0,
+					max: 1,
+					defaultValue: 0.3,
+					step: null,
+					scale: "linear",
+					clampPolicy: "clamp",
+					automatable: true,
+				},
+			],
+			device({}),
+		);
+		expect(values.drive).toBe(0.3);
+	});
+
+	it("substitutes the default for a stored non-finite value", () => {
+		const values = types.readDeviceParameters(
+			[
+				{
+					id: "overdrive.tone",
+					label: "Tone",
+					unit: "normalized",
+					min: 0,
+					max: 1,
+					defaultValue: 0.5,
+					step: null,
+					scale: "linear",
+					clampPolicy: "clamp",
+					automatable: true,
+				},
+			],
+			device({ tone: Number.NaN }),
+		);
+		// A NaN can never reach a Web Audio param — it would poison the node
+		// permanently rather than merely sounding wrong.
+		expect(values.tone).toBe(0.5);
+	});
+});
+
+describe("shared wet/dry, output trim, and bypass", () => {
+	it("splits between the dry input and the processed wet leg", async () => {
+		const dry = rms(await render(device({ wet: 0, output: 0 })));
+		const wet = rms(await render(device({ wet: 1, output: 0 })));
+		// The core halves the signal, so full wet is half of full dry.
+		expect(wet).toBeCloseTo(dry / 2, 2);
+		// A 50% mix lands between them rather than snapping to either leg.
+		const half = rms(await render(device({ wet: 0.5, output: 0 })));
+		expect(half).toBeGreaterThan(wet);
+		expect(half).toBeLessThan(dry);
+	});
+
+	it("applies output trim to the mixed signal", async () => {
+		const flat = rms(await render(device({ wet: 1, output: 0 })));
+		const boosted = rms(await render(device({ wet: 1, output: 12 })));
+		const cut = rms(await render(device({ wet: 1, output: -12 })));
+		expect(boosted / flat).toBeCloseTo(10 ** (12 / 20), 1);
+		expect(cut / flat).toBeCloseTo(10 ** (-12 / 20), 1);
+	});
+
+	it("passes a bypassed device's input through untouched, trim included", async () => {
+		const bypassed = rms(await render(device({ wet: 1, output: 12 }, true)));
+		const dry = rms(await render(device({ wet: 0, output: 0 })));
+		// Bypass is full-dry *and* neutral trim: a bypassed device must not be a
+		// hidden gain stage (FX-01 "a device can be ... bypassed").
+		expect(bypassed).toBeCloseTo(dry, 2);
+	});
+
+	it("never replaces a node for a bypass or parameter edit", () => {
+		const node = build(device({ wet: 1, output: 0 }));
+		const { input, output } = node;
+		node.update(device({ wet: 0.2, output: 6 }, true));
+		node.update(device({ wet: 1, output: 0 }, false));
+		// `DeviceChain` only relinks when composition or order changes; holding
+		// the same identity is what guarantees a bypass or knob move never
+		// triggers one (FX-01: "do not rebuild unrelated audio nodes").
+		expect(node.input).toBe(input);
+		expect(node.output).toBe(output);
+		node.dispose();
+	});
+
+	it("disposes every node it owns, idempotently", () => {
+		const node = build(device({}));
+		node.dispose();
+		expect(() => node.dispose()).not.toThrow();
+	});
+});

--- a/src/audio/devices/deviceNode.ts
+++ b/src/audio/devices/deviceNode.ts
@@ -1,0 +1,102 @@
+import * as Tone from "tone";
+import { deviceParameters } from "../../domain/devices";
+import type { Device } from "../../domain/entities";
+import type { DeviceNode } from "../DeviceChain";
+import {
+	type DeviceCoreFactory,
+	type DeviceGraphContext,
+	readDeviceParameters,
+	setOrRamp,
+} from "./types";
+
+/**
+ * Wraps a device's DSP core in the mix stage every device shares (FX-01:
+ * "Applicable devices include wet/dry mix and output trim"; "A device can be
+ * ... bypassed"):
+ *
+ * `input` fans out to an always-connected dry leg and a wet leg through the
+ * core; both meet at a trim stage feeding `output`.
+ *
+ * Bypass and wet/dry are both expressed as gains on those two legs, never as a
+ * reconnection. That makes bypass click-free and, more importantly, keeps a
+ * bypassed device's core *alive*: a delay's repeats and a reverb's tail keep
+ * ringing into a muted wet leg, so un-bypassing mid-tail does not restart the
+ * effect from silence (FX-01 tails). It also means neither bypass nor a
+ * parameter edit ever replaces a node, so `DeviceChain` never relinks for one.
+ *
+ * A device declaring no `wet` parameter (the plain filter) runs fully wet; its
+ * dry leg stays at zero and costs nothing.
+ */
+export function buildDeviceNode(
+	device: Device,
+	context: DeviceGraphContext,
+	createCore: DeviceCoreFactory,
+): DeviceNode {
+	const definitions = deviceParameters(device.type);
+	const hasWet = definitions.some((d) => d.id.endsWith(".wet"));
+	const hasOutput = definitions.some((d) => d.id.endsWith(".output"));
+
+	const input = new Tone.Gain(1);
+	const dry = new Tone.Gain(0);
+	const wet = new Tone.Gain(1);
+	const output = new Tone.Gain(1);
+	const trim = new Tone.Volume(0);
+
+	const core = createCore(device, context);
+
+	input.connect(dry);
+	input.connect(core.input);
+	core.output.connect(wet);
+	dry.connect(trim);
+	wet.connect(trim);
+	trim.connect(output);
+
+	/**
+	 * Bypass is *not* a separate switch layered over the mix: it is the same two
+	 * gains, driven to a full-dry split. Modelling it this way means a device
+	 * cannot end up bypassed and wet at once, and an un-bypass restores exactly
+	 * the stored mix.
+	 */
+	function applyMix(
+		next: Device,
+		values: Readonly<Record<string, number>>,
+		initial: boolean,
+	) {
+		const mix = next.bypassed ? 0 : hasWet ? values.wet : 1;
+		setOrRamp(wet.gain, mix, initial);
+		setOrRamp(dry.gain, 1 - mix, initial);
+		// Output trim follows bypass too, so a bypassed device is truly inert
+		// rather than a hidden gain stage.
+		setOrRamp(
+			trim.volume,
+			next.bypassed || !hasOutput ? 0 : values.output,
+			initial,
+		);
+	}
+
+	const initialValues = readDeviceParameters(definitions, device);
+	core.apply(initialValues, context, true);
+	applyMix(device, initialValues, true);
+
+	return {
+		id: device.id,
+		type: device.type,
+		input,
+		output,
+		update(next) {
+			const values = readDeviceParameters(definitions, next);
+			core.apply(values, context, false);
+			applyMix(next, values, false);
+		},
+		dispose() {
+			core.dispose();
+			input.dispose();
+			dry.dispose();
+			wet.dispose();
+			trim.dispose();
+			output.dispose();
+		},
+		gainReductionDb: core.gainReductionDb?.bind(core),
+		ready: core.ready?.bind(core),
+	};
+}

--- a/src/audio/devices/types.ts
+++ b/src/audio/devices/types.ts
@@ -1,0 +1,122 @@
+import type * as Tone from "tone";
+import type { Device } from "../../domain/entities";
+import {
+	bareParameterId,
+	type ParameterDefinition,
+} from "../../domain/parameters";
+import type { AudioProjectScope } from "../AudioRuntime";
+
+/**
+ * Continuous device parameter edits ramp over this window rather than stepping,
+ * so a cutoff sweep, a drive push, or a wet/dry move never clicks (FX-01:
+ * parameter changes "are smoothed where necessary"). Matched to the instrument
+ * layer's `SMOOTHING_SECONDS` so the two feel identical under the hand.
+ */
+export const DEVICE_SMOOTHING_SECONDS = 0.02;
+
+/**
+ * What a device node needs from the graph that owns it. A device gets its
+ * owning scope so anything it constructs is registered for disposal (PRD
+ * AUD-09), and a tempo reader so a tempo-syncable device can resolve a musical
+ * division to seconds without importing the transport or the song.
+ */
+export interface DeviceGraphContext {
+	readonly scope: AudioProjectScope;
+	/** The song's current tempo in BPM, read at each `update()`. */
+	readonly tempo: () => number;
+}
+
+/**
+ * The DSP core of one device type: the processing itself, with no wet/dry,
+ * output trim, or bypass handling. {@link buildDeviceNode} wraps a core in the
+ * shared mix stage every device shares, so a device implementation is only ever
+ * as long as its own signal path.
+ *
+ * `apply()` receives the device's fully-defaulted parameter values (see
+ * {@link readDeviceParameters}) and must apply them to the *existing* nodes —
+ * never by constructing a replacement. Continuous values go through
+ * {@link setOrRamp}, which handles the initial-versus-edit distinction that
+ * `initial` carries.
+ */
+export interface DeviceCore {
+	readonly input: Tone.ToneAudioNode;
+	readonly output: Tone.ToneAudioNode;
+	apply(
+		values: DeviceParameterValues,
+		context: DeviceGraphContext,
+		initial: boolean,
+	): void;
+	dispose(): void;
+	/**
+	 * An optional live read of how much gain the device is currently removing,
+	 * in dB (0 when it is not reducing). Only the compressor implements it; the
+	 * panel polls it for a gain-reduction meter (FX-01) and it is never the
+	 * source of an analytics event.
+	 */
+	gainReductionDb?(): number;
+	/**
+	 * Resolves once any asynchronously-built resource the device needs is in
+	 * place. Only the reverb implements it, because its impulse response is
+	 * generated off the audio thread. Live playback never awaits it — the node
+	 * simply keeps its previous impulse until the new one lands, so a decay edit
+	 * mid-tail does not drop to silence — but an *offline* render must, since a
+	 * render that starts before the impulse exists produces no tail at all.
+	 */
+	ready?(): Promise<void>;
+}
+
+/** A device's parameter values, by bare id, with every default filled in. */
+export type DeviceParameterValues = Readonly<Record<string, number>>;
+
+/**
+ * Reads a device's stored parameters against its registered definitions,
+ * substituting each definition's default for a key the sparse map omits. Every
+ * device core reads its values through this, so a device persisted before a
+ * parameter existed still resolves to a complete, in-range set rather than
+ * `undefined` reaching a Web Audio param.
+ */
+export function readDeviceParameters(
+	definitions: readonly ParameterDefinition[],
+	device: Device,
+): DeviceParameterValues {
+	const values: Record<string, number> = {};
+	for (const definition of definitions) {
+		const key = bareParameterId(definition.id);
+		const stored = device.parameters[key];
+		values[key] = Number.isFinite(stored) ? stored : definition.defaultValue;
+	}
+	return values;
+}
+
+/** Builds the DSP core for a device type. */
+export type DeviceCoreFactory = (
+	device: Device,
+	context: DeviceGraphContext,
+) => DeviceCore;
+
+/** The slice of a Tone/Web Audio param {@link setOrRamp} needs. */
+export interface RampableParam {
+	linearRampTo(value: number, rampTime: number): unknown;
+	setValueAtTime(value: number, time: number): unknown;
+}
+
+/**
+ * Applies one continuous parameter: set outright the first time, ramped on
+ * every edit after (PRD FX-01 smoothing).
+ *
+ * The distinction is not cosmetic. A ramp is *scheduled* against the audio
+ * context's clock — a future automation curve, not a value — so in an offline
+ * render, whose clock has not advanced when the graph is built, a ramp can land
+ * after the render has finished and leave the node at its construction default
+ * throughout. That made two renders with different settings come out
+ * byte-identical: a test passing by accident, and a ~1-in-10 flake across these
+ * suites. `setValueAtTime(value, 0)` is unambiguous in both worlds.
+ */
+export function setOrRamp(
+	param: RampableParam,
+	value: number,
+	initial: boolean,
+): void {
+	if (initial) param.setValueAtTime(value, 0);
+	else param.linearRampTo(value, DEVICE_SMOOTHING_SECONDS);
+}


### PR DESCRIPTION
## What & why

2 of 8 in the LOOP-009 stack (builds on #181). Adds the shared device-node kit that every processing device core builds on: wet/dry mix, output trim, bypass, and `setOrRamp` (the helper that distinguishes *setting* a parameter from *ramping* it — ramping an initial value against the audio context's clock is not the same as setting it, which matters for deterministic offline renders). This lives behind `DeviceChain`'s existing `DeviceNodeFactory` seam.

Refs #49

PRD: FX-01 (every device exposes wet/dry mix and output trim; parameter changes are smoothed and do not rebuild unrelated audio nodes).

## Walkthrough

No UI change — shared DSP infrastructure only, not yet wired to any concrete device or exposed in `ProjectAudioGraph`.

## Evidence

`bun run typecheck`, `bun run test`, and `bun run check` pass on this commit in isolation. This branch passed an Opus review round in the implementation workflow.

## Acceptance criteria met

- [x] Contributes the shared smoothing/bypass/wet-dry infrastructure that "parameters smooth without node replacement" (FX-01) and per-device wet/dry + output trim (FX-01) depend on.
- Remaining LOOP-009 acceptance boxes are addressed by later PRs in this stack.

---

_Generated by [Claude Code](https://claude.ai/code)_