### PR TITLE
LOOP-009 - Compressor device core, with gain-reduction metering

### DIFF
--- a/src/audio/devices/compressor.test.ts
+++ b/src/audio/devices/compressor.test.ts
@@ -1,0 +1,147 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { createDevice, defaultDeviceParameters } from "../../domain/devices";
+import type { Device } from "../../domain/entities";
+import type { DeviceId } from "../../domain/ids";
+import { installWebAudioGlobals, rms, rmsWindow } from "../testAudioContext";
+
+// Must run before Tone is imported — see AudioRuntime.test.ts for why.
+installWebAudioGlobals();
+
+let Tone: typeof import("tone");
+let deviceNode: typeof import("./deviceNode");
+let compressor: typeof import("./compressor");
+
+beforeAll(async () => {
+	Tone = await import("tone");
+	deviceNode = await import("./deviceNode");
+	compressor = await import("./compressor");
+});
+
+const context = { scope: null as never, tempo: () => 120 };
+
+function device(overrides: Record<string, number> = {}): Device {
+	return {
+		...createDevice("dev_comp" as DeviceId, "compressor", 0),
+		parameters: { ...defaultDeviceParameters("compressor"), ...overrides },
+	};
+}
+
+/**
+ * Renders a sine that steps from quiet to loud halfway through, so the
+ * compressor has something to actually clamp down on and the two halves can be
+ * compared against each other within one render.
+ */
+async function renderStep(d: Device): Promise<Float32Array> {
+	const buffer = await Tone.Offline(() => {
+		const node = deviceNode.buildDeviceNode(
+			d,
+			context,
+			compressor.createCompressorCore,
+		);
+		const osc = new Tone.Oscillator({ type: "sine", frequency: 220 });
+		const gain = new Tone.Gain(0.05);
+		osc.connect(gain);
+		gain.connect(node.input);
+		node.output.toDestination();
+		osc.start(0);
+		gain.gain.setValueAtTime(0.05, 0);
+		gain.gain.setValueAtTime(1, 0.5);
+	}, 1);
+	return buffer.getChannelData(0);
+}
+
+describe("compressor (FX-01)", () => {
+	it("narrows a 20x input step toward the threshold", async () => {
+		const compressed = await renderStep(
+			device({
+				threshold: -30,
+				ratio: 20,
+				attack: 0.001,
+				release: 0.05,
+				makeup: 0,
+			}),
+		);
+		// Everything is measured *inside one render*, against the input step this
+		// test itself creates (0.05 -> 1, a factor of 20). Comparing two separate
+		// renders is what made an earlier version of this flaky: each offline
+		// render builds its graph against the shared global context, so the two
+		// were not reliably independent.
+		const quiet = rmsWindow(compressed, 0.2, 0.45);
+		const loud = rmsWindow(compressed, 0.75, 0.95);
+		// The quiet half is under the threshold and passes through, so the output
+		// step must be materially smaller than the 20x input step.
+		expect(loud / quiet).toBeGreaterThan(1);
+		expect(loud / quiet).toBeLessThan(10);
+	});
+
+	it("compresses harder at a higher ratio", async () => {
+		// Same within-render measurement, so the two settings are compared by how
+		// much each narrows its own step rather than across renders.
+		async function stepGrowth(ratio: number): Promise<number> {
+			const data = await renderStep(device({ threshold: -30, ratio }));
+			return rmsWindow(data, 0.75, 0.95) / rmsWindow(data, 0.2, 0.45);
+		}
+		expect(await stepGrowth(20)).toBeLessThan(await stepGrowth(2));
+	});
+
+	it("applies makeup gain on top of the compressed signal", async () => {
+		const flat = await renderStep(device({ threshold: -30, ratio: 8 }));
+		const loud = await renderStep(
+			device({ threshold: -30, ratio: 8, makeup: 12 }),
+		);
+		expect(rms(loud) / rms(flat)).toBeGreaterThan(3);
+	});
+
+	it("exposes a gain-reduction read for metering", () => {
+		const node = deviceNode.buildDeviceNode(
+			device({ threshold: -40, ratio: 20 }),
+			context,
+			compressor.createCompressorCore,
+		);
+		// The wrapper forwards the core's meter, so a panel can poll one number
+		// per frame without the device pushing any telemetry of its own (FX-01
+		// gain-reduction metering).
+		expect(typeof node.gainReductionDb?.()).toBe("number");
+		// Reported as a positive magnitude, which is how a meter reads — the
+		// underlying node's `reduction` is negative or zero.
+		expect(node.gainReductionDb?.()).toBeGreaterThanOrEqual(0);
+		expect(Number.isFinite(node.gainReductionDb?.() ?? Number.NaN)).toBe(true);
+		node.dispose();
+	});
+
+	it("accepts every extreme of its registered ranges without throwing", () => {
+		const node = deviceNode.buildDeviceNode(
+			device(),
+			context,
+			compressor.createCompressorCore,
+		);
+		// A threshold of 0 dB and a ratio of 1 are the top of their ranges and
+		// both are legitimate "do not compress" settings; a threshold of -60 with
+		// a 20:1 ratio is the destructive end. Neither may throw.
+		expect(() =>
+			node.update(device({ threshold: 0, ratio: 1, makeup: 0 })),
+		).not.toThrow();
+		expect(() =>
+			node.update(
+				device({
+					threshold: -60,
+					ratio: 20,
+					attack: 0,
+					release: 2,
+					makeup: 24,
+				}),
+			),
+		).not.toThrow();
+		node.dispose();
+	});
+
+	it("disposes idempotently", () => {
+		const node = deviceNode.buildDeviceNode(
+			device(),
+			context,
+			compressor.createCompressorCore,
+		);
+		node.dispose();
+		expect(() => node.dispose()).not.toThrow();
+	});
+});

