### PR TITLE
LOOP-009 - Tempo-syncable stereo delay device core

### DIFF
--- a/src/audio/devices/delay.test.ts
+++ b/src/audio/devices/delay.test.ts
@@ -1,0 +1,209 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { createDevice, defaultDeviceParameters } from "../../domain/devices";
+import type { Device } from "../../domain/entities";
+import type { DeviceId } from "../../domain/ids";
+import {
+	hfEnergy,
+	installWebAudioGlobals,
+	rms,
+	rmsWindow,
+} from "../testAudioContext";
+
+// Must run before Tone is imported — see AudioRuntime.test.ts for why.
+installWebAudioGlobals();
+
+let Tone: typeof import("tone");
+let deviceNode: typeof import("./deviceNode");
+let delay: typeof import("./delay");
+
+beforeAll(async () => {
+	Tone = await import("tone");
+	deviceNode = await import("./deviceNode");
+	delay = await import("./delay");
+});
+
+function context(tempo = 120) {
+	return { scope: null as never, tempo: () => tempo };
+}
+
+function device(
+	type: Parameters<typeof createDevice>[1],
+	overrides: Record<string, number> = {},
+): Device {
+	return {
+		...createDevice("dev_time" as DeviceId, type, 0),
+		parameters: { ...defaultDeviceParameters(type), ...overrides },
+	};
+}
+
+/**
+ * Renders a short burst — a sine that stops a quarter of the way in — through
+ * one device, so what happens *after* the source stops is measurable. That is
+ * the only way to assert on a tail or a repeat: with a continuous source the
+ * wet signal is indistinguishable from the dry one.
+ */
+async function renderBurst(
+	create: import("./types").DeviceCoreFactory,
+	d: Device,
+	duration: number,
+	options: { source?: "sine" | "noise"; tempo?: number } = {},
+): Promise<Float32Array> {
+	const buffer = await Tone.Offline(() => {
+		const node = deviceNode.buildDeviceNode(
+			d,
+			context(options.tempo ?? 120),
+			create,
+		);
+		// White noise is the probe for anything measuring a *filter*: it has
+		// energy at every frequency, so removing the top of the band shows up
+		// unambiguously. A 220 Hz sine (the probe used elsewhere here) has almost
+		// nothing above 400 Hz to begin with, so a lowpass sweeping between 400 Hz
+		// and 18 kHz leaves its `hfEnergy`-per-level *identical* — which is what
+		// made the first version of the delay damping test measure nothing.
+		const source =
+			options.source === "noise"
+				? new Tone.Noise("white")
+				: new Tone.Oscillator({ type: "sine", frequency: 220 });
+		source.connect(node.input);
+		node.output.toDestination();
+		source.start(0).stop(duration * 0.25);
+	}, duration);
+	return buffer.getChannelData(0);
+}
+
+describe("delay (FX-01)", () => {
+	it("derives a synced time from the song tempo and ignores the free time", () => {
+		const values = {
+			...defaultDeviceParameters("delay"),
+			sync: 1,
+			division: 5,
+		};
+		// Division 5 is a 1/4 note: one beat, so 0.5 s at 120 BPM and 1 s at 60.
+		expect(delay.delaySeconds(values, 120)).toBeCloseTo(0.5, 5);
+		expect(delay.delaySeconds(values, 60)).toBeCloseTo(1, 5);
+		// Changing the free time changes nothing while synced.
+		expect(delay.delaySeconds({ ...values, time: 0.001 }, 120)).toBeCloseTo(
+			0.5,
+			5,
+		);
+	});
+
+	it("uses the free time verbatim and ignores tempo when sync is off", () => {
+		const values = {
+			...defaultDeviceParameters("delay"),
+			sync: 0,
+			time: 0.375,
+		};
+		expect(delay.delaySeconds(values, 120)).toBeCloseTo(0.375, 5);
+		expect(delay.delaySeconds(values, 200)).toBeCloseTo(0.375, 5);
+	});
+
+	it("bounds the delay line however slow the tempo or hostile the value", () => {
+		const synced = {
+			...defaultDeviceParameters("delay"),
+			sync: 1,
+			division: 6,
+		};
+		// A half note at an absurdly slow tempo would want far more than the
+		// allocated line; it is clamped rather than allocating without limit.
+		expect(delay.delaySeconds(synced, 1)).toBeLessThanOrEqual(4);
+		// A non-finite tempo falls back rather than producing NaN, which would
+		// poison the delay's `AudioParam` permanently.
+		expect(Number.isFinite(delay.delaySeconds(synced, Number.NaN))).toBe(true);
+	});
+
+	it("produces audible repeats after the source stops", async () => {
+		const data = await renderBurst(
+			delay.createDelayCore,
+			device("delay", { sync: 0, time: 0.1, feedback: 0.7, wet: 1 }),
+			1,
+		);
+		// The source stops at 0.25 s; energy well after that is the repeats.
+		expect(rmsWindow(data, 0.45, 0.7)).toBeGreaterThan(0.001);
+	});
+
+	it("darkens each successive repeat through the feedback damping filter", async () => {
+		const data = await renderBurst(
+			delay.createDelayCore,
+			device("delay", {
+				sync: 0,
+				time: 0.1,
+				feedback: 0.8,
+				filter: 600,
+				wet: 1,
+			}),
+			1.5,
+			// Noise, so there is high-frequency content for the loop filter to
+			// remove repeat by repeat — see `renderBurst`.
+			{ source: "noise" },
+		);
+		const early = data.subarray(
+			Math.floor(data.length * 0.3),
+			Math.floor(data.length * 0.45),
+		);
+		const late = data.subarray(
+			Math.floor(data.length * 0.7),
+			Math.floor(data.length * 0.85),
+		);
+		// Per unit of level, later repeats carry less high-frequency content —
+		// which is what stops a near-unity feedback from being a bright runaway.
+		expect(hfEnergy(late) / Math.max(1e-9, rms(late))).toBeLessThan(
+			hfEnergy(early) / Math.max(1e-9, rms(early)),
+		);
+	});
+
+	it("stays finite and bounded at the top of its feedback range (FX-02)", async () => {
+		const data = await renderBurst(
+			delay.createDelayCore,
+			device("delay", { sync: 0, time: 0.05, feedback: 0.99, wet: 1 }),
+			2,
+		);
+		expect(data.every((s) => Number.isFinite(s))).toBe(true);
+		// The saturator inside the feedback loop bounds what can circulate to
+		// ±1, so the device's own output stays near unity plus the dry signal.
+		// Without it this measured ~16 — fresh input keeps summing into the loop
+		// while the source plays, so a sub-unity feedback gain alone does *not*
+		// bound the result (FX-02: validation prevents unsafe output levels).
+		expect(Math.max(...data.map(Math.abs))).toBeLessThan(2.5);
+	});
+
+	it("widens the two channels with spread", async () => {
+		async function channelDifference(spread: number): Promise<number> {
+			const buffer = await Tone.Offline(() => {
+				const node = deviceNode.buildDeviceNode(
+					device("delay", {
+						sync: 0,
+						time: 0.1,
+						feedback: 0.5,
+						spread,
+						wet: 1,
+					}),
+					context(),
+					delay.createDelayCore,
+				);
+				const osc = new Tone.Oscillator({ type: "sine", frequency: 220 });
+				osc.connect(node.input);
+				node.output.toDestination();
+				osc.start(0).stop(0.2);
+			}, 1);
+			const l = buffer.getChannelData(0);
+			const r = buffer.getChannelData(buffer.numberOfChannels > 1 ? 1 : 0);
+			let sum = 0;
+			for (let i = 0; i < l.length; i++) sum += (l[i] - r[i]) ** 2;
+			return Math.sqrt(sum / l.length);
+		}
+		expect(await channelDifference(1)).toBeGreaterThan(
+			await channelDifference(0),
+		);
+	});
+
+	it("disposes without stranding its feedback loop", () => {
+		const node = deviceNode.buildDeviceNode(
+			device("delay"),
+			context(),
+			delay.createDelayCore,
+		);
+		node.dispose();
+		expect(() => node.dispose()).not.toThrow();
+	});
+});

