### PR TITLE
LOOP-009 - Reverb device core

### DIFF
--- a/src/audio/devices/reverb.test.ts
+++ b/src/audio/devices/reverb.test.ts
@@ -1,0 +1,163 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { createDevice, defaultDeviceParameters } from "../../domain/devices";
+import type { Device } from "../../domain/entities";
+import type { DeviceId } from "../../domain/ids";
+import {
+	hfEnergy,
+	installWebAudioGlobals,
+	rms,
+	rmsWindow,
+} from "../testAudioContext";
+
+// Must run before Tone is imported — see AudioRuntime.test.ts for why.
+installWebAudioGlobals();
+
+let Tone: typeof import("tone");
+let deviceNode: typeof import("./deviceNode");
+let reverb: typeof import("./reverb");
+
+beforeAll(async () => {
+	Tone = await import("tone");
+	deviceNode = await import("./deviceNode");
+	reverb = await import("./reverb");
+});
+
+// The reverb reads no tempo; the context is here only to satisfy the factory.
+const context = { scope: null as never, tempo: () => 120 };
+
+function device(overrides: Record<string, number> = {}): Device {
+	return {
+		...createDevice("dev_reverb" as DeviceId, "reverb", 0),
+		parameters: { ...defaultDeviceParameters("reverb"), ...overrides },
+	};
+}
+
+/**
+ * Renders a short burst — a sine that stops a quarter of the way in — through
+ * one device, so what happens *after* the source stops is measurable. That is
+ * the only way to assert on a tail or a repeat: with a continuous source the
+ * wet signal is indistinguishable from the dry one.
+ */
+async function renderBurst(
+	create: import("./types").DeviceCoreFactory,
+	d: Device,
+	duration: number,
+	options: { source?: "sine" | "noise" } = {},
+): Promise<Float32Array> {
+	const buffer = await Tone.Offline(async () => {
+		const node = deviceNode.buildDeviceNode(d, context, create);
+		// The reverb builds its impulse response off the audio thread, so a
+		// render started before it lands has no tail at all. `Tone.Offline`
+		// awaits an async callback before rendering, which is exactly the hook
+		// this needs.
+		await node.ready?.();
+		// White noise is the probe for anything measuring a *filter*: it has
+		// energy at every frequency, so removing the top of the band shows up
+		// unambiguously. A 220 Hz sine (the probe used elsewhere here) has almost
+		// nothing above 400 Hz to begin with, so a lowpass sweeping between 400 Hz
+		// and 18 kHz leaves its `hfEnergy`-per-level *identical* — which is what
+		// made the first version of the reverb damping test measure nothing.
+		const source =
+			options.source === "noise"
+				? new Tone.Noise("white")
+				: new Tone.Oscillator({ type: "sine", frequency: 220 });
+		source.connect(node.input);
+		node.output.toDestination();
+		source.start(0).stop(duration * 0.25);
+	}, duration);
+	return buffer.getChannelData(0);
+}
+
+describe("reverb (FX-01)", () => {
+	it("rings on after the source stops, and longer with a longer decay", async () => {
+		// Noise rather than a sine: `Tone.Reverb` builds each impulse response
+		// from unseeded noise, and a broadband source excites the whole impulse
+		// so the measured tail reflects the decay setting rather than however
+		// this particular impulse happened to land near 220 Hz. Averaging a few
+		// renders removes what variance is left.
+		async function meanTail(decay: number): Promise<number> {
+			let total = 0;
+			for (let i = 0; i < 3; i++) {
+				const data = await renderBurst(
+					reverb.createReverbCore,
+					device({ decay, size: 0.5, wet: 1 }),
+					2,
+					{ source: "noise" },
+				);
+				// The source stops a quarter of the way in; this window is tail only.
+				total += rmsWindow(data, 0.6, 0.9);
+			}
+			return total / 3;
+		}
+		expect(await meanTail(4)).toBeGreaterThan((await meanTail(0.3)) * 2);
+	});
+
+	it("damps the tail with its filter", async () => {
+		// Measured with a *noise* burst: see `renderBurst` for why a sine cannot
+		// detect this filter at all.
+		async function brightness(cutoff: number): Promise<number> {
+			const data = await renderBurst(
+				reverb.createReverbCore,
+				device({ decay: 2, filter: cutoff, wet: 1 }),
+				1,
+				{ source: "noise" },
+			);
+			// Normalised by level, so this compares tone rather than loudness —
+			// a 400 Hz lowpass drops the total level too.
+			return hfEnergy(data) / Math.max(1e-9, rms(data));
+		}
+		// The gap here is roughly 18x, far larger than the run-to-run spread from
+		// `Tone.Reverb` building each impulse response from unseeded noise, so a
+		// wide margin keeps this deterministic rather than pinning one impulse.
+		expect(await brightness(400)).toBeLessThan((await brightness(18_000)) / 4);
+	});
+
+	it("regenerates its impulse only when decay, size, or pre-delay changed", () => {
+		const core = reverb.createReverbCore(device(), context);
+		// `Tone.Reverb`'s `decay` and `preDelay` setters each rebuild the impulse
+		// themselves, so counting assignments to them counts regenerations —
+		// and proves nothing here calls `generate()` a second, redundant time.
+		const node = core.input as unknown as { decay: number; preDelay: number };
+		let rebuilds = 0;
+		for (const key of ["decay", "preDelay"] as const) {
+			let stored = node[key];
+			Object.defineProperty(node, key, {
+				get: () => stored,
+				set: (v: number) => {
+					rebuilds++;
+					stored = v;
+				},
+				configurable: true,
+			});
+		}
+
+		const values = { ...defaultDeviceParameters("reverb") };
+		// The first apply writes both, so one regeneration's worth of settings.
+		core.apply(values, context, true);
+		expect(rebuilds).toBe(2);
+
+		core.apply(values, context, false);
+		expect(rebuilds).toBe(2); // identical values: nothing to rebuild
+
+		core.apply({ ...values, filter: 1_000 }, context, false);
+		// A filter-only edit is a ramp on the damping node. Regenerating here
+		// would restart a ringing tail from a fresh impulse for no reason.
+		expect(rebuilds).toBe(2);
+
+		core.apply({ ...values, decay: 6 }, context, false);
+		expect(rebuilds).toBe(4);
+		core.apply({ ...values, decay: 6, size: 0.9 }, context, false);
+		expect(rebuilds).toBe(6);
+
+		core.dispose();
+	});
+
+	it("stays finite at the longest decay it allows (FX-02)", async () => {
+		const data = await renderBurst(
+			reverb.createReverbCore,
+			device({ decay: 30, size: 1, wet: 1 }),
+			1,
+		);
+		expect(data.every((s) => Number.isFinite(s))).toBe(true);
+	});
+});