--- a/src/audio/devices/compressor.ts
+++ b/src/audio/devices/compressor.ts
@@ -1,0 +1,83 @@
+import * as Tone from "tone";
+import {
+	type DeviceCore,
+	type DeviceCoreFactory,
+	type RampableParam,
+	setOrRamp,
+} from "./types";
+
+/**
+ * Applies one `DynamicsCompressorNode` param through the shared
+ * {@link setOrRamp}, first clamping into the range the node itself accepts.
+ *
+ * The clamp is this device's own concern: the registered ranges sit inside the
+ * node's, but a stored value from a future range change must not reach it out
+ * of bounds. `setOrRamp` also guarantees a *linear* ramp, which matters
+ * specifically here — Tone picks an exponential curve for a decibel param, and
+ * an exponential ramp cannot reach 0, so a threshold of 0 dB (the legitimate
+ * top of the registered range, meaning "do not compress") threw `RangeError`
+ * rather than applying.
+ */
+function applyParam(
+	param: RampableParam & {
+		readonly minValue: number;
+		readonly maxValue: number;
+	},
+	value: number,
+	initial: boolean,
+): void {
+	setOrRamp(
+		param,
+		Math.min(param.maxValue, Math.max(param.minValue, value)),
+		initial,
+	);
+}
+
+/**
+ * Compressor: threshold, ratio, attack, release, and makeup gain, with a live
+ * gain-reduction read for metering (PRD FX-01).
+ *
+ * Every control maps onto the one `Tone.Compressor` (a `DynamicsCompressorNode`
+ * underneath), so a parameter edit is an `AudioParam` change, never a node
+ * rebuild. Makeup is a separate gain stage after it rather than a compressor
+ * setting, because `DynamicsCompressorNode` has none — folding it into the
+ * threshold instead would silently change how hard the device compresses.
+ *
+ * Parallel ("New York") compression comes from the shared wet/dry stage in
+ * `deviceNode.ts`, not from anything here.
+ */
+export const createCompressorCore: DeviceCoreFactory = (): DeviceCore => {
+	const compressor = new Tone.Compressor();
+	const makeup = new Tone.Volume(0);
+	compressor.connect(makeup);
+
+	return {
+		input: compressor,
+		output: makeup,
+		apply(values, _context, initial) {
+			// `knee` is not exposed as a control: FX-01 lists five compressor
+			// parameters and a sixth would be a knob without a stated purpose. A
+			// fixed moderate knee keeps low ratios musical rather than abrupt.
+			applyParam(compressor.knee, 6, initial);
+			applyParam(compressor.threshold, values.threshold, initial);
+			applyParam(compressor.ratio, values.ratio, initial);
+			applyParam(compressor.attack, values.attack, initial);
+			applyParam(compressor.release, values.release, initial);
+			applyParam(makeup.volume, values.makeup, initial);
+		},
+		/**
+		 * The node's own `reduction`, in dB: 0 when the compressor is not working
+		 * and increasingly negative as it clamps down. Returned as a *positive*
+		 * magnitude, which is how a gain-reduction meter reads, and polled by the
+		 * panel — never pushed as an analytics event, so metering adds no
+		 * per-frame telemetry.
+		 */
+		gainReductionDb() {
+			return Math.abs(compressor.reduction);
+		},
+		dispose() {
+			compressor.dispose();
+			makeup.dispose();
+		},
+	};
+};

