### PR TITLE
LOOP-009 - Wire the six device cores into ProjectAudioGraph

### DIFF
--- a/src/audio/DeviceChain.ts
+++ b/src/audio/DeviceChain.ts
@@ -37,16 +37,21 @@ export interface DeviceNode {
 	ready?(): Promise<void>;
 }
 
-export type DeviceNodeFactory = (device: Device) => DeviceNode;
+/**
+ * Builds the node for one device. Returning `undefined` means "this `type` has
+ * no DSP behind it", and the chain substitutes an inert passthrough — see
+ * {@link createPassthroughDeviceNode}.
+ */
+export type DeviceNodeFactory = (device: Device) => DeviceNode | undefined;
 
 /**
- * Schema v1 defines the generic `Device` shape (id, type, order, bypass,
- * parameters) but no concrete processors — filter/EQ, overdrive, compression,
- * delay, and reverb are authored with their devices in Alpha Milestone 1 (PRD section
- * 7.3). Until a factory is registered for a `device.type`, the chain gives it
- * an inert passthrough node instead of refusing to build the graph, so
- * topology — insertion, removal, and reordering — is fully provable ahead of
- * any real DSP.
+ * The node a `device.type` with no registered core gets: an inert passthrough,
+ * rather than a refusal to build the graph at all.
+ *
+ * That matters in two situations. It let LOOP-008 prove chain topology —
+ * insertion, removal, reordering — before LOOP-009 authored any real DSP; and
+ * it means a project referencing a device type this build does not know (one
+ * saved by a later build, say) still loads and plays the rest of its chain.
  */
 export function createPassthroughDeviceNode(device: Device): DeviceNode {
 	const node = new Tone.Gain(1);
@@ -138,7 +143,8 @@ export class DeviceChain {
 			if (existing) {
 				existing.node.update(device);
 			} else {
-				const node = this.createNode(device);
+				const node =
+					this.createNode(device) ?? createPassthroughDeviceNode(device);
 				const handle = this.scope.register("node", () => node.dispose());
 				this.nodes.set(device.id, { node, handle });
 				compositionChanged = true;

--- a/src/audio/ProjectAudioGraph.ts
+++ b/src/audio/ProjectAudioGraph.ts
@@ -7,6 +7,7 @@ import type {
 	ReturnId,
 	TrackId,
 } from "../domain/ids";
+import { SONG_TEMPO } from "../domain/parameters";
 import { TICKS_PER_QUARTER } from "../domain/time";
 import type {
 	AudioAssetProjection,
@@ -24,6 +25,7 @@ import {
 import type { AudioHost, AudioProjectScope } from "./AudioRuntime";
 import { playAudioLoop } from "./audioLoopPlayer";
 import type { DeviceNodeFactory } from "./DeviceChain";
+import { createDeviceNodeFactory } from "./devices";
 import type { InstrumentNodeFactory } from "./InstrumentGraph";
 import { MasterAudioGraph } from "./MasterAudioGraph";
 import { ReturnAudioGraph } from "./ReturnAudioGraph";
@@ -160,7 +162,17 @@ export class ProjectAudioGraph {
 			{ onLoadFailure: options.onAssetLoadFailure },
 		);
 		this.createInstrument = options.createInstrument;
-		this.createDeviceNode = options.createDeviceNode;
+		// The six core processing devices (PRD FX-01, LOOP-009). A test may
+		// substitute its own factory; production always gets the real DSP. The
+		// tempo reader is read *at apply time* from the latest projection, so a
+		// tempo-synced delay follows a tempo change without the graph rebuilding
+		// anything.
+		this.createDeviceNode =
+			options.createDeviceNode ??
+			createDeviceNodeFactory({
+				scope: this.scope,
+				tempo: () => this.lastProjection?.tempo ?? SONG_TEMPO.defaultValue,
+			});
 		this.underrunMonitor = options.underrunMonitor;
 		this.now = options.now ?? audioClockNow;
 		this.master = new MasterAudioGraph(

--- a/src/audio/devices/index.ts
+++ b/src/audio/devices/index.ts
@@ -1,0 +1,58 @@
+import type { Device } from "../../domain/entities";
+import type { DeviceNode, DeviceNodeFactory } from "../DeviceChain";
+import { createCompressorCore } from "./compressor";
+import { createDelayCore } from "./delay";
+import { buildDeviceNode } from "./deviceNode";
+import { createOverdriveCore, createSaturatorCore } from "./distortion";
+import { createFilterCore } from "./filter";
+import { createReverbCore } from "./reverb";
+import type { DeviceCoreFactory, DeviceGraphContext } from "./types";
+
+export { buildDeviceNode } from "./deviceNode";
+export type { DeviceCore, DeviceGraphContext } from "./types";
+export { DEVICE_SMOOTHING_SECONDS, setOrRamp } from "./types";
+
+/**
+ * The alpha's six core processing devices, keyed by the `type` string
+ * `src/domain/devices.ts` registers them under (PRD FX-01). This map is the one
+ * place a `device.type` becomes real DSP; adding a seventh device is a new core
+ * module plus one entry here.
+ */
+const DEVICE_CORES: Readonly<Record<string, DeviceCoreFactory>> = {
+	filter: createFilterCore,
+	overdrive: createOverdriveCore,
+	saturator: createSaturatorCore,
+	compressor: createCompressorCore,
+	delay: createDelayCore,
+	reverb: createReverbCore,
+};
+
+/**
+ * Builds the {@link DeviceNodeFactory} `DeviceChain` uses, given a way to read
+ * the song's current tempo (which only the tempo-syncable delay consults).
+ *
+ * A `device.type` with no registered core returns `undefined`, which leaves
+ * `DeviceChain` to fall back to its inert passthrough. That is deliberate: an
+ * unknown type — a project saved by a future build, say — must still load and
+ * play the rest of the chain rather than failing to build the graph at all.
+ */
+export function createDeviceNodeFactory(
+	context: DeviceGraphContext,
+): DeviceNodeFactory {
+	return (device: Device): DeviceNode | undefined => {
+		const createCore = DEVICE_CORES[device.type];
+		if (!createCore) return undefined;
+		return buildDeviceNode(device, context, createCore);
+	};
+}
+
+/** Whether a `device.type` has real DSP behind it, rather than a passthrough. */
+export function hasDeviceCore(type: string): boolean {
+	return type in DEVICE_CORES;
+}
+
+/** Every `device.type` with a registered core. Lets a test prove this map and
+ * the domain's device-type registry have not drifted apart in either direction. */
+export function registeredDeviceCoreTypes(): readonly string[] {
+	return Object.keys(DEVICE_CORES);
+}

--- a/src/audio/devices/registry.test.ts
+++ b/src/audio/devices/registry.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { deviceTypes } from "../../domain/devices";
+import type { Device } from "../../domain/entities";
+import type { DeviceId } from "../../domain/ids";
+import { installWebAudioGlobals } from "../testAudioContext";
+
+// Must run before Tone is imported — see AudioRuntime.test.ts for why.
+installWebAudioGlobals();
+
+let registry: typeof import("./index");
+
+beforeAll(async () => {
+	registry = await import("./index");
+});
+
+const context = { scope: null as never, tempo: () => 120 };
+
+describe("device core registry (FX-01)", () => {
+	it("has real DSP behind every registered device type", () => {
+		// The domain registry and the audio registry must not drift: a type the
+		// user can add from the palette but that silently renders as a
+		// passthrough would look like a working device that does nothing.
+		for (const definition of deviceTypes()) {
+			expect(registry.hasDeviceCore(definition.type)).toBe(true);
+		}
+	});
+
+	/**
+	 * Deliberately does *not* construct the nodes.
+	 *
+	 * Building the six real cores here — the reverb in particular, which
+	 * generates an impulse response against whatever context it is constructed
+	 * in — is both slow (~80 s against the live context) and, worse, it
+	 * disturbs the shared global context for every test that runs after it in
+	 * the same worker. Adding that here took these suites from green to failing
+	 * 9 runs in 10, with timeouts landing on unrelated tests.
+	 *
+	 * Each core's behavior is covered by its own suite, inside an offline
+	 * render. What is left for the registry to prove is only the *mapping*, so
+	 * that is all this asserts.
+	 */
+	it("maps every registered device type to a distinct core", () => {
+		const factory = registry.createDeviceNodeFactory(context);
+		expect(typeof factory).toBe("function");
+		const types = deviceTypes().map((d) => d.type);
+		expect(types.length).toBeGreaterThan(0);
+		expect(types.every((type) => registry.hasDeviceCore(type))).toBe(true);
+		// And nothing beyond them: an entry with no matching device type would
+		// be dead code that no palette can reach.
+		expect(registry.registeredDeviceCoreTypes().slice().sort()).toEqual(
+			types.slice().sort(),
+		);
+	});
+
+	it("leaves an unregistered type to the chain's passthrough fallback", () => {
+		const factory = registry.createDeviceNodeFactory(context);
+		const unknown: Device = {
+			id: "dev_unknown" as DeviceId,
+			type: "bitcrusher",
+			order: 0,
+			bypassed: false,
+			parameters: {},
+			preset: null,
+		};
+		// `undefined` is the contract for "no DSP behind this type"; the chain
+		// substitutes an inert passthrough so a project saved by a later build
+		// still loads and plays the rest of its chain.
+		expect(factory(unknown)).toBeUndefined();
+		expect(registry.hasDeviceCore("bitcrusher")).toBe(false);
+	});
+});


### PR DESCRIPTION
## What & why

7 of 8 in the LOOP-009 stack (builds on #186). Adds the device-type registry and wires it into `DeviceChain`'s factory seam, replacing `createPassthroughDeviceNode` as the default. This is the commit that makes FX-01 processing audible at all — before it, a device a user added to a track or the master was inert, because the seam always built an inert passthrough node regardless of `device.type`.

Refs #49

PRD: FX-01 (a device can be added, removed, reordered, duplicated, bypassed, and reset; live playback uses equivalent Solid Groove processing to offline render and the Ableton fallback stems), FX-02 (users can stack duplicate effects and place devices in unconventional orders).

## Walkthrough

No UI change — this wires DSP nodes into the existing audio graph; the device panel that exposes these controls is LOOP-008's UI (already landed) / a later slice. There is no new user-visible surface in this PR, but existing devices added through LOOP-008's UI now produce audible processing instead of silence.

## Evidence

`bun run typecheck`, `bun run check`, and `bun run test` all pass at this commit — 2052 tests, 155 files, matching the stack tip's full run. This branch passed an Opus review round in the implementation workflow.

## Acceptance criteria met

- [x] Each device type is a registered `device_type` value reachable in the live graph (the analytics catalog registration itself landed in LOOP-008; this PR is what makes the registered types actually build real nodes).
- [x] The alpha supports duplicate devices and unconventional ordering (`DeviceChain` reconciliation is unchanged from LOOP-008 — this PR only replaces what a `device.type` resolves to).
- [ ] Limiter interaction is not yet covered by this PR — `MasterAudioGraph.test.ts` still exercises the master safety limiter with a synthetic loud chain from LOOP-008, not with these real devices feeding it. Left unticked; see follow-up needed.
- Deterministic per-device audio tests were added in the earlier PRs in this stack, not here.

---

_Generated by [Claude Code](https://claude.ai/code)_