--- a/src/audio/devices/delay.ts
+++ b/src/audio/devices/delay.ts
@@ -1,0 +1,129 @@
+import * as Tone from "tone";
+import { delayDivision } from "../../domain/devices";
+import {
+	type DeviceCore,
+	type DeviceCoreFactory,
+	type DeviceParameterValues,
+	setOrRamp,
+} from "./types";
+
+/** The longest delay line the device will allocate, in seconds. Bounds the
+ * memory a synced delay can demand at a very slow tempo (FX-02: validation
+ * "prevents ... runaway resource use"). */
+const MAX_DELAY_SECONDS = 4;
+
+/**
+ * The delay time one channel should use, in seconds.
+ *
+ * When `sync` is on, the time comes from the song tempo and the stored
+ * division; when it is off, `delay.time` is the delay in seconds and tempo is
+ * irrelevant (FX-01: "Delay supports synced and free timing"). Either way the
+ * result is clamped into the allocated delay line so a hostile stored value or
+ * an extreme tempo cannot ask for an unbounded buffer.
+ */
+export function delaySeconds(
+	values: DeviceParameterValues,
+	tempo: number,
+): number {
+	const free = values.time;
+	if (values.sync < 0.5) return Math.min(MAX_DELAY_SECONDS, Math.max(0, free));
+	const safeTempo = Number.isFinite(tempo) && tempo > 0 ? tempo : 120;
+	// A whole note is four beats, so `240 / bpm` seconds.
+	const synced = (240 / safeTempo) * delayDivision(values.division).wholeNotes;
+	return Math.min(MAX_DELAY_SECONDS, Math.max(0, synced));
+}
+
+/**
+ * Tempo-syncable stereo delay with feedback and damping (PRD FX-01: "Delay
+ * supports synced and free timing, feedback, filtering, stereo behavior, and
+ * wet/dry control").
+ *
+ * The two channels each have their own delay line, and `spread` offsets the
+ * right one by up to a full division — 0 is a centred mono delay, 1 a wide
+ * ping-pong. Feedback is shared and passes through the damping filter, so each
+ * repeat is darker than the last rather than a bright copy repeating forever;
+ * that filter in the loop is also what keeps a near-unity feedback (0.99, the
+ * top of the deliberately extreme range) a long decaying tail instead of a
+ * runaway.
+ *
+ * Every control ramps on the existing nodes. A delay *time* change is ramped
+ * too, which pitches the repeats as it moves — the tape-style behavior a
+ * musician expects from turning a delay-time knob, and what a synced delay does
+ * when the song tempo changes under it.
+ */
+export const createDelayCore: DeviceCoreFactory = (): DeviceCore => {
+	const input = new Tone.Gain(1);
+	const splitter = new Tone.Split();
+	const left = new Tone.Delay({ maxDelay: MAX_DELAY_SECONDS });
+	const right = new Tone.Delay({ maxDelay: MAX_DELAY_SECONDS });
+	const damping = new Tone.Filter({ type: "lowpass", frequency: 8_000 });
+	const feedback = new Tone.Gain(0);
+	/**
+	 * A soft saturator inside the feedback loop, bounding what can circulate.
+	 *
+	 * Feedback below 1 makes each *repeat* quieter than the last, but it does
+	 * not bound the loop while the source is still feeding it: fresh input keeps
+	 * adding to what is already circulating, and at the top of the range (0.99)
+	 * that sums to roughly 1/(1-g) ≈ 100x before it settles. Measured without
+	 * this stage the device handed on a peak of ~16, which is precisely the
+	 * "unsafe output level" FX-02 requires validation to prevent — and leaving it
+	 * to the master limiter would mean every device after this one in the chain
+	 * still sees the overload.
+	 *
+	 * A tanh curve is the right shape rather than a hard clamp: it bounds the
+	 * loop to ±1 while staying smooth, so a long tail saturates gently into the
+	 * classic tape-delay warmth instead of buzzing. It is inaudible at ordinary
+	 * feedback settings, where the loop never approaches the knee.
+	 */
+	const feedbackLimit = new Tone.WaveShaper((x: number) => Math.tanh(x), 1024);
+	const merger = new Tone.Merge();
+	const output = new Tone.Gain(1);
+
+	input.connect(splitter);
+	splitter.connect(left, 0, 0);
+	splitter.connect(right, 1, 0);
+	left.connect(merger, 0, 0);
+	right.connect(merger, 0, 1);
+	// One shared feedback path through the damping filter and the loop limiter,
+	// folded back into the input so both channels' repeats decay together and
+	// stay in step.
+	merger.connect(damping);
+	damping.connect(feedback);
+	feedback.connect(feedbackLimit);
+	feedbackLimit.connect(input);
+	merger.connect(output);
+
+	return {
+		input,
+		output,
+		apply(values, ctx, initial) {
+			const base = delaySeconds(values, ctx.tempo());
+			setOrRamp(left.delayTime, base, initial);
+			// The right channel trails by up to one more division's worth, still
+			// inside the allocated line.
+			setOrRamp(
+				right.delayTime,
+				Math.min(MAX_DELAY_SECONDS, base * (1 + values.spread)),
+				initial,
+			);
+			setOrRamp(feedback.gain, values.feedback, initial);
+			setOrRamp(damping.frequency, values.filter, initial);
+		},
+		dispose() {
+			// Break the feedback loop first: a cycle left connected while its nodes
+			// are torn down one at a time is the classic way to strand a live
+			// path in the graph.
+			feedback.disconnect();
+			feedbackLimit.disconnect();
+			input.dispose();
+			splitter.dispose();
+			left.dispose();
+			right.dispose();
+			damping.dispose();
+			feedback.dispose();
+			feedbackLimit.dispose();
+			merger.dispose();
+			output.dispose();
+		},
+	};
+};