--- a/src/audio/devices/reverb.ts
+++ b/src/audio/devices/reverb.ts
@@ -1,0 +1,58 @@
+import * as Tone from "tone";
+import { type DeviceCore, type DeviceCoreFactory, setOrRamp } from "./types";
+
+/**
+ * Reverb: pre-delay into a decaying tail, with a damping filter (PRD FX-01:
+ * "Reverb supports decay/size, pre-delay, filtering, and wet/dry control").
+ *
+ * `Tone.Reverb` generates its impulse response from `decay` and `preDelay`, and
+ * regenerating it is asynchronous — so `decay` and `size` are the two controls
+ * that cannot be a plain `AudioParam` ramp. Assigning either setter regenerates
+ * the impulse *on the same node* (which is why nothing here calls `generate()`
+ * explicitly — that would be a second, redundant rebuild), and the guard below
+ * assigns only when the value actually changed, so an unrelated edit (wet,
+ * filter, bypass) never pays for a regeneration and never interrupts a ringing
+ * tail.
+ *
+ * `size` scales the pre-delay and the decay together — a small bright box
+ * versus a large hall — while `decay` sets how long the tail lasts, which is
+ * what makes the two independently useful rather than one control twice.
+ */
+export const createReverbCore: DeviceCoreFactory = (): DeviceCore => {
+	const reverb = new Tone.Reverb({ decay: 2.5, preDelay: 0.01 });
+	const damping = new Tone.Filter({ type: "lowpass", frequency: 6_000 });
+	reverb.connect(damping);
+
+	let lastDecay = Number.NaN;
+	let lastSize = Number.NaN;
+	let lastPreDelay = Number.NaN;
+
+	return {
+		input: reverb,
+		output: damping,
+		apply(values, _context, initial) {
+			const sizeChanged = values.size !== lastSize;
+			if (
+				values.decay !== lastDecay ||
+				sizeChanged ||
+				values.predelay !== lastPreDelay
+			) {
+				lastDecay = values.decay;
+				lastSize = values.size;
+				lastPreDelay = values.predelay;
+				// Size stretches the tail between half and double the stated decay,
+				// so the two controls compose instead of one overriding the other.
+				reverb.decay = Math.max(0.001, values.decay * (0.5 + values.size));
+				// A larger room's first reflection arrives later; the stated
+				// pre-delay is the floor, size adds up to 50 ms of distance on top.
+				reverb.preDelay = values.predelay + values.size * 0.05;
+			}
+			setOrRamp(damping.frequency, values.filter, initial);
+		},
+		ready: () => reverb.ready,
+		dispose() {
+			reverb.dispose();
+			damping.dispose();
+		},
+	};
+};


### PR DESCRIPTION
## What & why

6 of 8 in the LOOP-009 stack (builds on #185). Adds the reverb device core: decay/size, pre-delay, filtering, and wet/dry control, with deterministic offline-render tests.

`Tone.Reverb` builds its impulse response from unseeded noise, so comparing absolute energy across two renders directly is not deterministic. The tests instead average several renders and assert wide margins, which is enough to distinguish normal from extreme settings without depending on exact sample values.

Refs #49

PRD: FX-01 (reverb supports decay/size, pre-delay, filtering, and wet/dry control).

## Walkthrough

No UI change — device core only, not yet wired into `ProjectAudioGraph` (that's the next PR in this stack).

## Evidence

`bun run typecheck`, `bun run test`, and `bun run check` pass on this commit in isolation. This branch passed an Opus review round in the implementation workflow.

## Acceptance criteria met

- [x] Reverb supports decay/size, pre-delay, filtering, and wet/dry control.
- [x] Deterministic audio tests (averaged across renders, given the unseeded impulse source) cover normal and extreme decay/size settings.
- Remaining LOOP-009 acceptance boxes (live wiring, limiter interaction with real devices) are addressed by the final two PRs in this stack.

---

_Generated by [Claude Code](https://claude.ai/code)_