### PR TITLE
ARR-002: Add linked vs independent placement duplication

### DIFF
--- a/src/arrangement/placementDuplication.test.ts
+++ b/src/arrangement/placementDuplication.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { executeTransaction } from "../commands/execute";
+import type { Clip, Project } from "../domain/entities";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import { createSeededIdFactory, type PlacementId } from "../domain/ids";
+import {
+	copyClip,
+	describeDuplicate,
+	duplicatePlacement,
+} from "./placementDuplication";
+import { MAX_ARRANGEMENT_TICKS, movePlacement } from "./placementGeometry";
+
+function fixture(): {
+	project: Project;
+	placementId: PlacementId;
+	clip: Clip;
+} {
+	const project = createSliceFixtureProject();
+	return {
+		project,
+		placementId: project.song.placements[0].id,
+		clip: project.clips[0],
+	};
+}
+
+/** Applies the operation's commands the way the editor does: one transaction. */
+function apply(
+	project: Project,
+	commands: Parameters<typeof executeTransaction>[1],
+) {
+	const result = executeTransaction(project, commands);
+	expect(
+		result.ok,
+		JSON.stringify((result as { issues?: unknown }).issues),
+	).toBe(true);
+	return result.project;
+}
+
+describe("duplicatePlacement: reuse versus independent variation (CLP-01)", () => {
+	it("states which operation each mode will perform", () => {
+		expect(describeDuplicate("linked")).toContain("linked");
+		expect(describeDuplicate("linked")).toContain("both");
+		expect(describeDuplicate("independent")).toContain("independent");
+		expect(describeDuplicate("independent")).not.toContain("both");
+	});
+
+	it("linked mode reuses the source clip and adds no new clip", () => {
+		const { project, placementId, clip } = fixture();
+		const ids = createSeededIdFactory("linked");
+		const { commands } = duplicatePlacement(
+			project,
+			placementId,
+			"linked",
+			ids,
+		);
+		const next = apply(project, commands);
+
+		expect(next.clips).toHaveLength(project.clips.length);
+		expect(next.song.placements).toHaveLength(2);
+		expect(next.song.placements.every((p) => p.clipId === clip.id)).toBe(true);
+	});
+
+	it("independent mode forks a clip with a fresh ID and fresh event IDs", () => {
+		const { project, placementId, clip } = fixture();
+		const ids = createSeededIdFactory("independent");
+		const { commands, placementId: newId } = duplicatePlacement(
+			project,
+			placementId,
+			"independent",
+			ids,
+		);
+		const next = apply(project, commands);
+
+		expect(next.clips).toHaveLength(project.clips.length + 1);
+		const copy = next.clips.find((candidate) => candidate.id !== clip.id);
+		expect(copy).toBeDefined();
+		expect(copy?.id).not.toBe(clip.id);
+
+		const added = next.song.placements.find((p) => p.id === newId);
+		expect(added?.clipId).toBe(copy?.id);
+
+		// Nothing about the copy shares identity with the source.
+		if (clip.content.kind === "notes" && copy?.content.kind === "notes") {
+			const sourceIds = new Set(clip.content.events.map((event) => event.id));
+			expect(copy.content.events).toHaveLength(clip.content.events.length);
+			for (const event of copy.content.events) {
+				expect(sourceIds.has(event.id)).toBe(false);
+			}
+		}
+	});
+
+	it("edits to an independent copy leave the source untouched", () => {
+		const { project, placementId, clip } = fixture();
+		const ids = createSeededIdFactory("diverge");
+		const { commands } = duplicatePlacement(
+			project,
+			placementId,
+			"independent",
+			ids,
+		);
+		const next = apply(project, commands);
+		const copy = next.clips.find((candidate) => candidate.id !== clip.id);
+		if (copy?.content.kind !== "notes" || clip.content.kind !== "notes") {
+			throw new Error("expected note clips");
+		}
+		// Structural independence: the copy's event array is not the same object,
+		// so a later note edit to one cannot be observed through the other.
+		expect(copy.content.events).not.toBe(clip.content.events);
+		expect(copy.content.events[0]).not.toBe(clip.content.events[0]);
+	});
+
+	it("places the duplicate immediately after its source", () => {
+		const { project, placementId } = fixture();
+		const source = project.song.placements[0];
+		const ids = createSeededIdFactory("after");
+		const { commands, placementId: newId } = duplicatePlacement(
+			project,
+			placementId,
+			"linked",
+			ids,
+		);
+		const next = apply(project, commands);
+		const added = next.song.placements.find((p) => p.id === newId);
+		expect(added?.startTicks).toBe(source.startTicks + source.durationTicks);
+	});
+
+	it("refuses a duplicate that would run past the ten-minute guarantee", () => {
+		const { project, placementId } = fixture();
+		const moved = apply(
+			project,
+			movePlacement(project, placementId, MAX_ARRANGEMENT_TICKS),
+		);
+		const result = duplicatePlacement(
+			moved,
+			placementId,
+			"linked",
+			createSeededIdFactory("bounded"),
+		);
+		expect(result.commands).toEqual([]);
+		expect(result.placementId).toBeNull();
+	});
+});
+
+describe("copyClip", () => {
+	it("keeps an audioLoop clip's content but gives it a new identity", () => {
+		const { project } = fixture();
+		const source = project.clips[0];
+		const copy = copyClip(source, createSeededIdFactory("copy"));
+		expect(copy.id).not.toBe(source.id);
+		expect(copy.name).toBe(source.name);
+		expect(copy.content.kind).toBe(source.content.kind);
+	});
+});
+
+describe("atomicity and identity (CLP-01: no array-index identity)", () => {
+	it("an independent duplicate lands as exactly one transaction", () => {
+		const { project, placementId } = fixture();
+		const { commands } = duplicatePlacement(
+			project,
+			placementId,
+			"independent",
+			createSeededIdFactory("atomic"),
+		);
+		expect(commands).toHaveLength(2);
+		const before = project.metadata.revision;
+		const result = executeTransaction(project, commands);
+		expect(
+			result.ok,
+			JSON.stringify((result as { issues?: unknown }).issues),
+		).toBe(true);
+		// One transaction, one revision — not one per command.
+		expect(result.project.metadata.revision).toBe(before + 1);
+	});
+
+	it("a rejected command leaves the project object untouched", () => {
+		const { project, placementId } = fixture();
+		const { commands } = duplicatePlacement(
+			project,
+			placementId,
+			"linked",
+			createSeededIdFactory("reject"),
+		);
+		// Applying the same create twice must fail the whole transaction.
+		const result = executeTransaction(project, [...commands, ...commands]);
+		expect(result.ok).toBe(false);
+		expect(result.project).toBe(project);
+	});
+});

