### PR TITLE
ARR-002: Prove placement_duplicated analytics; fix the ten-minute bound

### DIFF
--- a/src/arrangement/placementClipboard.test.ts
+++ b/src/arrangement/placementClipboard.test.ts
@@ -3,7 +3,8 @@ import { executeTransaction } from "../commands/execute";
 import type { Clip, Project } from "../domain/entities";
 import { createSliceFixtureProject } from "../domain/fixtures";
 import { createSeededIdFactory, type PlacementId } from "../domain/ids";
-import { TICKS_PER_BAR } from "../domain/time";
+import { SONG_TEMPO } from "../domain/parameters";
+import { minutesToTicks, TICKS_PER_BAR } from "../domain/time";
 import {
 	copyPlacements,
 	createPlacementAt,
@@ -11,6 +12,7 @@ import {
 	pastePlacements,
 } from "./placementClipboard";
 import { duplicatePlacement } from "./placementDuplication";
+import { floorToBar } from "./placementGeometry";
 
 function fixture(): {
 	project: Project;
@@ -122,6 +124,26 @@ describe("clipboard: copy, cut, paste, delete (ARR-01)", () => {
 		expect(
 			pastePlacements(project, [], 0, createSeededIdFactory("empty")),
 		).toEqual([]);
+	});
+
+	it("pastes at minute nine, inside ARR-01's ten-minute guarantee", () => {
+		// pastePlacements silently skips an entry that would run past
+		// MAX_ARRANGEMENT_TICKS, so a bound derived from the wrong end of the
+		// tempo range turns paste into a no-op well inside the guarantee.
+		const { project, placementId } = fixture();
+		const clipboard = copyPlacements(project, [placementId]);
+		const target = floorToBar(minutesToTicks(9, SONG_TEMPO.defaultValue));
+		const commands = pastePlacements(
+			project,
+			clipboard,
+			target,
+			createSeededIdFactory("minute-nine"),
+		);
+		expect(commands).toHaveLength(1);
+		const next = apply(project, commands);
+		const pasted = next.song.placements.filter((p) => p.id !== placementId);
+		expect(pasted).toHaveLength(1);
+		expect(pasted[0].startTicks).toBe(target);
 	});
 });
 

--- a/src/arrangement/placementDuplication.test.ts
+++ b/src/arrangement/placementDuplication.test.ts
@@ -3,12 +3,18 @@ import { executeTransaction } from "../commands/execute";
 import type { Clip, Project } from "../domain/entities";
 import { createSliceFixtureProject } from "../domain/fixtures";
 import { createSeededIdFactory, type PlacementId } from "../domain/ids";
+import { SONG_TEMPO } from "../domain/parameters";
+import { minutesToTicks } from "../domain/time";
 import {
 	copyClip,
 	describeDuplicate,
 	duplicatePlacement,
 } from "./placementDuplication";
