### PR TITLE
ARR-002: Add the arrangement clipboard and placement creation

### DIFF
--- a/src/arrangement/placementClipboard.test.ts
+++ b/src/arrangement/placementClipboard.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { executeTransaction } from "../commands/execute";
+import type { Clip, Project } from "../domain/entities";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import { createSeededIdFactory, type PlacementId } from "../domain/ids";
+import { TICKS_PER_BAR } from "../domain/time";
+import {
+	copyPlacements,
+	createPlacementAt,
+	cutPlacements,
+	pastePlacements,
+} from "./placementClipboard";
+import { duplicatePlacement } from "./placementDuplication";
+
+function fixture(): {
+	project: Project;
+	placementId: PlacementId;
+	clip: Clip;
+} {
+	const project = createSliceFixtureProject();
+	return {
+		project,
+		placementId: project.song.placements[0].id,
+		clip: project.clips[0],
+	};
+}
+
+/** Applies the operation's commands the way the editor does: one transaction. */
+function apply(
+	project: Project,
+	commands: Parameters<typeof executeTransaction>[1],
+) {
+	const result = executeTransaction(project, commands);
+	expect(
+		result.ok,
+		JSON.stringify((result as { issues?: unknown }).issues),
+	).toBe(true);
+	return result.project;
+}
+
+describe("clipboard: copy, cut, paste, delete (ARR-01)", () => {
+	it("copies a placement's fields and pastes it at a snapped tick", () => {
+		const { project, placementId } = fixture();
+		const clipboard = copyPlacements(project, [placementId]);
+		expect(clipboard).toHaveLength(1);
+
+		const next = apply(
+			project,
+			pastePlacements(
+				project,
+				clipboard,
+				TICKS_PER_BAR * 4 + 30,
+				createSeededIdFactory("paste"),
+			),
+		);
+		expect(next.song.placements).toHaveLength(2);
+		const pasted = next.song.placements.find((p) => p.id !== placementId);
+		expect(pasted?.startTicks).toBe(TICKS_PER_BAR * 4);
+	});
+
+	it("cut removes the placement and still yields clipboard content", () => {
+		const { project, placementId } = fixture();
+		const { clipboard, commands } = cutPlacements(project, [placementId]);
+		expect(clipboard).toHaveLength(1);
+		const next = apply(project, commands);
+		expect(next.song.placements).toHaveLength(0);
+
+		// The cut content pastes back, because paste re-resolves the clip from the
+		// live project and the clip itself was never deleted.
+		const restored = apply(
+			next,
+			pastePlacements(next, clipboard, 0, createSeededIdFactory("restore")),
+		);
+		expect(restored.song.placements).toHaveLength(1);
+	});
+
+	it("preserves relative offsets across a multi-placement paste", () => {
+		const { project, placementId } = fixture();
+		const ids = createSeededIdFactory("multi");
+		const withSecond = apply(
+			project,
+			duplicatePlacement(project, placementId, "linked", ids).commands,
+		);
+		const allIds = withSecond.song.placements.map((p) => p.id);
+		const clipboard = copyPlacements(withSecond, allIds);
+		const gap =
+			Math.max(...clipboard.map((e) => e.startTicks)) -
+			Math.min(...clipboard.map((e) => e.startTicks));
+
+		const next = apply(
+			withSecond,
+			pastePlacements(
+				withSecond,
+				clipboard,
+				TICKS_PER_BAR * 8,
+				createSeededIdFactory("multi-paste"),
+			),
+		);
+		const pasted = next.song.placements
+			.filter((p) => !allIds.includes(p.id))
+			.map((p) => p.startTicks)
+			.sort((a, b) => a - b);
+		expect(pasted).toHaveLength(2);
+		expect(pasted[0]).toBe(TICKS_PER_BAR * 8);
+		expect(pasted[1] - pasted[0]).toBe(gap);
+	});
+
+	it("skips a clipboard entry whose clip no longer exists", () => {
+		const { project, placementId } = fixture();
+		const clipboard = copyPlacements(project, [placementId]);
+		const stale = clipboard.map((entry) => ({
+			...entry,
+			clipId: "clp_gone" as typeof entry.clipId,
+		}));
+		expect(
+			pastePlacements(project, stale, 0, createSeededIdFactory("stale")),
+		).toEqual([]);
+	});
+
+	it("pasting an empty clipboard produces no commands", () => {
+		const { project } = fixture();
+		expect(
+			pastePlacements(project, [], 0, createSeededIdFactory("empty")),
+		).toEqual([]);
+	});
+});
+
+describe("createPlacementAt", () => {
+	it("places an existing clip on its own track at a snapped tick", () => {
+		const { project, clip } = fixture();
+		const { commands, placementId } = createPlacementAt(
+			project,
+			clip.id,
+			TICKS_PER_BAR * 3 + 12,
+			createSeededIdFactory("create"),
+		);
+		const next = apply(project, commands);
+		const added = next.song.placements.find((p) => p.id === placementId);
+		expect(added?.startTicks).toBe(TICKS_PER_BAR * 3);
+		expect(added?.trackId).toBe(clip.trackId);
+		expect(added?.looped).toBe(false);
+	});
+
+	it("declines a clip the project does not contain", () => {
+		const { project } = fixture();
+		const result = createPlacementAt(
+			project,
+			"clp_missing" as Clip["id"],
+			0,
+			createSeededIdFactory("missing"),
+		);
+		expect(result.commands).toEqual([]);
+		expect(result.placementId).toBeNull();
+	});
+});
+
+describe("createPlacementAt", () => {
+	it("places an existing clip on its own track at a snapped tick", () => {
+		const { project, clip } = fixture();
+		const { commands, placementId } = createPlacementAt(
+			project,
+			clip.id,
+			TICKS_PER_BAR * 3 + 12,
+			createSeededIdFactory("create"),
+		);
+		const next = apply(project, commands);
+		const added = next.song.placements.find((p) => p.id === placementId);
+		expect(added?.startTicks).toBe(TICKS_PER_BAR * 3);
+		expect(added?.trackId).toBe(clip.trackId);
+		expect(added?.looped).toBe(false);
+	});
+
+	it("declines a clip the project does not contain", () => {
+		const { project } = fixture();
+		const result = createPlacementAt(
+			project,
+			"clp_missing" as Clip["id"],
+			0,
+			createSeededIdFactory("missing"),
+		);
+		expect(result.commands).toEqual([]);
+		expect(result.placementId).toBeNull();
+	});
+});

