### PR TITLE
Wire placement select/drag/resize into the arrangement canvas (ARR-002)

### DIFF
--- a/src/arrangement/ArrangementView.test.tsx
+++ b/src/arrangement/ArrangementView.test.tsx
@@ -3,14 +3,103 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { Analytics } from "../analytics/analytics";
 import { ConsentStore } from "../analytics/consent";
 import { createRecordingTransport } from "../analytics/transport";
-import { createLargeArrangementProject } from "../domain/fixtures";
+import {
+	createLargeArrangementProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { TICKS_PER_BAR } from "../domain/time";
+import { EditorSession } from "../editor/EditorSession";
+import { createInMemoryProjectRepository } from "../persistence/inMemoryProjectRepository";
+import { createManualClock } from "../shared/clock";
 import { memoryStorage } from "../testing/storage";
-import ArrangementView from "./ArrangementView";
+import ArrangementView, {
+	type PlacementEditingActions,
+} from "./ArrangementView";
 
 afterEach(() => {
 	cleanup();
 	vi.restoreAllMocks();
 });
+
+const PIXELS_PER_TICK = 0.08;
+const RULER_HEIGHT_PX = 22;
+const ROW_HEIGHT_PX = 28;
+
+/** jsdom's `PointerEvent` drops `clientX`/`button`; a `MouseEvent` bubbles to
+ * the same `onPointer*` handlers and carries them, exactly like `PianoRoll`'s
+ * own test helper does for the same reason. */
+function firePointer(
+	el: Element,
+	type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+	init: { clientX?: number; clientY?: number; pointerId?: number } = {},
+): void {
+	const event = new MouseEvent(type, {
+		bubbles: true,
+		cancelable: true,
+		button: 0,
+		clientX: init.clientX ?? 0,
+		clientY: init.clientY ?? 0,
+	});
+	Object.defineProperty(event, "pointerId", { value: init.pointerId ?? 1 });
+	fireEvent(el, event);
+}
+
+/** A one-placement fixture wired to a real `EditorSession`, so a test asserts
+ * against the project a gesture actually produced (mirrors `PianoRoll.test.tsx`
+ * and the `placementEditingHarness`'s own approach). */
+async function setUpEditing() {
+	const repository = createInMemoryProjectRepository();
+	const project = createSliceFixtureProject();
+	const created = await repository.createProject(project);
+	if (!created.ok) throw new Error("fixture failed to create");
+
+	const transport = createRecordingTransport();
+	const consent = new ConsentStore(memoryStorage());
+	consent.optIn();
+	const analytics = new Analytics({
+		transport,
+		consent,
+		storage: memoryStorage(),
+	});
+
+	const session = new EditorSession({
+		repository,
+		project,
+		clock: createManualClock(1_000),
+		analytics,
+		deviceStorage: memoryStorage(),
+	});
+
+	function renderView() {
+		return render(() => (
+			<ArrangementView
+				project={session.project}
+				analytics={analytics}
+				dispatch={session.dispatch.bind(session)}
+				beginGesture={session.beginGesture.bind(session)}
+			/>
+		));
+	}
+
+	return {
+		session,
+		transport,
+		renderView,
+		placementId: project.song.placements[0].id,
+	};
+}
+
+function interactionCanvasOf(container: HTMLElement): HTMLElement {
+	const el = container.querySelector(".arrangement-layer-interactive");
+	if (!el) throw new Error("no interaction canvas rendered");
+	return el as HTMLElement;
+}
+
+function selectedPlacementIds(container: HTMLElement): string[] {
+	return Array.from(
+		container.querySelectorAll("[data-selected-placement]"),
+	).map((el) => el.getAttribute("data-selected-placement") as string);
+}
 
 /** An `Analytics` that actually sends (consent granted, memory storage), with a
  * recording transport so tests can assert exactly what was logged. */
@@ -121,3 +210,68 @@ function featureUses(
 		.filter((event) => event.name === "feature_first_use")
 		.map((event) => event.params.feature as string);
 }
+
+describe("placement editing wiring (ARR-002)", () => {
+	it("pointer-down on a placement selects it, not the shell's bar range", async () => {
+		const { renderView, placementId } = await setUpEditing();
+		const { container } = renderView();
+		const canvas = interactionCanvasOf(container);
+		// The fixture's one placement spans tick 0..TICKS_PER_BAR at row 0; a
+		// point mid-body, well clear of the resize handles, hits its body.
+		firePointer(canvas, "pointerdown", {
+			clientX: (TICKS_PER_BAR / 2) * PIXELS_PER_TICK,
+			clientY: RULER_HEIGHT_PX + ROW_HEIGHT_PX / 2,
+		});
+		firePointer(canvas, "pointerup", { clientX: 0, clientY: 0 });
+		expect(selectedPlacementIds(container)).toEqual([placementId]);
+	});
+
+	it("dragging a placement's body moves it, bar-snapped, through the command layer", async () => {
+		const { session, renderView, placementId } = await setUpEditing();
+		const { container } = renderView();
+		const canvas = interactionCanvasOf(container);
+		const bodyY = RULER_HEIGHT_PX + ROW_HEIGHT_PX / 2;
+
+		firePointer(canvas, "pointerdown", {
+			clientX: (TICKS_PER_BAR / 2) * PIXELS_PER_TICK,
+			clientY: bodyY,
+		});
+		// Drag three bars to the right.
+		const targetTicks = TICKS_PER_BAR / 2 + TICKS_PER_BAR * 3;
+		firePointer(canvas, "pointermove", {
+			clientX: targetTicks * PIXELS_PER_TICK,
+			clientY: bodyY,
+		});
+		firePointer(canvas, "pointerup", {
+			clientX: targetTicks * PIXELS_PER_TICK,
+			clientY: bodyY,
+		});
+
+		const placement = session.project.song.placements.find(
+			(p) => p.id === placementId,
+		);
+		expect(placement?.startTicks).toBe(TICKS_PER_BAR * 3);
+		// The whole drag is one history entry, not one per pointermove.
+		expect(session.history.entries.length).toBe(1);
+	});
+
+	it("exposes the controller's operations through onEditingActionsReady, like registerPianoRollActions", async () => {
+		const { session, placementId } = await setUpEditing();
+		const holder: { current: PlacementEditingActions | null } = {
+			current: null,
+		};
+		render(() => (
+			<ArrangementView
+				project={session.project}
+				dispatch={session.dispatch.bind(session)}
+				beginGesture={session.beginGesture.bind(session)}
+				onEditingActionsReady={(actions) => {
+					holder.current = actions;
+				}}
+			/>
+		));
+		expect(holder.current).not.toBeNull();
+		holder.current?.select(placementId);
+		expect(holder.current?.hasSelection()).toBe(true);
+	});
+});

--- a/src/arrangement/ArrangementView.tsx
+++ b/src/arrangement/ArrangementView.tsx
@@ -4,6 +4,7 @@ import {
 	createMemo,
 	createSignal,
 	For,
+	onCleanup,
 	onMount,
 	Show,
 } from "solid-js";
@@ -11,7 +12,14 @@ import {
 	type Analytics,
 	analytics as defaultAnalytics,
 } from "../analytics/analytics";
+import type {
+	Gesture,
+	GestureOptions,
+	RawCommandInput,
+	TransactionResult,
+} from "../commands";
 import type { Project } from "../domain/entities";
+import { createIdFactory } from "../domain/ids";
 import { TICKS_PER_BAR } from "../domain/time";
 import { ArrangementToolbar } from "./ArrangementToolbar";
 import {
@@ -25,11 +33,20 @@ import {
 } from "./canvasRenderer";
 import type { RowMetrics, Viewport } from "./geometry";
 import {
+	createPlacementEditing,
+	type EditingGesture,
+	type PlacementEditing,
+} from "./placementEditingController";
+import {
 	type ArrangementProjection,
 	buildArrangementProjection,
 } from "./projection";
 import { useArrangementCanvas } from "./useArrangementCanvas";
 import "./ArrangementView.css";
+
+/** The placement-editing operations `EditorView` wires into the KEY-01
+ * registry and a duplicate-mode toolbar, mirroring `PianoRollActions`. */
+export type PlacementEditingActions = PlacementEditing;
 
 /**
  * The production arrangement editor shell (`ARR-001`; PRD ARR-01, section 9.3).
@@ -73,6 +90,20 @@ export interface ArrangementViewProps {
 	/** Whether the transport is playing, so the playhead follows only then. */
 	readonly isPlaying?: Accessor<boolean>;
 	readonly analytics?: Analytics;
+	/**
+	 * The shared command layer (`ARR-002`). Optional so existing callers/tests
+	 * that only exercise the ARR-001 shell keep working; placement editing is
+	 * inert without it.
+	 */
+	readonly dispatch?: (
+		commands: RawCommandInput | readonly RawCommandInput[],
+	) => TransactionResult | undefined;
+	readonly beginGesture?: (options?: GestureOptions) => Gesture | undefined;
+	/** Called once with the placement-editing operations, so `EditorView` can
+	 * wire them into the KEY-01 registry, mirroring `registerPianoRollActions`. */
+	readonly onEditingActionsReady?: (
+		actions: PlacementEditingActions | null,
+	) => void;
 }
 
 export default function ArrangementView(props: ArrangementViewProps) {
@@ -95,6 +126,14 @@ export default function ArrangementView(props: ArrangementViewProps) {
 	const waveformCache = createArrangementWaveformCache();
 	let shell: ArrangementShell | null = null;
 	let firstUseLogged = false;
+	let editing: PlacementEditing | null = null;
+	// Minted once for this component instance, like `waveformCache` above — an
+	// `IdFactory` is a plain closure, not reactive state, and must persist
+	// across renders rather than being rebuilt inside one.
+	const ids = createIdFactory();
+	// The placement drag in flight, if any: which pointer owns it, so a stray
+	// move/up from another pointer is ignored.
+	let activePointerId: number | null = null;
 
 	function initialViewport(): Viewport {
 		return {
@@ -112,6 +151,28 @@ export default function ArrangementView(props: ArrangementViewProps) {
 			playheadTicks: state?.playheadTicks ?? null,
 			selection: state?.selection ?? null,
 			hoverPlacementId: state?.hoverPlacementId ?? null,
+			selectedPlacementIds: new Set(editing?.getSelection() ?? []),
+		};
+	}
+
+	// --- Placement editing (ARR-002) adapters ---------------------------------
+	//
+	// `createPlacementEditing` wants a `dispatch` with no return value and a
+	// `beginGesture` returning its own `EditingGesture` shape, which differs
+	// from `UseEditorSessionResult`'s `Gesture`/`dispatch` (see
+	// `useEditorSession.ts`). These adapters translate without adding a second
+	// mutation path: every command still flows through `props.dispatch`/
+	// `props.beginGesture`, i.e. the shared command layer.
+
+	function adaptGesture(gesture: Gesture): EditingGesture {
+		return {
+			apply: (commands) => {
+				gesture.apply(commands);
+			},
+			commit: (summary) => {
+				gesture.commit(summary);
+			},
+			cancel: () => gesture.cancel(),
 		};
 	}
 
@@ -149,6 +210,27 @@ export default function ArrangementView(props: ArrangementViewProps) {
 			onDirty: () => canvas.scheduleDraw(),
 		});
 
+		if (props.dispatch) {
+			const dispatch = props.dispatch;
+			editing = createPlacementEditing({
+				getProject: () => props.project,
+				dispatch: (commands) => {
+					dispatch(commands);
+				},
+				beginGesture: (summary) => {
+					const gesture = props.beginGesture?.({ summary });
+					return gesture && adaptGesture(gesture);
+				},
+				ids,
+				analytics: analytics(),
+				onChange: () => {
+					shell?.markDirty("interaction");
+					bumpState();
+				},
+			});
+			props.onEditingActionsReady?.(editing);
+		}
+
 		canvas.observeViewport(scrollEl, bumpState);
 
 		// Prime the initial size and paint every layer once.
@@ -161,14 +243,21 @@ export default function ArrangementView(props: ArrangementViewProps) {
 		bumpState();
 	});
 
+	onCleanup(() => {
+		props.onEditingActionsReady?.(null);
+	});
+
 	// Project identity / structure changed: everything is dirty, scroll bounds
 	// re-clamp. The projection memo makes this reactive to any project change,
 	// but an unrelated edit still only re-runs the cheap projection build, and a
 	// no-op reconcile (same object) means the shell re-clamps to unchanged
-	// bounds and redraws once.
+	// bounds and redraws once. An undo/redo or remote edit can also remove a
+	// selected placement out from under the controller, so it drops any
+	// selected ID the project no longer contains (see `reconcile`'s doc comment).
 	createEffect(() => {
 		projection();
 		shell?.invalidateAll();
+		editing?.reconcile();
 		syncSpacer();
 		bumpState();
 	});
@@ -260,6 +349,12 @@ export default function ArrangementView(props: ArrangementViewProps) {
 
 	function handlePointerMove(event: PointerEvent): void {
 		if (!shell) return;
+		if (editing?.isDragging() && event.pointerId === activePointerId) {
+			const { x, y } = localPoint(event);
+			const { tick } = shell.pointToArrangement(x, y);
+			editing.updateDrag(tick);
+			return;
+		}
 		const { x, y } = localPoint(event);
 		if (y < 0) {
 			shell.clearHover();
@@ -272,9 +367,34 @@ export default function ArrangementView(props: ArrangementViewProps) {
 		if (!shell) return;
 		const { x, y } = localPoint(event);
 		if (y < 0) return;
+
+		// A placement hit starts a drag (move or resize) instead of the shell's
+		// own bar-range selection; anything else falls through to the existing
+		// behavior unchanged.
+		if (editing && (event.button ?? 0) === 0) {
+			const hit = shell.hitTestAt(x, y);
+			if (hit.kind === "placement") {
+				const { tick } = shell.pointToArrangement(x, y);
+				editing.beginDrag(hit.placementId, hit.handle, tick);
+				activePointerId = event.pointerId;
+				(event.currentTarget as Element).setPointerCapture?.(event.pointerId);
+				bumpState();
+				noteFirstUse();
+				return;
+			}
+		}
+
 		const selection = shell.handlePointerDown(x, y);
 		bumpState();
 		if (selection) noteFirstUse();
+	}
+
+	function endActiveDrag(event: PointerEvent): void {
+		if (!editing?.isDragging() || event.pointerId !== activePointerId) return;
+		editing.endDrag();
+		activePointerId = null;
+		(event.currentTarget as Element).releasePointerCapture?.(event.pointerId);
+		bumpState();
 	}
 
 	// --- Named DOM actions (also the keyboard/accessibility equivalents) ------
@@ -352,6 +472,14 @@ export default function ArrangementView(props: ArrangementViewProps) {
 		return { trackName: track?.name ?? "track", startBar, endBar };
 	});
 
+	/** The placement-editing selection (CLP-01), for the duplicate-mode toolbar
+	 * and the accessible mirror below — canvas pixels are never the sole
+	 * representation of which placements are selected. */
+	const placementSelection = createMemo(() => {
+		stateVersion();
+		return editing?.getSelection() ?? [];
+	});
+
 	return (
 		<div class="arrangement-view" data-testid="arrangement-view-ready">
 			<ArrangementToolbar
@@ -413,7 +541,17 @@ export default function ArrangementView(props: ArrangementViewProps) {
 							ref={interactionCanvas}
 							onPointerMove={handlePointerMove}
 							onPointerDown={handlePointerDown}
-							onPointerLeave={() => shell?.clearHover()}
+							onPointerUp={endActiveDrag}
+							onPointerCancel={endActiveDrag}
+							onPointerLeave={(event) => {
+								if (
+									editing?.isDragging() &&
+									event.pointerId === activePointerId
+								) {
+									return;
+								}
+								shell?.clearHover();
+							}}
 						/>
 					</div>
 				</div>
@@ -441,6 +579,13 @@ export default function ArrangementView(props: ArrangementViewProps) {
 								</button>
 							</li>
 						)}
+					</For>
+				</ul>
+				{/* The placement-editing selection (ARR-002), as real DOM rather than
+				    canvas pixels — see the module doc comment on why. */}
+				<ul aria-label="Selected placements" data-testid="placement-selection">
+					<For each={placementSelection()}>
+						{(placementId) => <li data-selected-placement={placementId} />}
 					</For>
 				</ul>
 			</div>

--- a/src/arrangement/canvasRenderer.test.ts
+++ b/src/arrangement/canvasRenderer.test.ts
@@ -23,9 +23,11 @@ const ROW_METRICS = { trackHeightPx: 28, headerHeightPx: 28 };
  */
 function fakeContext(): CanvasRenderingContext2D & {
 	fillRectCalls: number;
+	strokeRectCalls: number;
 	moveToXs: number[];
 } {
 	const fillRectSpy = vi.fn();
+	const strokeRectSpy = vi.fn();
 	const moveToXs: number[] = [];
 	const ctx = {
 		setTransform: vi.fn(),
@@ -33,7 +35,9 @@ function fakeContext(): CanvasRenderingContext2D & {
 		fillRect: (x: number, _y: number, _w: number, _h: number) => {
 			fillRectSpy(x);
 		},
-		strokeRect: vi.fn(),
+		strokeRect: (x: number, _y: number, _w: number, _h: number) => {
+			strokeRectSpy(x);
+		},
 		beginPath: vi.fn(),
 		moveTo: (x: number) => {
 			moveToXs.push(x);
@@ -50,10 +54,14 @@ function fakeContext(): CanvasRenderingContext2D & {
 		get fillRectCalls() {
 			return fillRectSpy.mock.calls.length;
 		},
+		get strokeRectCalls() {
+			return strokeRectSpy.mock.calls.length;
+		},
 		moveToXs,
 	};
 	return ctx as unknown as CanvasRenderingContext2D & {
 		fillRectCalls: number;
+		strokeRectCalls: number;
 		moveToXs: number[];
 	};
 }
@@ -129,6 +137,7 @@ describe("drawInteractionLayer", () => {
 			playheadTicks: TICKS_PER_BAR * 2,
 			selection: null,
 			hoverPlacementId: null,
+			selectedPlacementIds: new Set(),
 		});
 		// The playhead moveTo x is the tick converted to a pixel (0.08 px/tick).
 		const expectedX = Math.round(TICKS_PER_BAR * 2 * 0.08) + 0.5;
@@ -141,8 +150,23 @@ describe("drawInteractionLayer", () => {
 			playheadTicks: null,
 			selection: null,
 			hoverPlacementId: null,
+			selectedPlacementIds: new Set(),
 		});
 		expect(env.ctx.clearRect).toHaveBeenCalledTimes(1);
 		expect(env.ctx.fillRectCalls).toBe(0);
+	});
+
+	it("draws a filled, thick-bordered highlight for a selected placement (ARR-002)", () => {
+		const env = envFor(baseViewport());
+		const [placementId] = env.projection.placementsById.keys();
+		if (!placementId) throw new Error("fixture has no placement");
+		drawInteractionLayer(env, {
+			playheadTicks: null,
+			selection: null,
+			hoverPlacementId: null,
+			selectedPlacementIds: new Set([placementId]),
+		});
+		expect(env.ctx.fillRectCalls).toBeGreaterThan(0);
+		expect(env.ctx.strokeRectCalls).toBeGreaterThan(0);
 	});
 });

--- a/src/arrangement/canvasRenderer.ts
+++ b/src/arrangement/canvasRenderer.ts
@@ -42,6 +42,9 @@ export interface InteractionState {
 		readonly endTick: number;
 	} | null;
 	readonly hoverPlacementId: PlacementId | null;
+	/** Placement-editing selection (`ARR-002`; PRD CLP-01) — entities selected
+	 * by ID, distinct from `selection`'s bar range. */
+	readonly selectedPlacementIds: ReadonlySet<PlacementId>;
 }
 
 const COLORS = {
@@ -56,6 +59,7 @@ const COLORS = {
 	selection: "rgba(32, 200, 232, 0.18)",
 	selectionBorder: "#20c8e8",
 	hover: "#e6e6e6",
+	placementSelection: "rgba(32, 200, 232, 0.28)",
 };
 
 /** Rows begin below the ruler; the ruler is a fixed strip that does not scroll. */
@@ -314,6 +318,28 @@ export function drawInteractionLayer(
 				projection.rowMetrics.trackHeightPx,
 			);
 		}
+	}
+
+	// Selected placements (ARR-002): a thicker, filled border so the highlight
+	// reads as distinct from the plain hover outline below even when a
+	// placement is both selected and hovered at once.
+	for (const placementId of interaction.selectedPlacementIds) {
+		const placement = projection.placementsById.get(placementId);
+		if (!placement) continue;
+		const left = screenX(placement.startTicks, viewport);
+		const right = screenX(placement.endTicks, viewport);
+		const top = rowTop(placement.rowIndex, projection) - viewport.scrollTop;
+		const height = projection.rowMetrics.trackHeightPx;
+		ctx.fillStyle = COLORS.placementSelection;
+		ctx.fillRect(left, top, Math.max(1, right - left), height);
+		ctx.strokeStyle = COLORS.selectionBorder;
+		ctx.lineWidth = 3;
+		ctx.strokeRect(
+			left + 1.5,
+			top + 1.5,
+			Math.max(1, right - left - 3),
+			height - 3,
+		);
 	}
 
 	if (interaction.hoverPlacementId) {

--- a/src/arrangement/useArrangementCanvas.test.ts
+++ b/src/arrangement/useArrangementCanvas.test.ts
@@ -76,6 +76,7 @@ function harness() {
 				playheadTicks: 0,
 				selection: null,
 				hoverPlacementId: null,
+				selectedPlacementIds: new Set(),
 			}),
 			waveformCache: createArrangementWaveformCache(),
 		});


