### PR TITLE
ARR-002: Add the placement editing controller (selection, drag, edits)

### DIFF
--- a/src/arrangement/placementEditingController.test.ts
+++ b/src/arrangement/placementEditingController.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { TICKS_PER_BAR } from "../domain/time";
+import { createEditingHarness as harness } from "./placementEditingHarness";
+
+describe("selection", () => {
+	it("selects one placement and replaces the selection by default", () => {
+		const h = harness();
+		const first = h.placementId();
+		h.editing.select(first);
+		expect(h.editing.getSelection()).toEqual([first]);
+		expect(h.editing.hasSelection()).toBe(true);
+
+		h.editing.duplicate("linked");
+		const second = h.getProject().song.placements[1].id;
+		h.editing.select(second);
+		expect(h.editing.getSelection()).toEqual([second]);
+	});
+
+	it("additive selection toggles a placement in and out", () => {
+		const h = harness();
+		const first = h.placementId();
+		h.editing.select(first);
+		h.editing.duplicate("linked");
+		const second = h.getProject().song.placements[1].id;
+
+		h.editing.select(first);
+		h.editing.select(second, true);
+		expect(h.editing.getSelection()).toHaveLength(2);
+		h.editing.select(second, true);
+		expect(h.editing.getSelection()).toEqual([first]);
+	});
+
+	it("reconcile drops IDs the project no longer contains", () => {
+		const h = harness();
+		const id = h.placementId();
+		h.editing.select(id);
+		h.editing.deleteSelection();
+		// Re-select the now-deleted ID, as a stale selection surviving an undo
+		// would; reconcile against the live project must drop it.
+		h.editing.select(id);
+		expect(h.editing.getSelection()).toEqual([id]);
+		h.editing.reconcile();
+		expect(h.editing.getSelection()).toEqual([]);
+	});
+});
+
+describe("drag: move and resize commit as one gesture", () => {
+	it("a multi-step move commits exactly one gesture", () => {
+		const h = harness();
+		const id = h.placementId();
+		h.editing.beginDrag(id, "body", 0);
+		h.editing.updateDrag(TICKS_PER_BAR);
+		h.editing.updateDrag(TICKS_PER_BAR * 2);
+		h.editing.updateDrag(TICKS_PER_BAR * 3);
+		h.editing.endDrag();
+
+		expect(h.gestures.commits).toBe(1);
+		expect(h.gestures.cancels).toBe(0);
+		expect(h.getProject().song.placements[0].startTicks).toBe(
+			TICKS_PER_BAR * 3,
+		);
+		expect(h.editing.isDragging()).toBe(false);
+	});
+
+	it("a drag that never moved cancels rather than committing an empty entry", () => {
+		const h = harness();
+		h.editing.beginDrag(h.placementId(), "body", 0);
+		h.editing.endDrag();
+		expect(h.gestures.commits).toBe(0);
+		expect(h.gestures.cancels).toBe(1);
+	});
+
+	it("cancelDrag abandons the gesture", () => {
+		const h = harness();
+		h.editing.beginDrag(h.placementId(), "body", 0);
+		h.editing.updateDrag(TICKS_PER_BAR * 2);
+		h.editing.cancelDrag();
+		expect(h.gestures.cancels).toBe(1);
+		expect(h.editing.isDragging()).toBe(false);
+	});
+
+	it("dragging the end handle resizes instead of moving", () => {
+		const h = harness();
+		const id = h.placementId();
+		h.editing.beginDrag(id, "end", TICKS_PER_BAR);
+		h.editing.updateDrag(TICKS_PER_BAR * 4);
+		h.editing.endDrag();
+		const placement = h.getProject().song.placements[0];
+		expect(placement.startTicks).toBe(0);
+		expect(placement.durationTicks).toBe(TICKS_PER_BAR * 4);
+	});
+
+	it("beginning a drag selects the placement being dragged", () => {
+		const h = harness();
+		const id = h.placementId();
+		h.editing.beginDrag(id, "body", 0);
+		expect(h.editing.getSelection()).toEqual([id]);
+	});
+});
+
+describe("discrete operations", () => {
+	it("deletes the selection and clears it", () => {
+		const h = harness();
+		h.editing.select(h.placementId());
+		expect(h.editing.deleteSelection()).toBe(true);
+		expect(h.getProject().song.placements).toHaveLength(0);
+		expect(h.editing.getSelection()).toEqual([]);
+	});
+
+	it("delete with nothing selected does nothing", () => {
+		const h = harness();
+		expect(h.editing.deleteSelection()).toBe(false);
+		expect(h.getProject().song.placements).toHaveLength(1);
+	});
+
+	it("toggles the loop flag on the selection", () => {
+		const h = harness();
+		h.editing.select(h.placementId());
+		expect(h.editing.toggleLoop()).toBe(true);
+		expect(h.getProject().song.placements[0].looped).toBe(true);
+		expect(h.editing.toggleLoop()).toBe(true);
+		expect(h.getProject().song.placements[0].looped).toBe(false);
+	});
+});