### PR DESCRIPTION
## What & why

5 of 8 in the LOOP-009 stack (builds on #184). Adds the tempo-syncable stereo delay device core: synced and free timing, feedback, filtering, stereo spread, and wet/dry control, with deterministic offline-render tests.

A sub-unity feedback gain does not by itself bound a delay — each individual repeat is quieter, but fresh input keeps summing into what is already circulating, and at the top of the feedback range the device measured a peak around 16x. That is exactly the "unsafe output level" FX-02 requires validation to prevent, and leaving it to the master limiter would mean every later device in the chain still saw the overload. A tanh saturator now sits inside the feedback loop to bound it at the source.

Refs #49

PRD: FX-01 (delay supports synced and free timing, feedback, filtering, stereo behavior, and wet/dry control), FX-02 (validation prevents unsafe output levels without silently normalizing creative settings; feedback ranges include clearly labelled extreme settings that remain stable).

## Walkthrough

No UI change — device core only, not yet wired into `ProjectAudioGraph` (that's PR 7 of this stack).

## Evidence

`bun run typecheck`, `bun run test`, and `bun run check` pass on this commit in isolation. This branch passed an Opus review round in the implementation workflow.

## Acceptance criteria met

- [x] Delay supports synced and free timing, feedback, filtering, stereo behavior, and wet/dry control.
- [x] Deterministic audio tests cover normal and extreme feedback settings, including the runaway-feedback case validation now bounds.
- [x] Validation prevents unsafe output levels from delay feedback without flattening the sound by default (feedback saturator).
- Remaining LOOP-009 acceptance boxes (reverb, live wiring, limiter interaction with real devices) are addressed by later PRs in this stack.

---

_Generated by [Claude Code](https://claude.ai/code)_