### PR DESCRIPTION
## Summary

9 of 10 in the ARR-002 stack, builds on #202 (`claude/arr-002-shortcuts`). This PR wires the existing, fully-unit-tested `placementEditingController.ts`/`placementGeometry.ts`/`placementDuplication.ts`/`placementClipboard.ts` engine into `ArrangementView.tsx`'s actual pointer handlers — before this PR, none of that engine (added by PRs 2-8 of this stack) was reachable from the rendered component. This and the final PR in the stack (#205) together satisfy acceptance criteria 1 and 2, which no earlier PR in the stack could honestly claim.

- `createPlacementEditing` is instantiated once in `onMount`, with small adapters translating `useEditorSession`'s `dispatch`/`beginGesture` shapes into the controller's own (`EditingGesture` differs from `Gesture`, and the controller's `dispatch` has no return value). Every command still flows through `props.dispatch`/`props.beginGesture` — the shared command layer — never a second mutation path.
- `handlePointerDown` hit-tests for a placement (`shell.hitTestAt`) before falling through to the shell's existing bar-range selection logic, which is otherwise untouched. A placement hit calls `editing.beginDrag(...)`; `pointermove`/`pointerup`/`pointercancel` drive `updateDrag`/`endDrag` with `setPointerCapture`, mirroring `PianoRoll.tsx`'s own drag pattern.
- `canvasRenderer.ts`'s `InteractionState` gains `selectedPlacementIds: ReadonlySet<PlacementId>`, drawn as a filled, thick (3px) cyan-bordered highlight in `drawInteractionLayer`, visually distinct from the existing 2px hover outline.
- The same selection is mirrored as real DOM (`data-selected-placement` list items) so canvas pixels are never the sole representation (matches this file's existing accessible-mirror pattern for the bar-range selection/track list).
- `ArrangementView` gains three new **optional** props — `dispatch`, `beginGesture`, `onEditingActionsReady` — so existing callers/tests that only exercise the ARR-001 shell (the DOM-actions and `feature_first_use` tests already in `ArrangementView.test.tsx`) are unaffected.

## Deliberately deferred to PR 10 of 10 (#205)

The CLP-01 headline UI requirement — the two explicit linked-vs-independent duplicate buttons — and the KEY-01 keyboard wiring for cut/copy/paste/delete/duplicate are **not** in this PR. Both depend on the controller wiring here but touch different files (`EditorView.tsx`, `useEditorShortcuts.ts`, a new `PlacementToolbar.tsx`), and including them would have pushed this PR to ~515 changed lines — over the 400-line ceiling. Splitting here keeps each PR reviewable as one purpose: "the engine is reachable from pointer input" here, "the UI states which duplicate operation will run, and the keyboard reaches the same operations" next.

`onEditingActionsReady` is included in *this* PR (not the next) because it is a natural, tiny part of "wiring the controller in" — the same shape as `registerPianoRollActions` — and the next PR needs it to exist to consume it.

## Safety invariant

Every existing `ArrangementView.test.tsx` test (DOM actions, header windowing, accessible track list, `feature_first_use` analytics) is unchanged and still passes — those tests never pass `dispatch`, so `editing` stays `null` and every new code path is a no-op guarded by `if (editing) ...` / `editing?.`. Proof: `bunx vitest run src/arrangement/ArrangementView.test.tsx` — 10/10 pass, including 4 pre-existing ones untouched by this diff.

## Evidence

- `git diff --stat origin/claude/arr-002-shortcuts..HEAD`: `5 files changed, 355 insertions(+), 5 deletions(-)` — under the 400-line ceiling.
- `bun run typecheck` — clean.
- `bunx vitest run src/arrangement/ src/editor/` — 398/398 pass (stderr noise is a pre-existing jsdom fixture-asset-URL warning, unrelated to this change).
- `bun run check:ci` — clean.
- New tests: pointer-down selects a placement (asserted via the `data-selected-placement` accessible mirror, not canvas pixels); a body drag moves the placement bar-snapped through the real command layer, landing as exactly one history entry (proving atomicity); `onEditingActionsReady` exposes the controller's operations the same way `registerPianoRollActions` does; a new `canvasRenderer.test.ts` case covers the selection highlight's draw calls.
- Independently re-verified (not just re-run by the author): checked out this commit standalone, ran `bun run typecheck` (clean) and `bunx vitest run src/arrangement/` (14 files, 166/166 pass) fresh.

## Walkthrough

This PR alone has no new visible affordance worth a screenshot — the duplicate-mode toolbar that makes the selection meaningful lands in the next PR (#205), which carries the full walkthrough. What *is* new here, confirmed by the tests above: selecting a placement (pointer-down inside a clip block on the arrangement canvas) shows a cyan highlighted border around it, and dragging a placement's body moves it, snapped to the bar grid, landing on release as one undo entry.

## Acceptance criteria met

Contributes toward criteria 1 and 2 but does not independently satisfy either — see PR #205, which completes the wiring and is where both are genuinely claimed with a live-browser walkthrough.

Refs #60