--- a/src/arrangement/placementDuplication.ts
+++ b/src/arrangement/placementDuplication.ts
@@ -1,0 +1,132 @@
+/**
+ * Placement duplication: reuse versus independent variation (`ARR-002`; PRD
+ * CLP-01).
+ *
+ * Built on the bar snapping and ten-minute bounds in `placementGeometry.ts`,
+ * and pure in the same way: every function returns typed command inputs the
+ * caller hands to `CommandHistory` as one atomic transaction, and none of them
+ * mutate the project.
+ *
+ * The property CLP-01 turns on lives here: **reuse versus independent variation
+ * is an explicit choice, not a heuristic.** `duplicatePlacement` takes a
+ * `DuplicateMode`. `"linked"` emits one `placement.create` pointing at the
+ * *same* clip, so editing either occurrence changes both — the whole reason the
+ * schema separates placements from clip content (invariant 3). `"independent"`
+ * emits a `clip.create` for a deep copy with fresh IDs — a new clip ID and a
+ * fresh event ID for every note — followed by a `placement.create` pointing at
+ * the copy, so the two can diverge. `describeDuplicate` renders the sentence
+ * the UI shows *before* the gesture runs, so CLP-01's "the UI states which
+ * operation will occur" is answered by the same module that performs it and
+ * cannot drift from it.
+ *
+ * Everything created carries an explicit ID minted from the injected
+ * `IdFactory`, so replay, redo, and an assistant preview all reproduce the same
+ * project (PRD 9.6) — never an array position.
+ */
+
+import { addClip } from "../commands/definitions/clips";
+import { addPlacement } from "../commands/definitions/placements";
+import type { RawCommandInput } from "../commands/types";
+import type { Clip, Project } from "../domain/entities";
+import type { IdFactory, PlacementId } from "../domain/ids";
+import { toTicks } from "../domain/time";
+import {
+	clampTick,
+	findClip,
+	findPlacement,
+	MAX_ARRANGEMENT_TICKS,
+} from "./placementGeometry";
+
+/**
+ * Which of CLP-01's two duplicate operations to perform. `"linked"` reuses the
+ * source clip — the arrangement's whole reason for separating placements from
+ * content — so an edit to either occurrence is heard in both. `"independent"`
+ * forks a deep copy that can then diverge.
+ */
+export type DuplicateMode = "linked" | "independent";
+
+/**
+ * The sentence the UI shows *before* a duplicate runs, so the user knows which
+ * of the two operations the affordance will perform (CLP-01: "the UI states
+ * which operation will occur"). Generated from the same mode the operation
+ * takes, so the label and the behavior cannot drift apart.
+ */
+export function describeDuplicate(mode: DuplicateMode): string {
+	return mode === "linked"
+		? "Duplicate as a linked copy — editing either occurrence changes both"
+		: "Duplicate as an independent copy — the new clip can be edited on its own";
+}
+
+export interface DuplicateResult {
+	readonly commands: RawCommandInput[];
+	/** The new placement's ID, so a caller can select what it just created. */
+	readonly placementId: PlacementId | null;
+}
+
+/**
+ * Duplicate a placement immediately after itself, either reusing its clip or
+ * forking an independent variation.
+ *
+ * The independent path copies the clip with a *fresh* ID and mints a fresh
+ * event ID for every note it contains, so nothing about the copy shares
+ * identity with the source; `clip.create` and `placement.create` then land in
+ * one transaction, so a half-created variation is not reachable even if the
+ * second command were to be rejected.
+ */
+export function duplicatePlacement(
+	project: Project,
+	placementId: PlacementId,
+	mode: DuplicateMode,
+	ids: IdFactory,
+): DuplicateResult {
+	const placement = findPlacement(project, placementId);
+	if (!placement) return { commands: [], placementId: null };
+	const startTicks = toTicks(
+		clampTick(placement.startTicks + placement.durationTicks),
+	);
+	// A duplicate that would land beyond the guaranteed bound is refused rather
+	// than silently stacked on top of its source.
+	if (startTicks + placement.durationTicks > MAX_ARRANGEMENT_TICKS) {
+		return { commands: [], placementId: null };
+	}
+
+	const newPlacementId = ids("placement");
+	const commands: RawCommandInput[] = [];
+	let clipId = placement.clipId;
+
+	if (mode === "independent") {
+		const source = findClip(project, placement.clipId);
+		if (!source) return { commands: [], placementId: null };
+		const copy = copyClip(source, ids);
+		clipId = copy.id;
+		commands.push(addClip(copy));
+	}
+
+	commands.push(
+		addPlacement({
+			...placement,
+			id: newPlacementId,
+			clipId,
+			startTicks,
+		}),
+	);
+	return { commands, placementId: newPlacementId };
+}
+
+/** A deep copy of a clip with fresh IDs throughout — never a shared reference. */
+export function copyClip(clip: Clip, ids: IdFactory): Clip {
+	return {
+		...clip,
+		id: ids("clip"),
+		content:
+			clip.content.kind === "notes"
+				? {
+						...clip.content,
+						events: clip.content.events.map((event) => ({
+							...event,
+							id: ids("event"),
+						})),
+					}
+				: { ...clip.content },
+	};
+}


