### PR TITLE
HARD-006 - Session Replay consent flag (1 of 6)

### DIFF
--- a/src/analytics/consent.test.ts
+++ b/src/analytics/consent.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { hostileStorage, memoryStorage } from "../testing/storage";
-import { CONSENT_DEFAULT, CONSENT_STORAGE_KEY, ConsentStore } from "./consent";
+import {
+	CONSENT_DEFAULT,
+	CONSENT_FLAGS,
+	CONSENT_STORAGE_KEY,
+	ConsentStore,
+} from "./consent";
 
 describe("default state (DEC-009 owns the value, this owns the mechanism)", () => {
 	it("uses the declared default when nothing is stored", () => {
@@ -22,29 +27,71 @@ describe("default state (DEC-009 owns the value, this owns the mechanism)", () =
 		const store = new ConsentStore(storage);
 		expect(store.analyticsAllowed).toBe(false);
 		expect(store.errorMonitoringAllowed).toBe(CONSENT_DEFAULT.errorMonitoring);
+		// A preference written by a build that predates replay must not silently
+		// come back as "replay declined" — or, worse, as "replay granted" when the
+		// user had opted out of everything else. It takes the declared default.
+		expect(store.sessionReplayAllowed).toBe(CONSENT_DEFAULT.sessionReplay);
+	});
+
+	it("rejects a non-boolean stored value per flag rather than trusting it", () => {
+		const storage = memoryStorage();
+		storage.setItem(
+			CONSENT_STORAGE_KEY,
+			JSON.stringify({ sessionReplay: "yes please", errorMonitoring: false }),
+		);
+		const store = new ConsentStore(storage);
+		expect(store.sessionReplayAllowed).toBe(CONSENT_DEFAULT.sessionReplay);
+		expect(store.errorMonitoringAllowed).toBe(false);
+	});
+
+	it("declares every flag in CONSENT_FLAGS, so parse and set cannot miss one", () => {
+		// `parse`, `set`'s change detection, and `optOut` are all driven by this
+		// list. A fourth processor added without extending it would be read back
+		// as absent and would not trip a change notification.
+		expect([...CONSENT_FLAGS].sort()).toEqual([
+			"errorMonitoring",
+			"productAnalytics",
+			"sessionReplay",
+		]);
 	});
 });
 
 describe("opting out", () => {
-	it("turns both processors off in one action", () => {
+	it("turns every collection off in one action, replay included", () => {
+		// ADR 0002 decision 4: replay is covered by the same single control, so a
+		// user who declines telemetry is not recorded.
 		const store = new ConsentStore(memoryStorage());
 		store.optOut();
 		expect(store.analyticsAllowed).toBe(false);
 		expect(store.errorMonitoringAllowed).toBe(false);
+		expect(store.sessionReplayAllowed).toBe(false);
+	});
+
+	it("opting back in restores every collection, replay included", () => {
+		const store = new ConsentStore(memoryStorage());
+		store.optOut();
+		store.optIn();
+		expect(store.sessionReplayAllowed).toBe(true);
+		expect(store.analyticsAllowed).toBe(true);
+		expect(store.errorMonitoringAllowed).toBe(true);
 	});
 
 	it("survives a reload", () => {
 		const storage = memoryStorage();
 		new ConsentStore(storage).optOut();
-		expect(new ConsentStore(storage).analyticsAllowed).toBe(false);
+		const reloaded = new ConsentStore(storage);
+		expect(reloaded.analyticsAllowed).toBe(false);
+		expect(reloaded.sessionReplayAllowed).toBe(false);
 	});
 
-	it("keeps the two processors independently controllable", () => {
-		// DEC-009 may decide differently about a reliability signal than about
-		// product analytics, so the model must not force them together.
+	it("keeps the three collections independently controllable", () => {
+		// DEC-009 may decide differently about a reliability signal, about product
+		// analytics, and about a sampled recording, so the model must not force
+		// them together even though the one control does.
 		const store = new ConsentStore(memoryStorage());
-		store.set({ productAnalytics: false });
-		expect(store.analyticsAllowed).toBe(false);
+		store.set({ sessionReplay: false });
+		expect(store.sessionReplayAllowed).toBe(false);
+		expect(store.analyticsAllowed).toBe(true);
 		expect(store.errorMonitoringAllowed).toBe(true);
 	});
 });
@@ -58,6 +105,17 @@ describe("subscribers", () => {
 		store.optOut();
 		expect(seen).toHaveBeenCalledTimes(2);
 		expect(seen.mock.lastCall?.[0].productAnalytics).toBe(false);
+	});
+
+	it("notifies when only the replay flag changes", () => {
+		// The in-flight recording is stopped by a subscriber, so a change that
+		// notified nobody would leave replay capturing after a withdrawal.
+		const store = new ConsentStore(memoryStorage());
+		const seen = vi.fn();
+		store.subscribe(seen);
+		store.set({ sessionReplay: false });
+		expect(seen).toHaveBeenCalledTimes(2);
+		expect(seen.mock.lastCall?.[0].sessionReplay).toBe(false);
 	});
 
 	it("does not notify when nothing actually changed", () => {
@@ -100,11 +158,15 @@ describe("fail-open storage (PRD OPS-02)", () => {
 		const store = new ConsentStore(hostileStorage());
 		expect(() => store.optOut()).not.toThrow();
 		expect(store.analyticsAllowed).toBe(false);
+		// The replay flag matters most here: a withdrawal that cannot be written
+		// down must still stop the recording that is running right now.
+		expect(store.sessionReplayAllowed).toBe(false);
 	});
 
 	it("works with no storage at all", () => {
 		const store = new ConsentStore(null);
 		store.optOut();
 		expect(store.errorMonitoringAllowed).toBe(false);
+		expect(store.sessionReplayAllowed).toBe(false);
 	});
 });

--- a/src/analytics/consent.ts
+++ b/src/analytics/consent.ts
@@ -11,17 +11,28 @@
 // Both are isolated to `CONSENT_DEFAULT` and `src/components/TelemetryDisclosure.tsx`
 // so settling `DEC-009` is a one-line change here plus copy, not a redesign.
 //
-// Two processors, two flags: Google Analytics for product events and Sentry
-// for error monitoring (ADR 0001). They are separate because `DEC-009` may
+// Three collections, three flags: Google Analytics for product events, Sentry
+// for error monitoring (ADR 0001), and Sentry Session Replay for understanding
+// how the app is used (ADR 0002). They are separate because `DEC-009` may
 // decide differently about a reliability signal that keeps a release gate
-// honest than about product analytics. The alpha's disclosure surface presents
-// them as one choice; the model does not force that.
+// honest, about product analytics, and about a sampled recording of an
+// interaction — which is more sensitive per record than a counter. The alpha's
+// disclosure surface presents them as one choice; the model does not force that.
 
 export interface ConsentState {
 	/** PRD `OPS-02` product-analytics events. */
 	readonly productAnalytics: boolean;
 	/** PRD `OPS-03` error and crash reports (Sentry, per ADR 0001). */
 	readonly errorMonitoring: boolean;
+	/**
+	 * Sentry Session Replay (ADR 0002 decision 4).
+	 *
+	 * Declining is honoured *at the source*: the replay integration is never
+	 * constructed, so nothing is captured in the first place rather than being
+	 * captured and dropped before send. Withdrawing mid-session stops the
+	 * in-flight recording.
+	 */
+	readonly sessionReplay: boolean;
 }
 
 export const CONSENT_STORAGE_KEY = "sg_telemetry_consent";
@@ -31,18 +42,27 @@ export const CONSENT_STORAGE_KEY = "sg_telemetry_consent";
  *
  * **Provisional, pending `DEC-009`.** Set to collect-with-opt-out, matching
  * the PRD `OPS-02` phrasing that the user "can decline" — which describes an
- * opt-out, not an opt-in. If `DEC-009` decides opt-in, flip both to `false`;
+ * opt-out, not an opt-in. If `DEC-009` decides opt-in, flip them to `false`;
  * every consumer already treats "no stored preference" as this value and
- * nothing else needs to change.
+ * nothing else needs to change. `sessionReplay` follows the same rule and is
+ * `DEC-009`'s to settle too (ADR 0002 decision 5), alongside replay retention
+ * and region — it is a one-line change here, exactly as the others are.
  */
 export const CONSENT_DEFAULT: ConsentState = {
 	productAnalytics: true,
 	errorMonitoring: true,
+	sessionReplay: true,
 };
+
+/** Every flag, so nothing below has to restate the shape of `ConsentState`. */
+export const CONSENT_FLAGS = Object.keys(
+	CONSENT_DEFAULT,
+) as readonly (keyof ConsentState)[];
 
 export const CONSENT_ALL_OFF: ConsentState = {
 	productAnalytics: false,
 	errorMonitoring: false,
+	sessionReplay: false,
 };
 
 type Listener = (state: ConsentState) => void;
@@ -53,16 +73,16 @@ function parse(raw: string | null): ConsentState {
 		const parsed: unknown = JSON.parse(raw);
 		if (typeof parsed !== "object" || parsed === null) return CONSENT_DEFAULT;
 		const record = parsed as Record<string, unknown>;
-		return {
-			productAnalytics:
-				typeof record.productAnalytics === "boolean"
-					? record.productAnalytics
-					: CONSENT_DEFAULT.productAnalytics,
-			errorMonitoring:
-				typeof record.errorMonitoring === "boolean"
-					? record.errorMonitoring
-					: CONSENT_DEFAULT.errorMonitoring,
-		};
+		// Driven by `CONSENT_FLAGS` rather than field by field: a flag added later
+		// is read back and defaulted without anyone having to remember this
+		// function exists. A stored value that is not a boolean — hand-edited,
+		// written by an older build, or hostile — falls back to the default for
+		// that flag alone rather than discarding the whole preference.
+		const state = { ...CONSENT_DEFAULT } as Record<keyof ConsentState, boolean>;
+		for (const flag of CONSENT_FLAGS) {
+			if (typeof record[flag] === "boolean") state[flag] = record[flag];
+		}
+		return state;
 	} catch {
 		// Corrupt or hand-edited storage falls back to the default rather than
 		// throwing on app start.
@@ -98,12 +118,19 @@ export class ConsentStore {
 		return this.state.errorMonitoring;
 	}
 
+	/**
+	 * Whether Session Replay may capture (ADR 0002 decision 4).
+	 *
+	 * Consulted before the integration is constructed, not before a recording is
+	 * sent — declining means nothing is recorded at all.
+	 */
+	get sessionReplayAllowed(): boolean {
+		return this.state.sessionReplay;
+	}
+
 	set(patch: Partial<ConsentState>): ConsentState {
 		const next: ConsentState = { ...this.state, ...patch };
-		if (
-			next.productAnalytics === this.state.productAnalytics &&
-			next.errorMonitoring === this.state.errorMonitoring
-		) {
+		if (CONSENT_FLAGS.every((flag) => next[flag] === this.state[flag])) {
 			return this.state;
 		}
 		this.state = next;
@@ -128,13 +155,23 @@ export class ConsentStore {
 		}
 	}
 
-	/** Turns both processors off in one action — the user-facing opt-out. */
+	/**
+	 * Turns every collection off in one action — the user-facing opt-out.
+	 *
+	 * One action covers all three flags including replay (ADR 0002 decision 4):
+	 * the model keeps them separable for `DEC-009`, but the control the user
+	 * actually has is a single switch.
+	 */
 	optOut(): ConsentState {
 		return this.set(CONSENT_ALL_OFF);
 	}
 
 	optIn(): ConsentState {
-		return this.set({ productAnalytics: true, errorMonitoring: true });
+		return this.set({
+			productAnalytics: true,
+			errorMonitoring: true,
+			sessionReplay: true,
+		});
 	}
 
 	subscribe(listener: Listener): () => void {


### PR DESCRIPTION
## What & why

1 of 6 in the HARD-006 stack, builds on `main`.

This is the registration-only slice (per CLAUDE.md "Landing work" item 3): `src/analytics/consent.ts` is a shared registration point, so it lands first and alone, ahead of the masking, SDK configuration, and disclosure slices that build on it.

Adds a third `sessionReplay` flag to the consent model alongside the existing `productAnalytics` and `errorMonitoring` flags:

- `ConsentState` carries `sessionReplay`.
- `CONSENT_DEFAULT` gains the new flag (its final default value is `DEC-009` (#38), same as the other two — this is one line, matching how `productAnalytics`/`errorMonitoring` were seeded).
- `CONSENT_ALL_OFF` / the single user-facing "turn everything off" control now clears `sessionReplay` too, in the same action.
- `parse` validates and survives hostile or absent storage for the new flag, same as the existing two.
- A `replayAllowed` accessor is added alongside the existing processor accessors.

Refs #166. This slice does not close the issue — later slices (masking, SDK configuration, consent-at-source wiring, disclosure copy) are still to come.

## Walkthrough

No UI change. This slice only extends the consent data model (`src/analytics/consent.ts`); nothing renders differently.

## Evidence

Reported by the implementer for this slice and the full stack tip:
- `bun run typecheck` — pass
- `bun run test` — pass (2069 tests, 151 files at stack tip)
- `bun run check` — pass

This branch passed an Opus review round in the implementation workflow (a prior review round found ordering and payload-modelling issues elsewhere in the stack; those were fixed before this stack was finalized — see issue #166 comments).

## Acceptance criteria met

From #166:
- [x] `ConsentState` carries a session-replay flag; the single user-facing control still turns everything off in one action; the flag persists and survives hostile or absent storage (`src/analytics/consent.test.ts` extended).

The remaining acceptance criteria (disclosure copy, capture stopped at the source, `sentrySink.ts` configuration, OPS-03 payload rule, masking markers, budget re-measurement) are satisfied by the later slices in this stack.

---
_Generated by [Claude Code](https://claude.ai/code)_