### PR TITLE
ARR-002: Add bar-snapped placement geometry edits

### DIFF
--- a/src/arrangement/placementGeometry.test.ts
+++ b/src/arrangement/placementGeometry.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { executeTransaction } from "../commands/execute";
+import type { Project } from "../domain/entities";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import type { PlacementId } from "../domain/ids";
+import { TICKS_PER_BAR } from "../domain/time";
+import {
+	deletePlacements,
+	floorToBar,
+	MAX_ARRANGEMENT_TICKS,
+	movePlacement,
+	resizePlacement,
+	setPlacementLooped,
+	snapToBar,
+} from "./placementGeometry";
+
+function fixture(): { project: Project; placementId: PlacementId } {
+	const project = createSliceFixtureProject();
+	return { project, placementId: project.song.placements[0].id };
+}
+
+/** Applies the operation's commands the way the editor does: one transaction. */
+function apply(
+	project: Project,
+	commands: Parameters<typeof executeTransaction>[1],
+) {
+	const result = executeTransaction(project, commands);
+	expect(
+		result.ok,
+		JSON.stringify((result as { issues?: unknown }).issues),
+	).toBe(true);
+	return result.project;
+}
+
+describe("bar snapping (ARR-01: placements snap to bars by default)", () => {
+	it("snaps to the nearest bar in both directions", () => {
+		expect(snapToBar(TICKS_PER_BAR * 0.4)).toBe(0);
+		expect(snapToBar(TICKS_PER_BAR * 0.6)).toBe(TICKS_PER_BAR);
+		expect(snapToBar(TICKS_PER_BAR * 2)).toBe(TICKS_PER_BAR * 2);
+	});
+
+	it("floors to the bar at or before the tick", () => {
+		expect(floorToBar(TICKS_PER_BAR * 1.9)).toBe(TICKS_PER_BAR);
+		expect(floorToBar(TICKS_PER_BAR)).toBe(TICKS_PER_BAR);
+	});
+
+	it("never snaps below zero or past the ten-minute guarantee", () => {
+		expect(snapToBar(-TICKS_PER_BAR * 5)).toBe(0);
+		expect(snapToBar(MAX_ARRANGEMENT_TICKS * 10)).toBeLessThanOrEqual(
+			MAX_ARRANGEMENT_TICKS,
+		);
+	});
+
+	it("treats a non-finite drag position as tick zero rather than NaN", () => {
+		expect(snapToBar(Number.NaN)).toBe(0);
+		expect(snapToBar(Number.POSITIVE_INFINITY)).toBe(0);
+	});
+});
+
+describe("movePlacement", () => {
+	it("moves to a bar-snapped start and leaves the project valid", () => {
+		const { project, placementId } = fixture();
+		const commands = movePlacement(
+			project,
+			placementId,
+			TICKS_PER_BAR * 2 + 17,
+		);
+		const next = apply(project, commands);
+		expect(next.song.placements[0].startTicks).toBe(TICKS_PER_BAR * 2);
+	});
+
+	it("is a no-op when the snapped position is already current", () => {
+		const { project, placementId } = fixture();
+		expect(movePlacement(project, placementId, 5)).toEqual([]);
+	});
+
+	it("declines a move onto a track that does not own the clip", () => {
+		const { project, placementId } = fixture();
+		const foreignTrackId = project.song.tracks[0].id;
+		// The fixture has one track, so fabricate a different ID to stand for a
+		// track the clip does not belong to.
+		const otherTrackId = `${foreignTrackId}x` as typeof foreignTrackId;
+		expect(
+			movePlacement(project, placementId, TICKS_PER_BAR, otherTrackId),
+		).toEqual([]);
+	});
+
+	it("ignores an unknown placement rather than throwing", () => {
+		const { project } = fixture();
+		expect(movePlacement(project, "plc_missing" as PlacementId, 0)).toEqual([]);
+	});
+});
+
+describe("resizePlacement", () => {
+	it("resizes from the end edge by whole bars", () => {
+		const { project, placementId } = fixture();
+		const next = apply(
+			project,
+			resizePlacement(project, placementId, "end", TICKS_PER_BAR * 3 + 40),
+		);
+		expect(next.song.placements[0].durationTicks).toBe(TICKS_PER_BAR * 3);
+	});
+
+	it("keeps the far edge fixed when dragging the start edge", () => {
+		const { project, placementId } = fixture();
+		const grown = apply(
+			project,
+			resizePlacement(project, placementId, "end", TICKS_PER_BAR * 4),
+		);
+		const before = grown.song.placements[0];
+		const endTicks = before.startTicks + before.durationTicks;
+
+		const next = apply(
+			grown,
+			resizePlacement(grown, placementId, "start", TICKS_PER_BAR),
+		);
+		const after = next.song.placements[0];
+		expect(after.startTicks).toBe(TICKS_PER_BAR);
+		expect(after.startTicks + after.durationTicks).toBe(endTicks);
+	});
+
+	it("advances the clip offset in step with a trimmed head", () => {
+		const { project, placementId } = fixture();
+		const grown = apply(
+			project,
+			resizePlacement(project, placementId, "end", TICKS_PER_BAR * 4),
+		);
+		const next = apply(
+			grown,
+			resizePlacement(grown, placementId, "start", TICKS_PER_BAR * 2),
+		);
+		expect(next.song.placements[0].clipOffsetTicks).toBe(TICKS_PER_BAR * 2);
+	});
+
+	it("never shrinks a placement below one bar from either edge", () => {
+		const { project, placementId } = fixture();
+		// The fixture is already one bar, so dragging its end edge back past the
+		// start clamps to that same one bar — i.e. changes nothing at all.
+		expect(
+			resizePlacement(project, placementId, "end", -TICKS_PER_BAR * 4),
+		).toEqual([]);
+
+		// From a longer placement the clamp is observable as a real edit.
+		const long = apply(
+			project,
+			resizePlacement(project, placementId, "end", TICKS_PER_BAR * 5),
+		);
+		const fromEnd = apply(
+			long,
+			resizePlacement(long, placementId, "end", -TICKS_PER_BAR * 4),
+		);
+		expect(fromEnd.song.placements[0].durationTicks).toBe(TICKS_PER_BAR);
+
+		const grown = apply(
+			project,
+			resizePlacement(project, placementId, "end", TICKS_PER_BAR * 2),
+		);
+		const squeezed = apply(
+			grown,
+			resizePlacement(grown, placementId, "start", TICKS_PER_BAR * 9),
+		);
+		expect(squeezed.song.placements[0].durationTicks).toBe(TICKS_PER_BAR);
+	});
+});
+
+describe("setPlacementLooped", () => {
+	it("toggles the loop flag and is a no-op when already set", () => {
+		const { project, placementId } = fixture();
+		const next = apply(project, setPlacementLooped(project, placementId, true));
+		expect(next.song.placements[0].looped).toBe(true);
+		expect(setPlacementLooped(next, placementId, true)).toEqual([]);
+	});
+});
+
+describe("deletePlacements", () => {
+	it("deletes selected placements and ignores unknown IDs", () => {
+		const { project, placementId } = fixture();
+		expect(deletePlacements(project, ["plc_missing" as PlacementId])).toEqual(
+			[],
+		);
+		const next = apply(project, deletePlacements(project, [placementId]));
+		expect(next.song.placements).toHaveLength(0);
+		// Deleting a placement never deletes the clip it referenced — that is what
+		// makes the clip reusable.
+		expect(next.clips).toHaveLength(project.clips.length);
+	});
+
+	it("addresses placements by ID, not array position", () => {
+		const { project, placementId } = fixture();
+		// Reverse the array; the placement's ID must still resolve to the same one.
+		const reordered: Project = {
+			...project,
+			song: {
+				...project.song,
+				placements: [...project.song.placements].reverse(),
+			},
+		};
+		const next = apply(
+			reordered,
+			movePlacement(reordered, placementId, TICKS_PER_BAR * 6),
+		);
+		expect(
+			next.song.placements.find((p) => p.id === placementId)?.startTicks,
+		).toBe(TICKS_PER_BAR * 6);
+	});
+});