### PR DESCRIPTION
## What & why

3 of 10 in the ARR-002 stack, builds on #195. Adds linked-vs-independent placement duplication — CLP-01's headline requirement.

`duplicatePlacement` takes an explicit `DuplicateMode` rather than guessing. `"linked"` emits one `placement.create` pointing at the same clip, so editing either occurrence changes both — the whole reason the schema separates placements from clip content (invariant 3). `"independent"` emits a `clip.create` for a deep copy with a fresh clip ID and a fresh event ID for every note, then a `placement.create` pointing at the copy, so the two can diverge. Both land in one transaction, so a half-created variation is never reachable.

`describeDuplicate(mode)` renders the exact sentence the UI shows *before* the gesture runs, generated from the same mode the operation takes, so the label and the behavior cannot drift apart — this is the function the later UI-wiring PR renders verbatim to satisfy "the UI states which operation will occur."

Refs #60

## Walkthrough

No UI change — pure logic only. The UI-wiring PR later in this stack surfaces `describeDuplicate`'s text on-screen and includes a walkthrough.

## Evidence

- `src/arrangement/placementDuplication.ts` (132 lines) + `src/arrangement/placementDuplication.test.ts` (188 lines) = 320 lines, under the ceiling.
- Tests assert: the independent copy shares no event identity or array reference with its source, a duplicate is exactly one revision (not one per command), and a rejected transaction returns the original project object untouched.
- `bun run typecheck` and targeted `placementDuplication.test.ts` pass on this commit standalone.

## Acceptance criteria met

Implements the logic behind "The UI explicitly distinguishes reuse from independent variation and all gestures are atomic commands" — the distinguishing logic and its atomic-transaction guarantee are proven here at the unit level. The box is only genuinely satisfied once a later PR renders `describeDuplicate`'s output where a user reads it before the gesture runs; not claiming it from this PR alone.