--- a/src/audio/devices/compressor.ts
+++ b/src/audio/devices/compressor.ts
@@ -7,16 +7,29 @@ import {
 } from "./types";
 
 /**
+ * How far below a ceiling of exactly 0 {@link applyParam} keeps a value. A
+ * millionth of a decibel is not a different threshold to any ear or any meter;
+ * it exists only to keep the value off the one number Tone treats specially.
+ */
+const ZERO_CEILING_EPSILON = 1e-6;
+
+/**
  * Applies one `DynamicsCompressorNode` param through the shared
  * {@link setOrRamp}, first clamping into the range the node itself accepts.
  *
  * The clamp is this device's own concern: the registered ranges sit inside the
  * node's, but a stored value from a future range change must not reach it out
- * of bounds. `setOrRamp` also guarantees a *linear* ramp, which matters
- * specifically here — Tone picks an exponential curve for a decibel param, and
- * an exponential ramp cannot reach 0, so a threshold of 0 dB (the legitimate
- * top of the registered range, meaning "do not compress") threw `RangeError`
- * rather than applying.
+ * of bounds.
+ *
+ * Zero gets clamped away from a ceiling of 0 for a narrower reason. Tone's
+ * ramps refuse to *start* from exactly zero — `Param.setRampPoint` pins the
+ * param's current value and substitutes its `_minOutput` (1e-7) for a zero,
+ * because an exponential ramp can never leave zero. For the threshold, whose
+ * accepted range tops out at 0 dB, that substituted 1e-7 is itself out of
+ * range, so a value of 0 dB applies fine and then throws `RangeError` on the
+ * *next* edit that ramps away from it. Since 0 dB is the legitimate top of the
+ * registered range ("do not compress"), the fix is to never store the literal
+ * zero: -1e-6 dB behaves identically and every later ramp stays in range.
  */
 function applyParam(
 	param: RampableParam & {
@@ -26,11 +39,8 @@ function applyParam(
 	value: number,
 	initial: boolean,
 ): void {
-	setOrRamp(
-		param,
-		Math.min(param.maxValue, Math.max(param.minValue, value)),
-		initial,
-	);
+	const ceiling = param.maxValue === 0 ? -ZERO_CEILING_EPSILON : param.maxValue;
+	setOrRamp(param, Math.min(ceiling, Math.max(param.minValue, value)), initial);
 }
 
 /**


### PR DESCRIPTION
## What & why

4 of 8 in the LOOP-009 stack (builds on #183). Adds the compressor device core with threshold, ratio, attack, release, and makeup gain, plus gain-reduction metering with deterministic offline-render tests.

Refs #49

PRD: FX-01 (compression exposes threshold, ratio, attack, release, and makeup gain with gain-reduction metering).

## Walkthrough

No UI change — device core only, not yet wired into `ProjectAudioGraph` (that's PR 7 of this stack).

## Evidence

`bun run typecheck`, `bun run test`, and `bun run check` pass on this commit in isolation. This branch passed an Opus review round in the implementation workflow.

## Acceptance criteria met

- [x] Compressor exposes threshold, ratio, attack, release, and makeup gain with gain-reduction metering.
- [x] Deterministic audio tests cover normal and extreme compressor settings.
- Remaining LOOP-009 acceptance boxes (delay, reverb, live wiring, limiter interaction) are addressed by later PRs in this stack.

---

_Generated by [Claude Code](https://claude.ai/code)_