--- a/src/arrangement/placementEditingController.ts
+++ b/src/arrangement/placementEditingController.ts
@@ -1,0 +1,271 @@
+/**
+ * The arrangement's placement-editing controller (`ARR-002`; PRD CLP-01,
+ * ARR-01).
+ *
+ * Framework-free, like `arrangementShell.ts` beside it: it owns the transient
+ * state a placement gesture needs — selection, the drag in flight, the
+ * clipboard — and turns pointer/keyboard intent into the pure operations in
+ * `placementGeometry`/`placementDuplication`/`placementClipboard`. It never
+ * mutates a project; every operation goes to the `dispatch` the editor session
+ * supplies, so each gesture is one transaction, one revision, one undo entry.
+ * A drag applies through a `Gesture` when available, so dragging across ten
+ * bars still commits as a single entry (PRD 9.6).
+ *
+ * Selection lives here rather than in the shell because the shell's
+ * `ArrangementSelection` is the ARR-01 *bar range* — a span of time you loop or
+ * zoom to — whereas placement editing selects *entities* by ID.
+ */
+
+import type { Analytics } from "../analytics/analytics";
+import type { RawCommandInput } from "../commands/types";
+import type { Project } from "../domain/entities";
+import type { IdFactory, PlacementId } from "../domain/ids";
+import {
+	copyPlacements,
+	cutPlacements,
+	type PlacementClipboardEntry,
+	pastePlacements,
+} from "./placementClipboard";
+import {
+	type DuplicateMode,
+	describeDuplicate,
+	duplicatePlacement,
+} from "./placementDuplication";
+import {
+	deletePlacements,
+	movePlacement,
+	resizePlacement,
+	setPlacementLooped,
+} from "./placementGeometry";
+
+/** Applies commands as one transaction; returns whether anything landed. */
+export type DispatchCommands = (commands: readonly RawCommandInput[]) => void;
+
+/** Opens a continuous gesture, or returns undefined when none is available. */
+export interface EditingGesture {
+	apply(commands: readonly RawCommandInput[]): void;
+	commit(summary?: string): void;
+	cancel(): void;
+}
+
+export interface PlacementEditingOptions {
+	readonly getProject: () => Project | null;
+	readonly dispatch: DispatchCommands;
+	readonly beginGesture?: (summary: string) => EditingGesture | undefined;
+	readonly ids: IdFactory;
+	readonly analytics?: Analytics;
+	/** Notified whenever selection, drag, or clipboard state changes. */
+	readonly onChange?: () => void;
+}
+
+/** A drag in flight: which placement, which edge (or body), and its gesture. */
+interface DragState {
+	readonly placementId: PlacementId;
+	readonly handle: "start" | "end" | "body";
+	/** Ticks between the pointer and the placement's start. */
+	readonly grabOffsetTicks: number;
+	readonly gesture: EditingGesture | undefined;
+	applied: boolean;
+}
+
+export function createPlacementEditing(options: PlacementEditingOptions) {
+	let selected: readonly PlacementId[] = [];
+	let clipboard: readonly PlacementClipboardEntry[] = [];
+	let drag: DragState | null = null;
+
+	function changed(): void {
+		options.onChange?.();
+	}
+
+	function project(): Project | null {
+		return options.getProject();
+	}
+
+	/** Runs an operation as one transaction, ignoring an empty command list. */
+	function run(commands: readonly RawCommandInput[]): boolean {
+		if (commands.length === 0) return false;
+		options.dispatch(commands);
+		return true;
+	}
+
+	// --- Selection ------------------------------------------------------------
+
+	function select(placementId: PlacementId, additive = false): void {
+		selected = additive
+			? selected.includes(placementId)
+				? selected.filter((id) => id !== placementId)
+				: [...selected, placementId]
+			: [placementId];
+		changed();
+	}
+
+	function clearSelection(): void {
+		if (selected.length === 0) return;
+		selected = [];
+		changed();
+	}
+
+	/** Drops selected IDs the project no longer contains (e.g. after an undo). */
+	function reconcile(): void {
+		const current = project();
+		if (!current) return;
+		const live = new Set(current.song.placements.map((p) => p.id));
+		const next = selected.filter((id) => live.has(id));
+		if (next.length === selected.length) return;
+		selected = next;
+		changed();
+	}
+
+	// --- Drag: move and resize ------------------------------------------------
+
+	function beginDrag(
+		placementId: PlacementId,
+		handle: "start" | "end" | "body",
+		pointerTicks: number,
+	): void {
+		const current = project();
+		const placement = current?.song.placements.find(
+			(candidate) => candidate.id === placementId,
+		);
+		if (!placement) return;
+		if (!selected.includes(placementId)) select(placementId);
+		drag = {
+			placementId,
+			handle,
+			grabOffsetTicks: pointerTicks - placement.startTicks,
+			gesture: options.beginGesture?.(
+				handle === "body" ? "Move placement" : "Resize placement",
+			),
+			applied: false,
+		};
+	}
+
+	/** One step of a drag. Applies live so the surface and audio stay in sync. */
+	function updateDrag(pointerTicks: number): void {
+		const current = project();
+		if (!drag || !current) return;
+		const commands =
+			drag.handle === "body"
+				? movePlacement(
+						current,
+						drag.placementId,
+						pointerTicks - drag.grabOffsetTicks,
+					)
+				: resizePlacement(current, drag.placementId, drag.handle, pointerTicks);
+		if (commands.length === 0) return;
+		if (drag.gesture) drag.gesture.apply(commands);
+		else options.dispatch(commands);
+		drag.applied = true;
+		changed();
+	}
+
+	/** Ends the drag, committing the whole thing as one history entry. */
+	function endDrag(): void {
+		if (!drag) return;
+		if (drag.applied) drag.gesture?.commit();
+		else drag.gesture?.cancel();
+		drag = null;
+		changed();
+	}
+
+	function cancelDrag(): void {
+		if (!drag) return;
+		drag.gesture?.cancel();
+		drag = null;
+		changed();
+	}
+
+	// --- Discrete operations --------------------------------------------------
+
+	function deleteSelection(): boolean {
+		const current = project();
+		if (!current) return false;
+		const applied = run(deletePlacements(current, selected));
+		if (applied) clearSelection();
+		return applied;
+	}
+
+	function toggleLoop(): boolean {
+		const current = project();
+		if (!current || selected.length === 0) return false;
+		const first = current.song.placements.find((p) => p.id === selected[0]);
+		if (!first) return false;
+		const looped = !first.looped;
+		const commands = selected.flatMap((id) =>
+			setPlacementLooped(current, id, looped),
+		);
+		return run(commands);
+	}
+
+	/** Duplicate the selection. `placement_duplicated` fires once per action,
+	 * carrying only which of CLP-01's two operations ran — never a name. */
+	function duplicate(mode: DuplicateMode): boolean {
+		const current = project();
+		if (!current || selected.length === 0) return false;
+		const results = selected.map((id) =>
+			duplicatePlacement(current, id, mode, options.ids),
+		);
+		const commands = results.flatMap((result) => result.commands);
+		if (!run(commands)) return false;
+		options.analytics?.log("placement_duplicated", { mode });
+		const created = results
+			.map((result) => result.placementId)
+			.filter((id): id is PlacementId => id !== null);
+		if (created.length > 0) {
+			selected = created;
+			changed();
+		}
+		return true;
+	}
+
+	// --- Clipboard ------------------------------------------------------------
+
+	const copy = (): boolean => {
+		const current = project();
+		if (!current || selected.length === 0) return false;
+		clipboard = copyPlacements(current, selected);
+		changed();
+		return clipboard.length > 0;
+	};
+
+	const cut = (): boolean => {
+		const current = project();
+		if (!current || selected.length === 0) return false;
+		const result = cutPlacements(current, selected);
+		if (!run(result.commands)) return false;
+		clipboard = result.clipboard;
+		clearSelection();
+		return true;
+	};
+
+	const paste = (targetTicks: number): boolean => {
+		const current = project();
+		return current
+			? run(pastePlacements(current, clipboard, targetTicks, options.ids))
+			: false;
+	};
+
+	return {
+		getSelection: (): readonly PlacementId[] => selected,
+		getClipboard: (): readonly PlacementClipboardEntry[] => clipboard,
+		isDragging: (): boolean => drag !== null,
+		hasSelection: (): boolean => selected.length > 0,
+		/** The label the UI shows before a duplicate (CLP-01). */
+		duplicateLabel: describeDuplicate,
+		select,
+		clearSelection,
+		reconcile,
+		beginDrag,
+		updateDrag,
+		endDrag,
+		cancelDrag,
+		deleteSelection,
+		toggleLoop,
+		duplicate,
+		copy,
+		cut,
+		paste,
+	};
+}
+
+export type PlacementEditing = ReturnType<typeof createPlacementEditing>;