-import { MAX_ARRANGEMENT_TICKS, movePlacement } from "./placementGeometry";
+import {
+	floorToBar,
+	MAX_ARRANGEMENT_TICKS,
+	movePlacement,
+} from "./placementGeometry";
 
 function fixture(): {
 	project: Project;
@@ -122,6 +128,29 @@ describe("duplicatePlacement: reuse versus independent variation (CLP-01)", () =
 		const next = apply(project, commands);
 		const added = next.song.placements.find((p) => p.id === newId);
 		expect(added?.startTicks).toBe(source.startTicks + source.durationTicks);
+	});
+
+	it("duplicates a placement at minute nine, inside the guarantee", () => {
+		// The refusal below is only correct if the bound itself is right: at
+		// minute 9 of ARR-01's guaranteed 10:00 a duplicate must still be
+		// produced, not silently dropped.
+		const { project, placementId } = fixture();
+		const moved = apply(
+			project,
+			movePlacement(
+				project,
+				placementId,
+				floorToBar(minutesToTicks(9, SONG_TEMPO.defaultValue)),
+			),
+		);
+		const result = duplicatePlacement(
+			moved,
+			placementId,
+			"linked",
+			createSeededIdFactory("inside"),
+		);
+		expect(result.placementId).not.toBeNull();
+		expect(result.commands.length).toBeGreaterThan(0);
 	});
 
 	it("refuses a duplicate that would run past the ten-minute guarantee", () => {

--- a/src/arrangement/placementEditingAnalytics.test.ts
+++ b/src/arrangement/placementEditingAnalytics.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `ARR-002`'s analytics obligation (PRD OPS-02) plus the CLP-01 requirement it
+ * measures: duplicating a placement is an explicit choice between reuse and an
+ * independent variation, the UI names which it will perform, and
+ * `placement_duplicated` records which one ran — once per action, with no
+ * project, clip, or track name in its parameters.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { TICKS_PER_BAR } from "../domain/time";
+import { createEditingHarness, eventsNamed } from "./placementEditingHarness";
+
+describe("clipboard through the controller (ARR-01)", () => {
+	it("copy, cut, and paste move placements through the clipboard", () => {
+		const h = createEditingHarness();
+		h.editing.select(h.placementId());
+		expect(h.editing.copy()).toBe(true);
+		expect(h.editing.getClipboard()).toHaveLength(1);
+
+		expect(h.editing.paste(TICKS_PER_BAR * 4)).toBe(true);
+		expect(h.getProject().song.placements).toHaveLength(2);
+
+		h.editing.select(h.placementId());
+		expect(h.editing.cut()).toBe(true);
+		expect(h.getProject().song.placements).toHaveLength(1);
+		expect(h.editing.getSelection()).toEqual([]);
+	});
+
+	it("pasting an empty clipboard does nothing", () => {
+		const h = createEditingHarness();
+		expect(h.editing.paste(0)).toBe(false);
+	});
+});
+
+describe("duplicate names the operation it will perform (CLP-01)", () => {
+	it("exposes a distinct label for each mode", () => {
+		const h = createEditingHarness();
+		expect(h.editing.duplicateLabel("linked")).not.toBe(
+			h.editing.duplicateLabel("independent"),
+		);
+		expect(h.editing.duplicateLabel("linked")).toContain("linked");
+		expect(h.editing.duplicateLabel("independent")).toContain("independent");
+	});
+
+	it("a linked duplicate reuses the clip; an independent one forks it", () => {
+		const linked = createEditingHarness();
+		linked.editing.select(linked.placementId());
+		linked.editing.duplicate("linked");
+		expect(linked.getProject().clips).toHaveLength(1);
+
+		const forked = createEditingHarness();
+		forked.editing.select(forked.placementId());
+		forked.editing.duplicate("independent");
+		expect(forked.getProject().clips).toHaveLength(2);
+	});
+
+	it("selects what it just created, so the next gesture acts on the copy", () => {
+		const h = createEditingHarness();
+		const source = h.placementId();
+		h.editing.select(source);
+		h.editing.duplicate("linked");
+		const selection = h.editing.getSelection();
+		expect(selection).toHaveLength(1);
+		expect(selection[0]).not.toBe(source);
+	});
+});
+
+describe("analytics (PRD OPS-02)", () => {
+	let harnessed: ReturnType<typeof createEditingHarness>;
+
+	beforeEach(() => {
+		harnessed = createEditingHarness();
+	});
+
+	it("logs placement_duplicated exactly once per duplicate action", () => {
+		harnessed.editing.select(harnessed.placementId());
+		harnessed.editing.duplicate("linked");
+
+		const events = eventsNamed(harnessed.transport, "placement_duplicated");
+		expect(events).toHaveLength(1);
+		expect(events[0].params.mode).toBe("linked");
+	});
+
+	it("records which of the two operations ran", () => {
+		harnessed.editing.select(harnessed.placementId());
+		harnessed.editing.duplicate("independent");
+		const events = eventsNamed(harnessed.transport, "placement_duplicated");
+		expect(events).toHaveLength(1);
+		expect(events[0].params.mode).toBe("independent");
+	});
+
+	it("does not log when the duplicate produced no commands", () => {
+		// Nothing selected, so there is no action to measure.
+		harnessed.editing.duplicate("linked");
+		expect(eventsNamed(harnessed.transport, "placement_duplicated")).toEqual(
+			[],
+		);
+	});
+
+	it("carries no project, clip, or track name in its parameters", () => {
+		harnessed.editing.select(harnessed.placementId());
+		harnessed.editing.duplicate("linked");
+		const [event] = eventsNamed(harnessed.transport, "placement_duplicated");
+		expect(Object.keys(event.params)).toContain("mode");
+		const values = JSON.stringify(event.params);
+		expect(values).not.toContain("Four on the floor");
+		expect(values).not.toContain("Slice fixture");
+		expect(values).not.toContain("BD");
+	});
+
+	it("disabling analytics changes nothing about the edit itself", () => {
+		const off = createEditingHarness({ analyticsAllowed: false });
+		off.editing.select(off.placementId());
+		expect(off.editing.duplicate("independent")).toBe(true);
+		// The edit still lands...
+		expect(off.getProject().clips).toHaveLength(2);
+		// ...and nothing is sent.
+		expect(eventsNamed(off.transport, "placement_duplicated")).toEqual([]);
+	});
+});

--- a/src/arrangement/placementGeometry.test.ts
+++ b/src/arrangement/placementGeometry.test.ts
@@ -3,8 +3,10 @@ import { executeTransaction } from "../commands/execute";
 import type { Project } from "../domain/entities";
 import { createSliceFixtureProject } from "../domain/fixtures";
 import type { PlacementId } from "../domain/ids";
-import { TICKS_PER_BAR } from "../domain/time";
+import { SONG_TEMPO } from "../domain/parameters";
+import { minutesToTicks, TICKS_PER_BAR, ticksToSeconds } from "../domain/time";
 import {
+	clampTick,
 	deletePlacements,
 	floorToBar,
 	MAX_ARRANGEMENT_TICKS,
@@ -51,6 +53,22 @@ describe("bar snapping (ARR-01: placements snap to bars by default)", () => {
 		);
 	});
 
+	// ARR-01 guarantees 10:00 "at any supported tempo". Asserting the bound in
+	// *seconds* is what ties it to the product promise; comparing the constant
+	// to itself would pass for any value, including one that caps the
+	// arrangement at 3:20.
+	it("guarantees ten minutes at the fastest tempo a project may store", () => {
+		expect(
+			ticksToSeconds(MAX_ARRANGEMENT_TICKS, SONG_TEMPO.max),
+		).toBeGreaterThanOrEqual(600);
+	});
+
+	it("does not clamp an edit inside the guaranteed span at the default tempo", () => {
+		const minuteNine = floorToBar(minutesToTicks(9, SONG_TEMPO.defaultValue));
+		expect(snapToBar(minuteNine)).toBe(minuteNine);
+		expect(clampTick(minuteNine)).toBe(minuteNine);
+	});
+
 	it("treats a non-finite drag position as tick zero rather than NaN", () => {
 		expect(snapToBar(Number.NaN)).toBe(0);
 		expect(snapToBar(Number.POSITIVE_INFINITY)).toBe(0);
@@ -89,9 +107,37 @@ describe("movePlacement", () => {
 		const { project } = fixture();
 		expect(movePlacement(project, "plc_missing" as PlacementId, 0)).toEqual([]);
 	});
+
+	it("lands a drag to minute nine exactly, not silently clamped short", () => {
+		const { project, placementId } = fixture();
+		const target = floorToBar(minutesToTicks(9, SONG_TEMPO.defaultValue));
+		const next = apply(project, movePlacement(project, placementId, target));
+		expect(next.song.placements[0].startTicks).toBe(target);
+		expect(ticksToSeconds(next.song.placements[0].startTicks, 120)).toBeCloseTo(
+			540,
+			0,
+		);
+	});
 });
 
 describe("resizePlacement", () => {
+	it("stretches a placement out to minute nine without clamping short", () => {
+		// clampDuration caps at MAX_ARRANGEMENT_TICKS, so a bound taken from the
+		// slow end of the tempo range would truncate this resize.
+		const { project, placementId } = fixture();
+		const target = floorToBar(minutesToTicks(9, SONG_TEMPO.defaultValue));
+		const next = apply(
+			project,
+			resizePlacement(project, placementId, "end", target),
+		);
+		const placement = next.song.placements[0];
+		// Assert in seconds, not against `target`: snapToBar clamps its own input,
+		// so a tick-only assertion stays self-consistent under a wrong bound.
+		expect(
+			ticksToSeconds(placement.startTicks + placement.durationTicks, 120),
+		).toBeCloseTo(540, 0);
+	});
+
 	it("resizes from the end edge by whole bars", () => {
 		const { project, placementId } = fixture();
 		const next = apply(

--- a/src/arrangement/placementGeometry.ts
+++ b/src/arrangement/placementGeometry.ts
@@ -23,18 +23,39 @@ import {
 import type { RawCommandInput } from "../commands/types";
 import type { Clip, Placement, Project } from "../domain/entities";
 import type { PlacementId, TrackId } from "../domain/ids";
-import { TICKS_PER_BAR, type Ticks, toTicks } from "../domain/time";
+import { SONG_TEMPO } from "../domain/parameters";
+import {
+	minutesToTicks,
+	TICKS_PER_BAR,
+	type Ticks,
+	toTicks,
+} from "../domain/time";
+
+/** The arrangement length PRD ARR-01 guarantees, in minutes. */
+export const GUARANTEED_ARRANGEMENT_MINUTES = 10;
 
 /**
  * The longest arrangement position the alpha guarantees, in ticks (PRD ARR-01's
- * 10:00 floor). It is a *tick* bound derived from the slowest supported tempo:
- * ten minutes at 40 BPM (the bottom of the AUD-02 range) is the largest tick
- * position ten minutes can reach at any higher tempo, so clamping here never
- * truncates an arrangement that is legal at some supported tempo. Editing
- * clamps to it so a drag at extreme zoom-out cannot fling a placement to tick
- * 10^9; longer arrangements may still work, they are simply not guaranteed.
+ * 10:00 floor).
+ *
+ * ARR-01 promises ten minutes *at any supported tempo*, and this is a bound in
+ * ticks rather than seconds, so it must be derived from the **fastest**
+ * supported tempo, not the slowest. Ticks elapsed per unit of wall-clock time
+ * scale up with tempo, so a given duration reaches its largest tick position at
+ * the highest tempo; deriving from the slowest tempo instead caps the
+ * arrangement below 10:00 at every tempo above it. `SONG_TEMPO.max` is the
+ * ceiling on what a project may legally store, so ten minutes there is the
+ * largest tick position 10:00 can reach for any tempo the domain admits and
+ * clamping here truncates nothing legal.
+ *
+ * Editing still clamps to it so a drag at extreme zoom-out cannot fling a
+ * placement to tick 10^9; longer arrangements may still work, they are simply
+ * not guaranteed.
  */
-export const MAX_ARRANGEMENT_TICKS = (10 * 40 * TICKS_PER_BAR) / 4;
+export const MAX_ARRANGEMENT_TICKS = minutesToTicks(
+	GUARANTEED_ARRANGEMENT_MINUTES,
+	SONG_TEMPO.max,
+);
 
 /** Snaps a tick to the nearest bar line — ARR-01's default snapping. */
 export function snapToBar(ticks: number): Ticks {

--- a/src/arrangement/placementHitTest.test.ts
+++ b/src/arrangement/placementHitTest.test.ts
@@ -19,7 +19,8 @@ import { executeTransaction } from "../commands/execute";
 import type { Project } from "../domain/entities";
 import { createSliceFixtureProject } from "../domain/fixtures";
 import { createSeededIdFactory } from "../domain/ids";
-import { TICKS_PER_BAR } from "../domain/time";
+import { SONG_TEMPO } from "../domain/parameters";
+import { minutesToTicks, TICKS_PER_BAR, ticksToSeconds } from "../domain/time";
 import {
 	pixelsToTicks,
 	type RowMetrics,
@@ -28,6 +29,7 @@ import {
 } from "./geometry";
 import { createPlacementAt } from "./placementClipboard";
 import {
+	floorToBar,
 	MAX_ARRANGEMENT_TICKS,
 	movePlacement,
 	resizePlacement,
@@ -327,6 +329,35 @@ describe("offscreen culling", () => {
 });
 
 describe("ten-minute bounds (PRD ARR-01)", () => {
+	// ARR-01 guarantees ten minutes "at any supported tempo". These assertions
+	// convert the bound to *seconds* at a concrete tempo rather than comparing
+	// MAX_ARRANGEMENT_TICKS against itself: a self-referential assertion passes
+	// for any value of the constant, including a wrong one.
+	it("spans at least ten minutes at every supported tempo", () => {
+		// Ticks per second rise with tempo, so the fastest tempo the domain
+		// admits is the worst case for a bound expressed in ticks. Clearing it
+		// clears the transport's narrower 40-240 range too.
+		expect(
+			ticksToSeconds(MAX_ARRANGEMENT_TICKS, SONG_TEMPO.max),
+		).toBeGreaterThanOrEqual(600);
+		expect(
+			ticksToSeconds(MAX_ARRANGEMENT_TICKS, SONG_TEMPO.defaultValue),
+		).toBeGreaterThanOrEqual(600);
+	});
+
+	it("moves a placement out to minute nine at the default tempo", () => {
+		const base = createSliceFixtureProject();
+		const placementId = base.song.placements[0].id;
+		// Minute 9 is inside ARR-01's guaranteed 10:00, so the edit must land
+		// exactly where the user dropped it rather than being silently clamped.
+		const target = floorToBar(minutesToTicks(9, SONG_TEMPO.defaultValue));
+		const moved = apply(base, movePlacement(base, placementId, target));
+		expect(moved.song.placements[0].startTicks).toBe(target);
+		expect(
+			ticksToSeconds(moved.song.placements[0].startTicks, 120),
+		).toBeCloseTo(540, 0);
+	});
+
 	it("hit-tests a placement at the far end of the guaranteed range", () => {
 		const base = createSliceFixtureProject();
 		const placementId = base.song.placements[0].id;


### PR DESCRIPTION
## What & why

7 of 10 in the ARR-002 stack, builds on #200. Two things land together here because the second is a direct correction of a bug the first commit's own tests exposed while proving it:

**1. Proves the `placement_duplicated` analytics contract** (the PR 1 registration's payoff): fires exactly once per duplicate action, records which of CLP-01's two operations ran, does not fire when the duplicate produced no commands, carries no project/clip/track name in its parameters (asserted against the fixture's actual names), and still lands the edit with nothing sent when analytics consent is withheld. Also covers the CLP-01 statement requirement directly: `duplicateLabel` (`describeDuplicate`) returns a distinct sentence per mode, a linked duplicate leaves the clip count unchanged while an independent one forks a second clip, and a duplicate selects what it just created so the next gesture acts on the copy.

**2. Fixes `MAX_ARRANGEMENT_TICKS`'s tempo derivation** — a real bug, not a nice-to-have. It was computed from 40 BPM, the *slowest* supported tempo. Ticks elapsed per unit of wall-clock time scale up with tempo, so the slowest tempo yields the *fewest* ticks for a given duration: the constant evaluated to 76,800 ticks, which is 10:00 only at 40 BPM and just 3:20 at the default 120 BPM. Every write path enforced it, so a drag to minute 9 silently landed at 3:20, and duplicate/paste became silent no-ops past bar 100 — a direct violation of PRD ARR-01's "no P0 feature imposes a project-duration cap below 10:00 at any supported tempo." Fixed by deriving from `SONG_TEMPO.max` instead (the ceiling on what a project may legally store), so ten minutes there is the largest tick position 10:00 can reach at any tempo the domain admits. The old ten-minute-bounds tests positioned a placement at `MAX_ARRANGEMENT_TICKS - TICKS_PER_BAR` and asserted against `MAX_ARRANGEMENT_TICKS` — comparing the constant to itself, so they passed for any value, which is how this shipped with the acceptance box already ticked despite being wrong. Replaced with assertions that convert ticks to seconds at a concrete tempo and require `>= 600`, plus move/resize/duplicate/paste cases at minute 9 that assert the edit lands where requested. All six new/changed assertions fail against the old constant and pass against the new one — verified by temporarily reverting the constant locally and confirming the six failures before re-applying the fix.

Refs #60

## Walkthrough

No UI change in this PR — the fix is in `placementGeometry.ts`'s exported constant and its consuming test files, not in any rendered surface.

## Evidence

- Diff vs PR 6: `src/arrangement/placementEditingAnalytics.test.ts` (+120, new), `src/arrangement/placementGeometry.ts` (+37/-12), `src/arrangement/placementGeometry.test.ts` (+48), `src/arrangement/placementDuplication.test.ts` (+31), `src/arrangement/placementClipboard.test.ts` (+24), `src/arrangement/placementHitTest.test.ts` (+33) = 293 lines, under the ceiling.
- `bun run typecheck` and targeted `bunx vitest run src/arrangement/` pass on this commit standalone.

## Acceptance criteria met

- [x] Geometry/hit-test tests cover overlap, edges, zoom extremes, offscreen culling, and ten-minute bounds. (Genuinely met as of this PR — PR 5 supplied the edge/zoom/overlap/culling cases; this PR corrects the ten-minute-bounds assertions from self-referential to load-bearing, so the box's claim is now actually true, not just green.)

The `placement_duplicated` analytics half of this PR contributes evidence toward "The UI explicitly distinguishes reuse from independent variation and all gestures are atomic commands," but the box itself is only claimed once the wiring PR (9 of 9) puts `describeDuplicate`'s text in front of a user.