--- a/src/arrangement/placementClipboard.ts
+++ b/src/arrangement/placementClipboard.ts
@@ -1,0 +1,150 @@
+/**
+ * The arrangement clipboard and placement creation (`ARR-002`; PRD ARR-01:
+ * "copy, cut, paste, duplicate, and delete work for selected placements").
+ *
+ * Copy/cut capture a placement's fields into a plain, project-independent
+ * entry; paste re-resolves the clip from the *live* project and places what it
+ * still can. That indirection is deliberate — a clipboard holding a snapshot of
+ * clip *content* would let a paste resurrect a clip the user deleted in
+ * between, so the clipboard holds only a reference, and an entry whose clip is
+ * gone is skipped rather than recreated.
+ *
+ * Like the rest of placement editing, everything here is pure: the caller hands
+ * the returned commands to `CommandHistory` as one atomic transaction, and
+ * every created entity carries an explicit ID from the injected `IdFactory`.
+ */
+
+import { addPlacement } from "../commands/definitions/placements";
+import type { RawCommandInput } from "../commands/types";
+import type { Clip, Project } from "../domain/entities";
+import type { IdFactory, PlacementId, TrackId } from "../domain/ids";
+import { toTicks } from "../domain/time";
+import type { DuplicateResult } from "./placementDuplication";
+import {
+	clampDuration,
+	clampTick,
+	deletePlacements,
+	findClip,
+	findPlacement,
+	MAX_ARRANGEMENT_TICKS,
+	snapToBar,
+} from "./placementGeometry";
+
+/**
+ * A copied placement, held by the UI between copy/cut and paste. It carries the
+ * placement's own fields plus, for a clip the project may no longer contain by
+ * the time of the paste (a cut whose clip was then deleted), nothing at all —
+ * paste re-resolves the clip from the live project and declines if it is gone,
+ * rather than resurrecting content from a stale snapshot.
+ */
+export interface PlacementClipboardEntry {
+	readonly clipId: Clip["id"];
+	readonly trackId: TrackId;
+	readonly startTicks: number;
+	readonly durationTicks: number;
+	readonly clipOffsetTicks: number;
+	readonly looped: boolean;
+}
+
+export function copyPlacements(
+	project: Project,
+	placementIds: readonly PlacementId[],
+): PlacementClipboardEntry[] {
+	const entries: PlacementClipboardEntry[] = [];
+	for (const id of placementIds) {
+		const placement = findPlacement(project, id);
+		if (!placement) continue;
+		entries.push({
+			clipId: placement.clipId,
+			trackId: placement.trackId,
+			startTicks: placement.startTicks,
+			durationTicks: placement.durationTicks,
+			clipOffsetTicks: placement.clipOffsetTicks,
+			looped: placement.looped,
+		});
+	}
+	return entries;
+}
+
+/** Copy-then-delete: the clipboard content plus the commands that remove them. */
+export function cutPlacements(
+	project: Project,
+	placementIds: readonly PlacementId[],
+): {
+	readonly clipboard: PlacementClipboardEntry[];
+	readonly commands: RawCommandInput[];
+} {
+	return {
+		clipboard: copyPlacements(project, placementIds),
+		commands: deletePlacements(project, placementIds),
+	};
+}
+
+/**
+ * Paste the clipboard at a bar-snapped target tick, preserving the relative
+ * offsets between the copied placements so a multi-placement paste keeps its
+ * shape. A clip that no longer exists is skipped — the paste places what it
+ * still can rather than failing the whole transaction or inventing content.
+ */
+export function pastePlacements(
+	project: Project,
+	clipboard: readonly PlacementClipboardEntry[],
+	targetTicks: number,
+	ids: IdFactory,
+): RawCommandInput[] {
+	if (clipboard.length === 0) return [];
+	const anchor = Math.min(...clipboard.map((entry) => entry.startTicks));
+	const target = snapToBar(targetTicks);
+	const commands: RawCommandInput[] = [];
+	for (const entry of clipboard) {
+		if (!findClip(project, entry.clipId)) continue;
+		const startTicks = toTicks(clampTick(target + (entry.startTicks - anchor)));
+		if (startTicks + entry.durationTicks > MAX_ARRANGEMENT_TICKS) continue;
+		commands.push(
+			addPlacement({
+				id: ids("placement"),
+				clipId: entry.clipId,
+				trackId: entry.trackId,
+				startTicks,
+				durationTicks: toTicks(entry.durationTicks),
+				clipOffsetTicks: toTicks(entry.clipOffsetTicks),
+				looped: entry.looped,
+			}),
+		);
+	}
+	return commands;
+}
+
+/**
+ * Place an existing clip on its own track at a bar-snapped tick — the
+ * "create a placement" gesture, e.g. double-clicking empty arrangement space.
+ */
+export function createPlacementAt(
+	project: Project,
+	clipId: Clip["id"],
+	startTicks: number,
+	ids: IdFactory,
+): DuplicateResult {
+	const clip = findClip(project, clipId);
+	if (!clip) return { commands: [], placementId: null };
+	const start = snapToBar(startTicks);
+	const durationTicks = clampDuration(start, clip.lengthTicks);
+	if (start + durationTicks > MAX_ARRANGEMENT_TICKS) {
+		return { commands: [], placementId: null };
+	}
+	const placementId = ids("placement");
+	return {
+		commands: [
+			addPlacement({
+				id: placementId,
+				clipId: clip.id,
+				trackId: clip.trackId,
+				startTicks: start,
+				durationTicks,
+				clipOffsetTicks: toTicks(0),
+				looped: false,
+			}),
+		],
+		placementId,
+	};
+}