--- a/src/arrangement/placementEditingHarness.ts
+++ b/src/arrangement/placementEditingHarness.ts
@@ -1,0 +1,74 @@
+/**
+ * Test-only harness for `placementEditingController` (`ARR-002`): a live
+ * fixture project the controller edits through a real `executeTransaction`
+ * dispatch, plus a recording analytics transport and a counting gesture — so a
+ * test asserts on the project the edits actually produced, not on the commands
+ * they intended to produce.
+ */
+
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import { executeTransaction } from "../commands/execute";
+import type { RawCommandInput } from "../commands/types";
+import type { Project } from "../domain/entities";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import { createSeededIdFactory } from "../domain/ids";
+import { memoryStorage } from "../testing/storage";
+import {
+	createPlacementEditing,
+	type EditingGesture,
+} from "./placementEditingController";
+
+export type RecordingTransport = ReturnType<typeof createRecordingTransport>;
+
+/** Events of one catalogued name, in order. */
+export function eventsNamed(transport: RecordingTransport, name: string) {
+	return transport.events.filter((event) => event.name === name);
+}
+
+export function createEditingHarness(
+	options: { analyticsAllowed?: boolean } = {},
+) {
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	const allowed = options.analyticsAllowed ?? true;
+	consent.set({ productAnalytics: allowed, errorMonitoring: allowed });
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+
+	let project: Project = createSliceFixtureProject();
+	const gestures = { commits: 0, cancels: 0 };
+
+	function dispatch(commands: readonly RawCommandInput[]): void {
+		const result = executeTransaction(project, commands);
+		if (result.ok) project = result.project;
+	}
+
+	const editing = createPlacementEditing({
+		getProject: () => project,
+		dispatch,
+		beginGesture: (): EditingGesture => ({
+			apply: (commands) => dispatch(commands),
+			commit: () => {
+				gestures.commits += 1;
+			},
+			cancel: () => {
+				gestures.cancels += 1;
+			},
+		}),
+		ids: createSeededIdFactory("controller"),
+		analytics,
+	});
+
+	return {
+		editing,
+		transport,
+		gestures,
+		getProject: () => project,
+		placementId: () => project.song.placements[0].id,
+	};
+}


