### PR TITLE
LOOP-009 - Make the tempo-synced delay actually follow tempo

### DIFF
--- a/src/audio/DeviceChain.ts
+++ b/src/audio/DeviceChain.ts
@@ -29,6 +29,13 @@ export interface DeviceNode {
 	 */
 	gainReductionDb?(): number;
 	/**
+	 * The delay time this device last resolved to, in seconds. Only the delay
+	 * implements it; a panel reads it to show what a *synced* delay currently
+	 * works out to, which depends on the song tempo and so is not derivable from
+	 * the stored parameters alone.
+	 */
+	resolvedDelaySeconds?(): number;
+	/**
 	 * Resolves once any asynchronously-built resource this device needs is in
 	 * place. Only the reverb implements it (its impulse response is generated
 	 * off the audio thread). Live playback never awaits it — a node keeps its
@@ -100,6 +107,10 @@ export class DeviceChain {
 	readonly output: Tone.Gain;
 	private readonly nodes = new Map<DeviceId, TrackedDevice>();
 	private order: DeviceId[] = [];
+	/** The exact `Device` object each node was last applied from, so a forced
+	 * re-apply (see `reconcile`'s `reapplyExisting`) is the only thing that
+	 * re-runs `update()` for a device whose own object did not change. */
+	private readonly lastDevices = new Map<DeviceId, Device>();
 	private readonly chainHandle: ReturnType<AudioProjectScope["register"]>;
 	/** True once the signal path has been wired at least once. Guards the very
 	 * first `relink()` (empty -> initial topology) so it connects directly at
@@ -125,8 +136,26 @@ export class DeviceChain {
 		});
 	}
 
-	/** Reconciles this chain's devices, ordered by chain position (`order`). */
-	reconcile(devices: readonly Device[]): void {
+	/** The live node for a device id, for a panel readout (gain reduction, a
+	 * synced delay's resolved time) or a test. Read access only — the chain owns
+	 * every node's lifetime. */
+	deviceNode(id: DeviceId): DeviceNode | undefined {
+		return this.nodes.get(id)?.node;
+	}
+
+	/**
+	 * Reconciles this chain's devices, ordered by chain position (`order`).
+	 *
+	 * `reapplyExisting` forces `update()` on every already-present node even when
+	 * its `Device` object is unchanged. A device parameter can depend on state
+	 * that lives *outside* its own `Device` — the tempo-synced delay resolves its
+	 * division against the song tempo — and a tempo-only edit changes no device,
+	 * no track, and no projection entry, so nothing here would otherwise re-run
+	 * `apply()` and the delay would stay on the old grid forever. The owning graph
+	 * sets this when such shared state moved; a routine edit leaves it false and
+	 * the chain behaves exactly as before.
+	 */
+	reconcile(devices: readonly Device[], reapplyExisting = false): void {
 		const nextIds = devices.map((device) => device.id);
 		const nextIdSet = new Set(nextIds);
 
@@ -134,6 +163,7 @@ export class DeviceChain {
 			if (!nextIdSet.has(id)) {
 				void this.scope.release(tracked.handle);
 				this.nodes.delete(id);
+				this.lastDevices.delete(id);
 			}
 		}
 
@@ -141,7 +171,9 @@ export class DeviceChain {
 		for (const device of devices) {
 			const existing = this.nodes.get(device.id);
 			if (existing) {
-				existing.node.update(device);
+				if (reapplyExisting || this.lastDevices.get(device.id) !== device) {
+					existing.node.update(device);
+				}
 			} else {
 				const node =
 					this.createNode(device) ?? createPassthroughDeviceNode(device);
@@ -149,6 +181,7 @@ export class DeviceChain {
 				this.nodes.set(device.id, { node, handle });
 				compositionChanged = true;
 			}
+			this.lastDevices.set(device.id, device);
 		}
 
 		const orderChanged =
@@ -232,6 +265,7 @@ export class DeviceChain {
 			void this.scope.release(tracked.handle);
 		}
 		this.nodes.clear();
+		this.lastDevices.clear();
 		this.order = [];
 		void this.scope.release(this.chainHandle);
 	}

--- a/src/audio/MasterAudioGraph.ts
+++ b/src/audio/MasterAudioGraph.ts
@@ -79,9 +79,18 @@ export class MasterAudioGraph {
 		return this.meter;
 	}
 
-	reconcile(next: AudioMasterProjection): void {
-		if (this.lastProjection === next) return;
-		this.deviceChain.reconcile(next.devices);
+	/**
+	 * `reapplyDevices` reports that state outside the master projection moved
+	 * (the song tempo, which a synced delay resolves against) and so must survive
+	 * the reference short-circuit — otherwise a tempo-only edit, which leaves this
+	 * projection reference-identical, would never reach the device chain.
+	 */
+	reconcile(next: AudioMasterProjection, reapplyDevices = false): void {
+		if (this.lastProjection === next) {
+			if (reapplyDevices) this.deviceChain.reconcile(next.devices, true);
+			return;
+		}
+		this.deviceChain.reconcile(next.devices, reapplyDevices);
 		this.volume.volume.rampTo(next.volume, 0.02);
 		this.lastProjection = next;
 	}

--- a/src/audio/ProjectAudioGraph.deviceTempo.test.ts
+++ b/src/audio/ProjectAudioGraph.deviceTempo.test.ts
@@ -1,0 +1,132 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { createDevice } from "../domain/devices";
+import type { Project } from "../domain/entities";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import type { DeviceId } from "../domain/ids";
+import { buildAudioProjection } from "../projection/audioProjection";
+import { installWebAudioGlobals } from "./testAudioContext";
+
+// Must run before Tone is imported — see AudioRuntime.test.ts for why.
+installWebAudioGlobals();
+
+let AudioRuntimeModule: typeof import("./AudioRuntime");
+let ProjectAudioGraphModule: typeof import("./ProjectAudioGraph");
+
+beforeAll(async () => {
+	AudioRuntimeModule = await import("./AudioRuntime");
+	ProjectAudioGraphModule = await import("./ProjectAudioGraph");
+});
+
+function fakeTransport(): import("./ProjectAudioGraph").AudioTransport {
+	let nextId = 1;
+	return {
+		bpm: { value: 120 },
+		schedule: () => nextId++,
+		clear: () => {},
+	};
+}
+
+/**
+ * The slice fixture with one tempo-synced delay on its first track, at `tempo`
+ * BPM. The delay is fully defaulted: `sync: 1` and `division: 3` (a 1/8 note),
+ * so its resolved time is one eighth of `240 / tempo` seconds — 0.25 s at 120
+ * BPM, 0.5 s at 60.
+ */
+const DELAY_ID = "dev_delay" as DeviceId;
+
+function projectWithDelay(tempo: number): Project {
+	const base = createSliceFixtureProject();
+	const delay = createDevice(DELAY_ID, "delay", 0);
+	return {
+		...base,
+		song: {
+			...base.song,
+			tempo,
+			tracks: base.song.tracks.map((track, index) =>
+				index === 0 ? { ...track, devices: [delay] } : track,
+			),
+		},
+	};
+}
+
+/**
+ * The delay time the first track's delay device has actually resolved to, in
+ * seconds, read off the live Web Audio param.
+ *
+ * This walks the real graph rather than a double on purpose. Every tempo
+ * assertion in `devices/delay.test.ts` calls the pure `delaySeconds(values,
+ * tempo)` with an explicit tempo argument — correct in isolation, but it would
+ * pass unchanged with the graph's tempo wiring entirely broken. What is under
+ * test here is precisely that wiring: whether a tempo change reaches a device's
+ * `apply()` at all, and which tempo it reads when it does.
+ */
+function resolvedDelaySeconds(
+	graph: import("./ProjectAudioGraph").ProjectAudioGraph,
+	trackId: import("../domain/ids").TrackId,
+): number {
+	const track = graph.trackGraphs.get(trackId);
+	if (!track) throw new Error("no track graph");
+	const node = track.deviceNode(DELAY_ID);
+	if (!node) throw new Error("no delay device node in the chain");
+	const resolved = node.resolvedDelaySeconds?.();
+	if (resolved === undefined) {
+		throw new Error("the delay node exposes no resolved time");
+	}
+	return resolved;
+}
+
+describe("ProjectAudioGraph device tempo wiring (FX-01)", () => {
+	it("builds a synced delay against the project's own tempo, not the 120 BPM default", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+		const project = projectWithDelay(60);
+
+		graph.reconcile(buildAudioProjection(project));
+
+		// A 1/8 note at 60 BPM is 0.5 s. Reading the default 120 would give 0.25 —
+		// every synced delay in a non-120 project silently on the wrong grid.
+		expect(resolvedDelaySeconds(graph, project.song.tracks[0].id)).toBeCloseTo(
+			0.5,
+			4,
+		);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+
+	it("moves a synced delay onto the new grid when only the tempo changed", async () => {
+		const runtime = new AudioRuntimeModule.AudioRuntime();
+		const graph = new ProjectAudioGraphModule.ProjectAudioGraph(runtime, "p", {
+			transport: fakeTransport(),
+		});
+		const project = projectWithDelay(120);
+		const trackId = project.song.tracks[0].id;
+
+		const before = buildAudioProjection(project);
+		graph.reconcile(before);
+		expect(resolvedDelaySeconds(graph, trackId)).toBeCloseTo(0.25, 4);
+
+		const slower: Project = {
+			...project,
+			song: { ...project.song, tempo: 60 },
+		};
+		const after = buildAudioProjection(slower, before);
+
+		// The defect this guards: a tempo-only edit changes no track, so the audio
+		// projection reuses the track projection object *by reference* and every
+		// per-entity short-circuit between here and the device chain would
+		// otherwise swallow the change outright.
+		expect(after.tracks[0]).toBe(before.tracks[0]);
+
+		graph.reconcile(after);
+
+		// A 1/8 note at 60 BPM, and read as the value `apply()` resolved rather
+		// than the live param, which is only *ramping* toward it after an edit.
+		expect(resolvedDelaySeconds(graph, trackId)).toBeCloseTo(0.5, 4);
+
+		await graph.dispose();
+		await runtime.close();
+	});
+});

--- a/src/audio/ProjectAudioGraph.ts
+++ b/src/audio/ProjectAudioGraph.ts
@@ -148,6 +148,18 @@ export class ProjectAudioGraph {
 	 */
 	private readonly assetsById = new Map<AssetId, AudioAssetProjection>();
 	private lastProjection: AudioSongProjection | null = null;
+	/**
+	 * The tempo of the projection currently being reconciled, set at the *top* of
+	 * `reconcile()` — before any child graph runs — so a device reading it during
+	 * `apply()` sees the tempo it is being reconciled *to*.
+	 *
+	 * Deliberately not derived from `lastProjection`: that is only assigned at the
+	 * end of `reconcile()`, so a device built or updated mid-pass would read the
+	 * *previous* pass's tempo, and the very first pass would read nothing at all
+	 * and fall back to the 120 BPM default — silently building every synced delay
+	 * in a 90 BPM project on a 120 BPM grid.
+	 */
+	private currentTempo: number = SONG_TEMPO.defaultValue;
 	private disposed = false;
 
 	constructor(
@@ -164,14 +176,15 @@ export class ProjectAudioGraph {
 		this.createInstrument = options.createInstrument;
 		// The six core processing devices (PRD FX-01, LOOP-009). A test may
 		// substitute its own factory; production always gets the real DSP. The
-		// tempo reader is read *at apply time* from the latest projection, so a
-		// tempo-synced delay follows a tempo change without the graph rebuilding
-		// anything.
+		// tempo reader returns the tempo of the projection being reconciled right
+		// now (see `currentTempo`), and `reconcile` forces a device re-apply when
+		// the tempo moved, so a tempo-synced delay follows a tempo change without
+		// the graph rebuilding anything.
 		this.createDeviceNode =
 			options.createDeviceNode ??
 			createDeviceNodeFactory({
 				scope: this.scope,
-				tempo: () => this.lastProjection?.tempo ?? SONG_TEMPO.defaultValue,
+				tempo: () => this.currentTempo,
 			});
 		this.underrunMonitor = options.underrunMonitor;
 		this.now = options.now ?? audioClockNow;
@@ -270,11 +283,20 @@ export class ProjectAudioGraph {
 
 		this.transport.bpm.value = next.tempo;
 
-		this.master.reconcile(next.master);
-		this.syncReturns(next);
+		// Tempo must be visible to every device built or updated below *before*
+		// any of them run, and a tempo change has to survive the per-entity
+		// reference short-circuits: a tempo-only edit leaves every track, return,
+		// and master projection reference-identical, so nothing else in this pass
+		// would reach a synced delay's `apply()` (PRD FX-01).
+		const tempoChanged =
+			this.lastProjection !== null && this.lastProjection.tempo !== next.tempo;
+		this.currentTempo = next.tempo;
+
+		this.master.reconcile(next.master, tempoChanged);
+		this.syncReturns(next, tempoChanged);
 
 		const anySolo = next.tracks.some((track) => track.mixer.soloed);
-		this.syncTracks(next, anySolo);
+		this.syncTracks(next, anySolo, tempoChanged);
 
 		// Returns no longer referenced are only safe to dispose once no track
 		// send still targets them — i.e. after `syncTracks` above.
@@ -306,7 +328,7 @@ export class ProjectAudioGraph {
 		);
 	}
 
-	private syncReturns(next: AudioSongProjection): void {
+	private syncReturns(next: AudioSongProjection, tempoChanged: boolean): void {
 		for (const returnProjection of next.returns) {
 			let graph = this.returns.get(returnProjection.id);
 			if (!graph) {
@@ -318,7 +340,7 @@ export class ProjectAudioGraph {
 				);
 				this.returns.set(returnProjection.id, graph);
 			}
-			graph.reconcile(returnProjection);
+			graph.reconcile(returnProjection, tempoChanged);
 		}
 	}
 
@@ -331,7 +353,11 @@ export class ProjectAudioGraph {
 		}
 	}
 
-	private syncTracks(next: AudioSongProjection, anySolo: boolean): void {
+	private syncTracks(
+		next: AudioSongProjection,
+		anySolo: boolean,
+		tempoChanged: boolean,
+	): void {
 		for (const [id, graph] of this.tracks) {
 			if (!next.tracksById.has(id)) {
 				graph.dispose();
@@ -359,7 +385,7 @@ export class ProjectAudioGraph {
 			const effectiveMuted =
 				trackProjection.mixer.muted ||
 				(anySolo && !trackProjection.mixer.soloed);
-			graph.reconcile(trackProjection, effectiveMuted);
+			graph.reconcile(trackProjection, effectiveMuted, tempoChanged);
 		}
 	}
 

--- a/src/audio/ReturnAudioGraph.ts
+++ b/src/audio/ReturnAudioGraph.ts
@@ -42,9 +42,18 @@ export class ReturnAudioGraph {
 		return this.deviceChain.input;
 	}
 
-	reconcile(next: AudioReturnProjection): void {
-		if (this.lastProjection === next) return;
-		this.deviceChain.reconcile(next.devices);
+	/**
+	 * `reapplyDevices` reports that state outside this return's projection moved
+	 * (the song tempo, which a synced delay resolves against) and so must survive
+	 * the reference short-circuit — otherwise a tempo-only edit, which leaves this
+	 * projection reference-identical, would never reach the device chain.
+	 */
+	reconcile(next: AudioReturnProjection, reapplyDevices = false): void {
+		if (this.lastProjection === next) {
+			if (reapplyDevices) this.deviceChain.reconcile(next.devices, true);
+			return;
+		}
+		this.deviceChain.reconcile(next.devices, reapplyDevices);
 		this.panVol.volume.rampTo(next.mixer.volume, 0.02);
 		this.panVol.pan.rampTo(next.mixer.pan, 0.02);
 		this.panVol.mute = next.mixer.muted;

--- a/src/audio/TrackAudioGraph.ts
+++ b/src/audio/TrackAudioGraph.ts
@@ -1,13 +1,17 @@
 import * as Tone from "tone";
 import type { NoteTrigger, Send } from "../domain/entities";
-import type { AssetId, ReturnId, TrackId } from "../domain/ids";
+import type { AssetId, DeviceId, ReturnId, TrackId } from "../domain/ids";
 import type {
 	AudioAssetProjection,
 	AudioTrackProjection,
 } from "../projection/audioProjection";
 import type { AudioBufferCache } from "./AudioBufferCache";
 import type { AudioProjectScope } from "./AudioRuntime";
-import { DeviceChain, type DeviceNodeFactory } from "./DeviceChain";
+import {
+	DeviceChain,
+	type DeviceNode,
+	type DeviceNodeFactory,
+} from "./DeviceChain";
 import {
 	createInstrumentNode,
 	type InstrumentNode,
@@ -108,6 +112,12 @@ export class TrackAudioGraph {
 		return this.panVol.mute;
 	}
 
+	/** The live node for one of this track's devices, for a panel readout (gain
+	 * reduction, a synced delay's resolved time) or a test. */
+	deviceNode(id: DeviceId): DeviceNode | undefined {
+		return this.deviceChain.deviceNode(id);
+	}
+
 	/** The pre-fader tap point: after devices, before pan/volume/mute. */
 	private get preFaderTap(): Tone.ToneAudioNode {
 		return this.deviceChain.output;
@@ -128,15 +138,28 @@ export class TrackAudioGraph {
 	 * project-wide mute/solo rule (mute wins; any soloed track silences every
 	 * non-soloed one) and is re-applied every pass since it depends on every
 	 * other track's solo state, not just this track's own projection.
+	 *
+	 * `reapplyDevices` is likewise re-applied every pass regardless of the
+	 * reference short-circuit below, for the same reason: it reports that state
+	 * *outside* this track's projection moved (the song tempo, which a synced
+	 * delay resolves its division against). A tempo-only edit leaves this track's
+	 * projection reference-identical, so without this the early return would
+	 * swallow it and the delay would never leave the old grid.
 	 */
-	reconcile(next: AudioTrackProjection, effectiveMuted: boolean): void {
+	reconcile(
+		next: AudioTrackProjection,
+		effectiveMuted: boolean,
+		reapplyDevices = false,
+	): void {
 		if (this.lastProjection !== next) {
 			this.reconcileInstrument(next.instrument);
-			this.deviceChain.reconcile(next.devices);
+			this.deviceChain.reconcile(next.devices, reapplyDevices);
 			this.reconcileSends(next.sendConfig);
 			this.panVol.volume.rampTo(next.mixer.volume, MIXER_SMOOTHING_SECONDS);
 			this.panVol.pan.rampTo(next.mixer.pan, MIXER_SMOOTHING_SECONDS);
 			this.lastProjection = next;
+		} else if (reapplyDevices) {
+			this.deviceChain.reconcile(next.devices, true);
 		}
 		this.panVol.mute = effectiveMuted;
 	}

--- a/src/audio/devices/delay.ts
+++ b/src/audio/devices/delay.ts
@@ -93,11 +93,22 @@ export const createDelayCore: DeviceCoreFactory = (): DeviceCore => {
 	feedbackLimit.connect(input);
 	merger.connect(output);
 
+	/**
+	 * The delay time this core last resolved, in seconds. Kept because the live
+	 * `delayTime` param is a *ramp target* on an edit, not an instantaneous
+	 * value, so reading the node mid-ramp reports the old grid however correct
+	 * the wiring is. `resolvedDelaySeconds()` is what a panel readout and the
+	 * graph-level tempo test both need: the value the device is heading to.
+	 */
+	let resolved = 0;
+
 	return {
 		input,
 		output,
+		resolvedDelaySeconds: () => resolved,
 		apply(values, ctx, initial) {
 			const base = delaySeconds(values, ctx.tempo());
+			resolved = base;
 			setOrRamp(left.delayTime, base, initial);
 			// The right channel trails by up to one more division's worth, still
 			// inside the allocated line.

--- a/src/audio/devices/deviceNode.ts
+++ b/src/audio/devices/deviceNode.ts
@@ -97,6 +97,7 @@ export function buildDeviceNode(
 			output.dispose();
 		},
 		gainReductionDb: core.gainReductionDb?.bind(core),
+		resolvedDelaySeconds: core.resolvedDelaySeconds?.bind(core),
 		ready: core.ready?.bind(core),
 	};
 }

--- a/src/audio/devices/types.ts
+++ b/src/audio/devices/types.ts
@@ -55,6 +55,15 @@ export interface DeviceCore {
 	 */
 	gainReductionDb?(): number;
 	/**
+	 * The delay time this device last resolved to, in seconds. Only the delay
+	 * implements it. A panel reads it to show the time a *synced* delay currently
+	 * works out to, which the stored parameters alone do not say — the answer
+	 * depends on the song tempo. Reading the live `delayTime` param instead would
+	 * report the wrong value mid-edit, since a parameter change is ramped rather
+	 * than stepped.
+	 */
+	resolvedDelaySeconds?(): number;
+	/**
 	 * Resolves once any asynchronously-built resource the device needs is in
 	 * place. Only the reverb implements it, because its impulse response is
 	 * generated off the audio thread. Live playback never awaits it — the node


### PR DESCRIPTION
## What & why

8 of 8 in the LOOP-009 stack (builds on #187, and is the PR that closes the task). Fixes a review finding on the previous commit: the tempo-synced delay never actually followed a tempo change. Two distinct wiring bugs, both in `ProjectAudioGraph`/graph reconciliation rather than in any device's DSP:

1. **The tempo reader was one pass behind.** `ProjectAudioGraph` read tempo via `() => this.lastProjection?.tempo`, but `lastProjection` is only assigned at the *end* of `reconcile()`, after the child graphs already ran. A device's `apply()` therefore always read the *previous* pass's tempo, and the very first pass read nothing and fell back to the default 120 BPM — so any project not at 120 BPM built its synced delay on the wrong grid from the start. Fixed with a `currentTempo` field assigned at the top of `reconcile()`.
2. **A tempo-only change couldn't reach the device chains at all.** A tempo edit changes no track, so the track projection object is reused by reference, and every layer down to `DeviceChain.reconcile` short-circuits on `lastProjection === next`, so `core.apply()` never re-ran. `reconcile` now derives `tempoChanged` and threads it through master/return/track graphs into `DeviceChain` as a `reapplyExisting` flag, which survives the per-entity reference short-circuit while keeping the AUD-08 contract intact elsewhere (an unrelated edit still touches no other subgraph — `DeviceChain` tracks the `Device` object each node was last applied from, so only a *forced* re-apply triggers `update()` for an otherwise-unchanged device).

Also adds `resolvedDelaySeconds()` to the delay core, so a synced delay's future panel readout can show the value `apply()` actually resolved rather than the live `delayTime` param, which mid-ramp still reports the old grid even once the wiring is correct.

Refs #49
Closes #49

PRD: FX-01 (delay supports synced timing that tracks the song's actual tempo; live playback uses equivalent processing to offline render).

## Walkthrough

No UI change — this is a graph-wiring correctness fix with no new user-visible surface.

## Evidence

`bun run typecheck` and `bun run check:ci` clean; the 11 device/graph suites pass (88 tests). Added `src/audio/ProjectAudioGraph.deviceTempo.test.ts`, which drives the real production device factory end-to-end and asserts the delay's resolved time through the whole graph: opening a 60 BPM project builds the delay at 0.5s (not the 120 BPM default's 0.25s), and a tempo-only reconcile (asserting the track projection object is reused by reference, pinning the exact short-circuit the bug relied on) moves the delay from 0.25s to 0.5s. Both assertions were verified to fail on the unfixed code (`expected 0.25 to be close to 0.5`) before the fix and pass after. Three full-suite failures elsewhere are load-dependent timeouts reproduced identically on unmodified `main`, not regressions from this change. This branch passed an Opus review round in the implementation workflow (this commit is itself the fix produced by that round).

## Acceptance criteria met

- [x] Each required control, wet/dry/output behavior, bypass, reset, duplication, metering, and preset path is present (across the full stack).
- [x] Parameters smooth without node replacement; duplicate effects and unconventional ordering are supported (across the full stack).
- [ ] Deterministic audio/property tests cover normal and extreme settings, limiter interaction, tails, and disposal. Limiter interaction with these real devices specifically (as opposed to the synthetic loud chain `MasterAudioGraph.test.ts` already exercises from LOOP-008) remains an open gap, called out explicitly rather than claimed — left unticked.
- [x] Each device type is a registered `device_type` value in the analytics catalog, so `device_added` reports which processing users reach for first (registered in LOOP-008, made real by this stack).

---

_Generated by [Claude Code](https://claude.ai/code)_