### PR TITLE
HARD-006 - Stop Session Replay at the source when consent is declined (5 of 6)

### DIFF
--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -270,6 +270,182 @@ describe("consent (PRD OPS-02 opt-out)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Session Replay consent, honoured at the source (ADR 0002 decision 4)
+// ---------------------------------------------------------------------------
+
+describe("Session Replay consent (ADR 0002 decision 4)", () => {
+	/**
+	 * A sink whose replay stop is observable *separately* from its teardown.
+	 *
+	 * That separation is the whole point: withdrawing replay alone must end the
+	 * recording without stopping error monitoring, so a test that could only see
+	 * one combined stopper could not tell the required behaviour from the wrong
+	 * one.
+	 */
+	function replayableSink() {
+		const stopReplay = vi.fn(async () => {});
+		const stop = vi.fn(async () => {});
+		const built: { sessionReplay: boolean }[] = [];
+		const startErrorSink: StartErrorSink = async (_release, options) => {
+			built.push(options);
+			return { stop, stopReplay };
+		};
+		return { startErrorSink, built, stopReplay, stop };
+	}
+
+	function start(consent: ConsentStore, startErrorSink: StartErrorSink) {
+		const paint = deferredPaint();
+		const telemetry = initTelemetry({
+			surface: "editor",
+			consent,
+			target: fakeTarget(),
+			afterPaint: paint.schedule,
+			startErrorSink,
+			createAnalyticsTransport: createRecordingTransport,
+			setVendorAnalyticsCollection: () => {},
+		});
+		paint.flush();
+		return { paint, telemetry };
+	}
+
+	it("builds the SDK with replay on when consent allows it", async () => {
+		// The value is passed at *construction*, which is what makes declining a
+		// property of the SDK rather than a filter on what it sends.
+		const consent = new ConsentStore(memoryStorage());
+		const sink = replayableSink();
+		start(consent, sink.startErrorSink);
+		await tick();
+
+		expect(sink.built).toEqual([{ sessionReplay: true }]);
+	});
+
+	it("builds it with replay off for a user who has declined", async () => {
+		const consent = new ConsentStore(memoryStorage());
+		consent.set({ sessionReplay: false });
+		const sink = replayableSink();
+		start(consent, sink.startErrorSink);
+		await tick();
+
+		expect(sink.built).toEqual([{ sessionReplay: false }]);
+	});
+
+	it("reads replay consent when the SDK is built, not when the start is scheduled", async () => {
+		// The window between scheduling and resolution is two animation frames
+		// plus an idle callback, and the disclosure is reachable throughout it.
+		// Reading the flag at schedule time would construct a recording SDK for a
+		// user who declined during that window.
+		const consent = new ConsentStore(memoryStorage());
+		const sink = replayableSink();
+		const paint = deferredPaint();
+		initTelemetry({
+			surface: "editor",
+			consent,
+			target: fakeTarget(),
+			afterPaint: paint.schedule,
+			startErrorSink: sink.startErrorSink,
+			createAnalyticsTransport: createRecordingTransport,
+			setVendorAnalyticsCollection: () => {},
+		});
+		consent.set({ sessionReplay: false });
+		paint.flush();
+		await tick();
+
+		expect(sink.built).toEqual([{ sessionReplay: false }]);
+	});
+
+	it("keeps error monitoring running when replay alone is declined", async () => {
+		// The two consents are separate. Declining replay must not cost the
+		// crash-free session rate.
+		const consent = new ConsentStore(memoryStorage());
+		consent.set({ sessionReplay: false });
+		const sink = replayableSink();
+		start(consent, sink.startErrorSink);
+		await tick();
+
+		expect(sink.built).toHaveLength(1);
+		expect(sink.stop).not.toHaveBeenCalled();
+	});
+
+	it("stops the in-flight recording when replay is withdrawn mid-session", async () => {
+		// "Opting out mid-session stops an in-flight recording rather than merely
+		// dropping it before send." The recording was already sampled in and is
+		// buffering in the page; only telling it to stop ends it.
+		const consent = new ConsentStore(memoryStorage());
+		const sink = replayableSink();
+		start(consent, sink.startErrorSink);
+		await tick();
+		expect(sink.stopReplay).not.toHaveBeenCalled();
+
+		consent.set({ sessionReplay: false });
+
+		await vi.waitFor(() => expect(sink.stopReplay).toHaveBeenCalledTimes(1));
+	});
+
+	it("leaves error monitoring attached when only replay is withdrawn", async () => {
+		const consent = new ConsentStore(memoryStorage());
+		const sink = replayableSink();
+		const { telemetry } = start(consent, sink.startErrorSink);
+		await tick();
+
+		consent.set({ sessionReplay: false });
+		await tick();
+
+		expect(sink.stop).not.toHaveBeenCalled();
+		// And it is still the disposer's to stop, so nothing has leaked.
+		await telemetry.dispose();
+		expect(sink.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops the recording that arrives after the withdrawal it missed", async () => {
+		// Replay declined while the SDK was still resolving: the consent
+		// subscription had no sink to call, so the resolution path has to stop it
+		// itself. Otherwise the session records for the rest of its life.
+		const consent = new ConsentStore(memoryStorage());
+		const sink = replayableSink();
+		const paint = deferredPaint();
+		let finishLoading: () => void = () => {};
+		const loaded = new Promise<void>((resolve) => {
+			finishLoading = resolve;
+		});
+		initTelemetry({
+			surface: "editor",
+			consent,
+			target: fakeTarget(),
+			afterPaint: paint.schedule,
+			startErrorSink: async (release, options) => {
+				await loaded;
+				return sink.startErrorSink(release, options);
+			},
+			createAnalyticsTransport: createRecordingTransport,
+			setVendorAnalyticsCollection: () => {},
+		});
+		paint.flush();
+
+		consent.set({ sessionReplay: false });
+		finishLoading();
+
+		await vi.waitFor(() => expect(sink.stopReplay).toHaveBeenCalledTimes(1));
+		// Error monitoring was never withdrawn, so the sink itself stays.
+		expect(sink.stop).not.toHaveBeenCalled();
+	});
+
+	it("withdrawing everything stops the recording and the sink", async () => {
+		// The single user-facing control turns all three off in one action.
+		const consent = new ConsentStore(memoryStorage());
+		const sink = replayableSink();
+		start(consent, sink.startErrorSink);
+		await tick();
+
+		consent.optOut();
+
+		await vi.waitFor(() => {
+			expect(sink.stopReplay).toHaveBeenCalledTimes(1);
+			expect(sink.stop).toHaveBeenCalledTimes(1);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Consent governs collection on every path, not just at the initial URL
 // ---------------------------------------------------------------------------
 
@@ -586,6 +762,17 @@ describe("the core journey is identical with both transports failing", () => {
 	async function journey(mode: "working" | "broken") {
 		const consent = new ConsentStore(memoryStorage());
 		if (mode === "broken") consent.optOut();
+		// The "broken" run has every flag off, replay included: ADR 0002 decision
+		// 4 requires that turning replay off costs no capability, exactly as
+		// `OPS-02` requires of analytics. Asserted here rather than assumed, so a
+		// later flag added to `optOut()` without being turned off is caught.
+		if (mode === "broken") {
+			expect(consent.current).toEqual({
+				productAnalytics: false,
+				errorMonitoring: false,
+				sessionReplay: false,
+			});
+		}
 
 		const analyticsBoundary = new Analytics({
 			transport:

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -94,10 +94,35 @@ export interface Telemetry {
 /** Detaches a started error sink and shuts its vendor transport down. */
 export type StopErrorSink = () => Promise<void>;
 
-/** A test's stand-in for the real dynamic import, optionally returning a stopper. */
+/**
+ * A running sink's teardown handles.
+ *
+ * `stopReplay` is separate from `stop` because the two consents are separate:
+ * withdrawing replay alone must stop the in-flight recording (ADR 0002
+ * decision 4) while error monitoring keeps running, so tearing the whole sink
+ * down is the wrong action for it.
+ */
+export interface RunningSink {
+	stop: StopErrorSink;
+	stopReplay: () => Promise<void>;
+}
+
+/**
+ * A test's stand-in for the real dynamic import.
+ *
+ * May resolve to nothing, to a bare stopper, or to a whole `RunningSink` — the
+ * last of which is what lets a test observe the replay stop *separately* from
+ * the sink teardown, which is the distinction ADR 0002 decision 4 turns on.
+ */
+// biome-ignore-start lint/suspicious/noConfusingVoidType: `void` rather than
+// `undefined` so an override can be written `async () => {}`, which most of
+// them are — the "returns nothing" case is the common one here, and `undefined`
+// would force every such override to return it explicitly.
 export type StartErrorSink = (
 	release: string,
-) => Promise<void> | Promise<StopErrorSink>;
+	options: { sessionReplay: boolean },
+) => Promise<void | StopErrorSink | RunningSink>;
+// biome-ignore-end lint/suspicious/noConfusingVoidType: see above.
 
 /**
  * Wires telemetry for one app load. Returns a disposer.
@@ -125,8 +150,8 @@ export function initTelemetry(options: InitTelemetryOptions): Telemetry {
 	/** Whether a monitored (non-landing) surface has been reached this load. */
 	let monitoredSurfaceReached = false;
 	let appOpenedLogged = false;
-	/** The running sink's stopper, or `null` when nothing is attached. */
-	let stopSink: StopErrorSink | null = null;
+	/** The running sink's teardown handles, or `null` when nothing is attached. */
+	let sink: RunningSink | null = null;
 	/** A start is scheduled or in flight, so `stopSink` is not yet meaningful. */
 	let sinkStarting = false;
 	let disposed = false;
@@ -137,19 +162,31 @@ export function initTelemetry(options: InitTelemetryOptions): Telemetry {
 	 * The start lands two animation frames plus an idle callback after it was
 	 * scheduled, and `TelemetryDisclosure` is reachable throughout. Neither the
 	 * consent subscription nor `dispose` can see a sink during that window —
-	 * `stopSink` is still null — so this is the only place that can stop one
-	 * that arrives too late. Without it, `sentry.init()` and its Release Health
+	 * `sink` is still null — so this is the only place that can stop one that
+	 * arrives too late. Without it, `sentry.init()` and its Release Health
 	 * session envelope stay attached for a user who has already declined or for
 	 * a page that has already torn telemetry down.
+	 *
+	 * Replay consent is read here rather than at schedule time, because it is
+	 * the value the SDK is *constructed* with (ADR 0002 decision 4) and the user
+	 * can change it anywhere in that window. Withdrawing it after the sink
+	 * resolves is handled by the consent subscription below, which stops the
+	 * in-flight recording.
 	 */
 	const attachSink = async (): Promise<void> => {
 		try {
-			const stop = await startMonitoring(reporter, options.startErrorSink);
+			const started = await startMonitoring(reporter, {
+				sessionReplay: consent.sessionReplayAllowed,
+				override: options.startErrorSink,
+			});
 			if (disposed || !consent.errorMonitoringAllowed) {
-				void stop();
+				void started.stop();
 				return;
 			}
-			stopSink = stop;
+			sink = started;
+			// Replay consent withdrawn while the SDK was resolving: the
+			// subscription below could not see this sink to stop it.
+			if (!consent.sessionReplayAllowed) void started.stopReplay();
 		} finally {
 			sinkStarting = false;
 		}
@@ -157,7 +194,7 @@ export function initTelemetry(options: InitTelemetryOptions): Telemetry {
 
 	const startMonitoringIfAllowed = (): void => {
 		if (disposed || !monitoredSurfaceReached) return;
-		if (stopSink !== null || sinkStarting) return;
+		if (sink !== null || sinkStarting) return;
 		if (!consent.errorMonitoringAllowed) return;
 		sinkStarting = true;
 		afterPaint(() => {
@@ -194,12 +231,25 @@ export function initTelemetry(options: InitTelemetryOptions): Telemetry {
 	// state, and again on every change. Symmetric in both directions: a grant
 	// rebuilds exactly what a withdrawal tore down.
 	const unsubscribeConsent = consent.subscribe((state) => {
+		// ADR 0002 decision 4: withdrawing replay stops the in-flight recording
+		// rather than merely dropping it before send. Done *first*, and
+		// unconditionally on the replay flag, so it happens whether replay alone
+		// was withdrawn or the single control turned everything off — the sink
+		// teardown below would otherwise take the handle away before we got here.
+		//
+		// A later re-grant does not resume *this* session's recording: replay is
+		// configured when the SDK is constructed, so it takes effect on the next
+		// load. That is the safe direction to be asymmetric in.
+		if (!state.sessionReplay && sink) {
+			void sink.stopReplay();
+		}
+
 		if (state.errorMonitoring) {
 			startMonitoringIfAllowed();
-		} else if (stopSink) {
-			const stop = stopSink;
-			stopSink = null;
-			void stop();
+		} else if (sink) {
+			const running = sink;
+			sink = null;
+			void running.stop();
 		}
 
 		if (state.productAnalytics) {
@@ -230,9 +280,9 @@ export function initTelemetry(options: InitTelemetryOptions): Telemetry {
 			disposed = true;
 			unsubscribeConsent();
 			uninstallHandlers();
-			const stop = stopSink;
-			stopSink = null;
-			if (stop) await stop();
+			const running = sink;
+			sink = null;
+			if (running) await running.stop();
 		},
 	};
 }
@@ -270,34 +320,51 @@ function recordMonitoringStatus(status: MonitoringStatus): void {
  */
 async function startMonitoring(
 	reporter: ErrorReporter,
-	override?: StartErrorSink,
-): Promise<StopErrorSink> {
-	if (override) {
-		const stop = await override(RELEASE_SHA).catch(() => undefined);
-		return typeof stop === "function" ? stop : async () => {};
+	config: { sessionReplay: boolean; override?: StartErrorSink },
+): Promise<RunningSink> {
+	const inert: RunningSink = {
+		stop: async () => {},
+		stopReplay: async () => {},
+	};
+	if (config.override) {
+		const result = await config
+			.override(RELEASE_SHA, { sessionReplay: config.sessionReplay })
+			.catch(() => undefined);
+		if (typeof result === "function") return { ...inert, stop: result };
+		return result && typeof result.stop === "function"
+			? { stop: result.stop, stopReplay: result.stopReplay ?? inert.stopReplay }
+			: inert;
 	}
 	try {
 		const { SentrySink } = await import("./monitoring/sentrySink");
-		const sink = new SentrySink({ release: RELEASE_SHA });
+		const sink = new SentrySink({
+			release: RELEASE_SHA,
+			// ADR 0002 decision 4, honoured at the source: `false` here means the
+			// replay integration is never constructed for this session.
+			sessionReplay: config.sessionReplay,
+		});
 		const started = await sink.start();
 		if (!started) {
 			// `SentrySink.start()` resolves false only when no DSN is configured;
 			// every other failure throws and lands in the catch below.
 			recordMonitoringStatus("no-dsn");
-			return async () => {};
+			return inert;
 		}
 		reporter.addSink(sink);
 		recordMonitoringStatus("started");
-		return async () => {
-			reporter.removeSink(sink);
-			await sink.stop();
+		return {
+			stop: async () => {
+				reporter.removeSink(sink);
+				await sink.stop();
+			},
+			stopReplay: () => sink.stopReplay(),
 		};
 	} catch {
 		// A blocked or failed SDK load is expected for some sessions (ADR 0001:
 		// "Ad and tracker blockers block sentry.io"). Errors still reach the GA4
 		// `exception` counter, and the resulting undercount is documented.
 		recordMonitoringStatus("load-failed");
-		return async () => {};
+		return inert;
 	}
 }
 


### PR DESCRIPTION
## What & why

5 of 6 in the HARD-006 stack, builds on #192 (`claude/hard-006-disclosure-copy`).

Wires `src/telemetry.ts` so declining session-replay consent stops the integration from capturing — asserted against the SDK configuration, not against a send filter — rather than dropping an already-recorded payload before it is sent. Opting out mid-session stops an in-flight recording via the `stopReplay()` seam added in `claude/hard-006-replay-3`.

Because the disclosure copy (previous slice) already lands before this slice, replay capture only ever becomes live at a commit where the user has already been told about it — the issue's ordering rule is verified per-commit, not just at the stack tip:

| commit | replay capture live | disclosure names Session Replay |
| --- | --- | --- |
| `23c1ce9` (config only) | no | no |
| `6bc7e85` (disclosure copy) | no | yes |
| `6d2ca79` (this slice) | yes | yes |

`src/telemetry.test.ts` extends the existing core-journey comparison (edit → save → undo) to cover the new flag, proving turning replay off costs no capability.

Refs #166.

## Walkthrough

No UI change. This slice is consent-wiring logic only (`src/telemetry.ts`); the disclosure copy it depends on already shipped in the previous slice.

## Evidence

Reported by the implementer for this slice and the full stack tip:
- `bun run typecheck` — pass
- `bun run test` — pass (2069 tests, 151 files at stack tip)
- `bun run check` — pass

This branch passed an Opus review round in the implementation workflow.

## Acceptance criteria met

From #166:
- [x] With telemetry declined, the replay integration does not capture — asserted against the SDK configuration, not against a send filter. Opting out mid-session stops the in-flight recording.
- [x] Turning replay off costs no capability — the `src/telemetry.test.ts` core-journey comparison (edit → save → undo) covers the new flag.

The remaining acceptance criterion (OPS-03 payload rule against the real recorder's behavior) is satisfied by the final slice in this stack.

---
_Generated by [Claude Code](https://claude.ai/code)_