### PR DESCRIPTION
## What & why

6 of 10 in the ARR-002 stack, builds on #198. Adds the placement-editing controller: `createPlacementEditing`, a framework-free object (like `arrangementShell.ts` beside it) that owns the transient state a placement gesture needs — selection, the drag in flight, the clipboard — and turns pointer/keyboard intent into the pure operations from PRs 2-4 (`placementGeometry`/`placementDuplication`/`placementClipboard`).

It never mutates a project directly: every operation goes through the `dispatch` the editor session supplies, so each gesture is one transaction, one revision, one undo entry. A drag applies through a `Gesture` when one is available, so dragging across ten bars commits as a single undo entry rather than ten, and a drag that never moved cancels instead of committing an empty entry. Selection lives in this controller rather than in the shell, because the shell's `ArrangementSelection` is the ARR-01 *bar range* (a span of time you loop or zoom to), while placement editing selects *entities* by ID. `reconcile()` drops selected IDs the project no longer contains, so an undo cannot leave a stale selection.

**Diff-size note (stated up front rather than left for a reviewer to discover):** this PR is 469 lines, 69 over this repo's 400-line ceiling. I considered splitting it and decided against a mechanical split, for the same reason the original author gave in the commit message: the controller is one cohesive closure — selection, drag, and the discrete edits all read and write the same transient state — and its test harness (`placementEditingHarness.ts`, a live fixture project the controller edits through a real `executeTransaction`, used by this PR's tests and the analytics PR later in the stack) has to ship with the controller for the tests to exist at all. Splitting harness-from-controller would be an artificial seam with no reviewable meaning; splitting controller-from-its-own-tests would violate this repo's "tests ship with the code" rule. The clipboard/analytics-specific tests were already kept in their own PR (this one only tests selection, drag, and the discrete operations — delete/loop-toggle — not duplicate/copy/cut, which are covered in PR 4 and PR 9 respectively) rather than trimming coverage to fit. Flagging this explicitly per this repo's "declining a constraint is a normal outcome if stated" convention, rather than silently exceeding it.

This PR is still pure controller logic with no rendered UI — the wiring PR (9 of 9) connects it to `ArrangementView.tsx`.

Refs #60

## Walkthrough

No UI change — the controller is framework-free and not yet imported by any component. The final PR in this stack wires it into `ArrangementView.tsx` and includes a full walkthrough.

## Evidence

- `src/arrangement/placementEditingController.ts` (271 lines) + `src/arrangement/placementEditingController.test.ts` (124 lines) + `src/arrangement/placementEditingHarness.ts` (74 lines, test infrastructure) = 469 lines.
- Tests cover: single/additive selection, `reconcile()` dropping stale IDs after a delete, a multi-step drag committing as exactly one gesture, a no-op drag cancelling rather than committing an empty entry, `cancelDrag` abandoning a gesture, end-handle drag resizing instead of moving, beginning a drag auto-selecting the dragged placement, delete-and-clear-selection, delete-with-nothing-selected being a no-op, and loop-flag toggling.
- `bun run typecheck` and targeted `placementEditingController.test.ts` pass on this commit standalone.

## Acceptance criteria met

Provides the orchestration logic for both remaining boxes, but neither is genuinely satisfiable until the final wiring PR connects this controller to a rendered surface a user can act on. Not marking either box from this PR alone.