--- a/src/arrangement/placementGeometry.ts
+++ b/src/arrangement/placementGeometry.ts
@@ -1,0 +1,193 @@
+/**
+ * Bar-snapped placement geometry edits for the arrangement (`ARR-002`; PRD
+ * CLP-01, ARR-01).
+ *
+ * The gestures that change *where and how long* a placement is — bar-snapped
+ * move, edge resize, loop toggle, and delete — as pure functions from the
+ * current `Project` and the user's intent to typed command inputs. Nothing here
+ * holds state, imports DOM/Canvas/SolidJS, or mutates the project: the caller
+ * hands the commands to `CommandHistory`, which applies them as one atomic
+ * transaction producing one revision and one undo entry. An operation that
+ * would change nothing returns no commands, so a drag ending where it started
+ * never burns a history entry. Duplication and the clipboard live next door in
+ * `placementDuplication.ts`, built on this module's snapping and bounds.
+ *
+ * Nothing here uses an array index as identity: placements and clips are found
+ * by schema-v1 prefixed ID (PRD CLP-01, 9.6).
+ */
+
+import {
+	removePlacement,
+	updatePlacement,
+} from "../commands/definitions/placements";
+import type { RawCommandInput } from "../commands/types";
+import type { Clip, Placement, Project } from "../domain/entities";
+import type { PlacementId, TrackId } from "../domain/ids";
+import { TICKS_PER_BAR, type Ticks, toTicks } from "../domain/time";
+
+/**
+ * The longest arrangement position the alpha guarantees, in ticks (PRD ARR-01's
+ * 10:00 floor). It is a *tick* bound derived from the slowest supported tempo:
+ * ten minutes at 40 BPM (the bottom of the AUD-02 range) is the largest tick
+ * position ten minutes can reach at any higher tempo, so clamping here never
+ * truncates an arrangement that is legal at some supported tempo. Editing
+ * clamps to it so a drag at extreme zoom-out cannot fling a placement to tick
+ * 10^9; longer arrangements may still work, they are simply not guaranteed.
+ */
+export const MAX_ARRANGEMENT_TICKS = (10 * 40 * TICKS_PER_BAR) / 4;
+
+/** Snaps a tick to the nearest bar line — ARR-01's default snapping. */
+export function snapToBar(ticks: number): Ticks {
+	const snapped = Math.round(ticks / TICKS_PER_BAR) * TICKS_PER_BAR;
+	return toTicks(clampTick(snapped));
+}
+
+/** Snaps down to the bar line at or before `ticks`. */
+export function floorToBar(ticks: number): Ticks {
+	const snapped = Math.floor(ticks / TICKS_PER_BAR) * TICKS_PER_BAR;
+	return toTicks(clampTick(snapped));
+}
+
+/** Clamps a raw tick into `[0, MAX_ARRANGEMENT_TICKS]`, treating NaN as zero. */
+export function clampTick(ticks: number): number {
+	if (!Number.isFinite(ticks)) return 0;
+	return Math.max(0, Math.min(MAX_ARRANGEMENT_TICKS, Math.round(ticks)));
+}
+
+/** A duration is at least one bar and never runs past the guaranteed bound. */
+export function clampDuration(
+	startTicks: number,
+	durationTicks: number,
+): Ticks {
+	const maxDuration = Math.max(
+		TICKS_PER_BAR,
+		MAX_ARRANGEMENT_TICKS - startTicks,
+	);
+	const bars = Math.max(1, Math.round(durationTicks / TICKS_PER_BAR));
+	return toTicks(Math.min(bars * TICKS_PER_BAR, maxDuration));
+}
+
+export function findPlacement(
+	project: Project,
+	placementId: PlacementId,
+): Placement | undefined {
+	return project.song.placements.find(
+		(placement) => placement.id === placementId,
+	);
+}
+
+export function findClip(
+	project: Project,
+	clipId: Clip["id"],
+): Clip | undefined {
+	return project.clips.find((clip) => clip.id === clipId);
+}
+
+/**
+ * Move a placement to a bar-snapped start tick, optionally onto another track.
+ * A cross-track move is only legal when the target track already owns the clip
+ * — `placement.update`'s integrity check rejects re-parenting otherwise, and
+ * silently forking a copy behind the user's back would be exactly the "reuse or
+ * fork?" ambiguity CLP-01 exists to remove. `canMoveToTrack` is how a UI asks
+ * before offering the drop.
+ */
+export function movePlacement(
+	project: Project,
+	placementId: PlacementId,
+	startTicks: number,
+	trackId?: TrackId,
+): RawCommandInput[] {
+	const placement = findPlacement(project, placementId);
+	if (!placement) return [];
+	const nextStart = snapToBar(startTicks);
+	const nextTrackId = trackId ?? placement.trackId;
+	if (nextStart === placement.startTicks && nextTrackId === placement.trackId) {
+		return [];
+	}
+	if (
+		nextTrackId !== placement.trackId &&
+		!canMoveToTrack(project, placement, nextTrackId)
+	) {
+		return [];
+	}
+	return [
+		updatePlacement(placementId, {
+			startTicks: nextStart,
+			...(nextTrackId === placement.trackId ? {} : { trackId: nextTrackId }),
+		}),
+	];
+}
+
+/** True when `track` already owns the placement's clip, so a move is legal. */
+export function canMoveToTrack(
+	project: Project,
+	placement: Placement,
+	trackId: TrackId,
+): boolean {
+	if (placement.trackId === trackId) return true;
+	const clip = findClip(project, placement.clipId);
+	return clip?.trackId === trackId;
+}
+
+/**
+ * Resize a placement by dragging one edge to a bar-snapped tick. The end edge
+ * changes duration alone. The start edge moves the start *and* shortens the
+ * duration by the same amount, so the far edge stays put, advancing
+ * `clipOffsetTicks` in step so clip content does not slide out from under it.
+ */
+export function resizePlacement(
+	project: Project,
+	placementId: PlacementId,
+	edge: "start" | "end",
+	ticks: number,
+): RawCommandInput[] {
+	const placement = findPlacement(project, placementId);
+	if (!placement) return [];
+	const endTicks = placement.startTicks + placement.durationTicks;
+
+	if (edge === "end") {
+		const nextEnd = Math.max(
+			placement.startTicks + TICKS_PER_BAR,
+			snapToBar(ticks),
+		);
+		const durationTicks = clampDuration(
+			placement.startTicks,
+			nextEnd - placement.startTicks,
+		);
+		if (durationTicks === placement.durationTicks) return [];
+		return [updatePlacement(placementId, { durationTicks })];
+	}
+
+	const nextStart = Math.min(snapToBar(ticks), endTicks - TICKS_PER_BAR);
+	if (nextStart === placement.startTicks) return [];
+	const delta = nextStart - placement.startTicks;
+	return [
+		updatePlacement(placementId, {
+			startTicks: toTicks(clampTick(nextStart)),
+			durationTicks: clampDuration(nextStart, placement.durationTicks - delta),
+			// Trimming the head skips that much of the clip; extending it rewinds,
+			// never below the clip's own start.
+			clipOffsetTicks: toTicks(Math.max(0, placement.clipOffsetTicks + delta)),
+		}),
+	];
+}
+
+/** Toggle the loop flag (ARR-01 / KEY-01 `arrangement.toggle_loop`). */
+export function setPlacementLooped(
+	project: Project,
+	placementId: PlacementId,
+	looped: boolean,
+): RawCommandInput[] {
+	const placement = findPlacement(project, placementId);
+	if (!placement || placement.looped === looped) return [];
+	return [updatePlacement(placementId, { looped })];
+}
+
+export function deletePlacements(
+	project: Project,
+	placementIds: readonly PlacementId[],
+): RawCommandInput[] {
+	return placementIds
+		.filter((id) => findPlacement(project, id) !== undefined)
+		.map((id) => removePlacement(id));
+}