### PR DESCRIPTION
## What & why

4 of 10 in the ARR-002 stack, builds on #196. Adds the arrangement clipboard and placement creation — copy, cut, paste, and create-at-tick for placements (PRD ARR-01: "copy, cut, paste, duplicate, and delete work for selected placements").

Copy/cut capture a placement's fields into a plain, project-independent entry; paste re-resolves the clip from the *live* project and places what it still can. That indirection is deliberate — a clipboard holding a snapshot of clip *content* would let a paste resurrect a clip the user deleted in between, so the clipboard holds only a reference, and an entry whose clip is gone is skipped rather than recreated. A multi-placement paste preserves the relative offsets between entries, so a copied group keeps its shape, and every pasted position is bar-snapped and bounds-clamped through the geometry module from PR 2.

Refs #60

## Walkthrough

No UI change — pure logic only. The UI-wiring PR later in this stack wires keyboard cut/copy/paste to this module and includes a walkthrough.

## Evidence

- `src/arrangement/placementClipboard.ts` (150 lines) + `src/arrangement/placementClipboard.test.ts` (184 lines) = 334 lines, under the ceiling.
- Tests cover: copy/cut capturing plain project-independent entries, paste re-resolving against the live project, a paste skipping an entry whose clip was deleted since copy, multi-placement paste preserving relative offsets, and bar-snap/bounds-clamp on every pasted position.
- `bun run typecheck` and targeted `placementClipboard.test.ts` pass on this commit standalone.

## Acceptance criteria met

Contributes toward "Playback and persistence reflect visible edits immediately without index identity or audio-graph rebuilds" (copy/cut/paste are ID-keyed, atomic-transaction commands) — genuinely satisfied only once the wiring PR dispatches these from the UI. Not marking it satisfied from this PR alone.