### PR DESCRIPTION
## What & why

2 of 10 in the ARR-002 stack, builds on #193. Adds bar-snapped placement geometry edits — move, edge resize, loop toggle, delete — as pure functions from a `Project` plus user intent to typed command inputs (PRD CLP-01, ARR-01).

The caller hands the result to `CommandHistory`, so every gesture lands as one atomic transaction, one revision, and one undo entry; an operation that would change nothing returns no commands, so a drag ending where it started never burns a history entry. Bar snapping is ARR-01's default. `MAX_ARRANGEMENT_TICKS` expresses the PRD's 10:00 guarantee as a tick bound. A start-edge resize keeps the far edge fixed and advances `clipOffsetTicks` in step, so clip content does not slide out from under the trimmed edge. A cross-track move is refused unless the target track already owns the clip — silently forking a copy would be exactly the "reuse or fork?" ambiguity CLP-01 exists to remove.

**Correction landed later in this stack:** the original `MAX_ARRANGEMENT_TICKS` was derived from the *slowest* supported tempo (40 BPM), which is backwards — it capped the guaranteed arrangement at 3:20 at the default 120 BPM instead of 10:00. PR 7 in this stack (`claude/arr-002-analytics`) fixes this by deriving the bound from the *fastest* tempo instead, with new tests that fail against the old constant. Called out here so a reviewer of this PR knows the bound this commit introduces does not yet reflect the corrected reasoning; it is fixed two PRs later, not silently left wrong.

This PR is pure logic, no UI wiring yet — that lands later in the stack.

Refs #60

## Walkthrough

No UI change — this PR adds pure functions with no rendered surface. The wiring PR later in this stack (which does change the UI) includes a walkthrough.

## Evidence

- `src/arrangement/placementGeometry.ts` (193 lines) + `src/arrangement/placementGeometry.test.ts` (206 lines) = 399 lines, under the 400-line ceiling.
- Tests cover: move with bar snapping, cross-track move legality, start/end edge resize (including `clipOffsetTicks` adjustment), loop toggle, delete, and bounds clamping.
- `bun run typecheck` passes on this commit standalone; targeted `placementGeometry.test.ts` passes (see the stack-wide verification summary in the closing PR).

## Acceptance criteria met

Contributes toward "Playback and persistence reflect visible edits immediately without index identity or audio-graph rebuilds" — every edit here is ID-keyed (never array-index-keyed) and produces typed commands for the shared command layer, but this box is only genuinely satisfied once the wiring PR later in the stack actually dispatches these from a rendered UI. Not marking it satisfied from this PR alone.

