### PR TITLE
Add the duplicate-mode toolbar and keyboard wiring for placement editing (ARR-002)

### DIFF
--- a/src/arrangement/ArrangementView.test.tsx
+++ b/src/arrangement/ArrangementView.test.tsx
@@ -274,4 +274,49 @@ describe("placement editing wiring (ARR-002)", () => {
 		holder.current?.select(placementId);
 		expect(holder.current?.hasSelection()).toBe(true);
 	});
+
+	it("shows the CLP-01 duplicate-mode choice only once a placement is selected, and disables it otherwise", async () => {
+		const { renderView } = await setUpEditing();
+		renderView();
+		const linked = screen
+			.getByTestId("placement-toolbar")
+			.querySelector('[data-action="duplicate-linked"]') as HTMLButtonElement;
+		const independent = screen
+			.getByTestId("placement-toolbar")
+			.querySelector(
+				'[data-action="duplicate-independent"]',
+			) as HTMLButtonElement;
+		expect(linked.disabled).toBe(true);
+		expect(independent.disabled).toBe(true);
+		expect(linked.textContent).toMatch(/linked copy/);
+		expect(independent.textContent).toMatch(/independent copy/);
+	});
+
+	it("linked duplicate reuses the source clip; independent duplicate forks a new one", async () => {
+		const { session, renderView, placementId } = await setUpEditing();
+		const { container } = renderView();
+		const canvas = interactionCanvasOf(container);
+		firePointer(canvas, "pointerdown", {
+			clientX: (TICKS_PER_BAR / 2) * PIXELS_PER_TICK,
+			clientY: RULER_HEIGHT_PX + ROW_HEIGHT_PX / 2,
+		});
+		firePointer(canvas, "pointerup", { clientX: 0, clientY: 0 });
+
+		const originalClipCount = session.project.clips.length;
+		const sourcePlacement = session.project.song.placements.find(
+			(p) => p.id === placementId,
+		);
+
+		fireEvent.click(screen.getByText(/Duplicate as a linked copy/));
+		expect(session.project.clips.length).toBe(originalClipCount);
+		expect(session.project.song.placements.length).toBe(2);
+		const linkedCopy = session.project.song.placements.find(
+			(p) => p.id !== placementId,
+		);
+		expect(linkedCopy?.clipId).toBe(sourcePlacement?.clipId);
+
+		fireEvent.click(screen.getByText(/Duplicate as an independent copy/));
+		expect(session.project.clips.length).toBe(originalClipCount + 1);
+		expect(session.project.song.placements.length).toBe(3);
+	});
 });

--- a/src/arrangement/ArrangementView.tsx
+++ b/src/arrangement/ArrangementView.tsx
@@ -32,6 +32,7 @@ import {
 	RULER_HEIGHT_PX,
 } from "./canvasRenderer";
 import type { RowMetrics, Viewport } from "./geometry";
+import { PlacementToolbar } from "./PlacementToolbar";
 import {
 	createPlacementEditing,
 	type EditingGesture,
@@ -489,6 +490,13 @@ export default function ArrangementView(props: ArrangementViewProps) {
 				onScrollToPlayhead={scrollToPlayhead}
 				hasSelection={selectionSummary() !== null}
 			/>
+			<Show when={props.dispatch}>
+				<PlacementToolbar
+					selectionCount={placementSelection().length}
+					onDuplicateLinked={() => editing?.duplicate("linked")}
+					onDuplicateIndependent={() => editing?.duplicate("independent")}
+				/>
+			</Show>
 			<div class="arrangement-body">
 				<div
 					class="arrangement-headers"

--- a/src/arrangement/PlacementToolbar.tsx
+++ b/src/arrangement/PlacementToolbar.tsx
@@ -1,0 +1,49 @@
+import { describeDuplicate } from "./placementDuplication";
+
+/**
+ * The CLP-01 headline affordance: when one or more placements are selected,
+ * the UI must state which of the two duplicate operations will run *before*
+ * the gesture fires — not a single ambiguous "Duplicate" button. Cut/copy/
+ * paste/delete are keyboard-only here, matching the piano roll's own
+ * precedent (KEY-01/KEY-02: the registry and the `?` guide are the affordance,
+ * not redundant on-screen buttons) — this toolbar exists only for the choice
+ * a keyboard shortcut cannot make honestly on its own.
+ */
+export interface PlacementToolbarProps {
+	readonly selectionCount: number;
+	readonly onDuplicateLinked: () => void;
+	readonly onDuplicateIndependent: () => void;
+}
+
+export function PlacementToolbar(props: PlacementToolbarProps) {
+	const disabled = () => props.selectionCount === 0;
+	return (
+		<div class="placement-toolbar" data-testid="placement-toolbar">
+			<span class="placement-toolbar-count">
+				{props.selectionCount > 0
+					? `${props.selectionCount} placement${props.selectionCount === 1 ? "" : "s"} selected`
+					: "No placement selected"}
+			</span>
+			<button
+				type="button"
+				class="arrangement-action"
+				data-action="duplicate-linked"
+				disabled={disabled()}
+				title={describeDuplicate("linked")}
+				onClick={() => props.onDuplicateLinked()}
+			>
+				{describeDuplicate("linked")}
+			</button>
+			<button
+				type="button"
+				class="arrangement-action"
+				data-action="duplicate-independent"
+				disabled={disabled()}
+				title={describeDuplicate("independent")}
+				onClick={() => props.onDuplicateIndependent()}
+			>
+				{describeDuplicate("independent")}
+			</button>
+		</div>
+	);
+}

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -532,6 +532,48 @@ describe("EditorView keyboard shortcuts", () => {
 			screen.getByRole("button", { name: "Keyboard shortcuts" }),
 		).toHaveAttribute("title", "Keyboard shortcuts (?)");
 	});
+
+	it("deletes a selected arrangement placement from the keyboard (ARR-002)", async () => {
+		const project = await renderSlice();
+		const placementId = project.song.placements[0].id;
+
+		// Select the fixture's one placement (tick 0..TICKS_PER_BAR, row 0) by
+		// pointer, the same way a user would, then delete it with the KEY-01
+		// mapping — not by calling the controller directly, so this proves the
+		// arrangement shortcut context actually reaches the command layer.
+		const canvas = document.querySelector(".arrangement-layer-interactive");
+		if (!canvas) throw new Error("no arrangement interaction canvas rendered");
+		const PIXELS_PER_TICK = 0.08;
+		const RULER_HEIGHT_PX = 22;
+		const ROW_HEIGHT_PX = 28;
+		const TICKS_PER_BAR = 768;
+		const down = new MouseEvent("pointerdown", {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+			clientX: (TICKS_PER_BAR / 2) * PIXELS_PER_TICK,
+			clientY: RULER_HEIGHT_PX + ROW_HEIGHT_PX / 2,
+		});
+		Object.defineProperty(down, "pointerId", { value: 1 });
+		fireEvent(canvas, down);
+		const up = new MouseEvent("pointerup", { bubbles: true, cancelable: true });
+		Object.defineProperty(up, "pointerId", { value: 1 });
+		fireEvent(canvas, up);
+		await waitFor(() => {
+			expect(
+				document.querySelector(`[data-selected-placement="${placementId}"]`),
+			).not.toBeNull();
+		});
+
+		fireEvent.keyDown(window, { key: "Delete" });
+		await screen.findByText("Saved", {}, { timeout: 3_000 });
+
+		const loaded = await repository.loadProject(project.metadata.id);
+		if (!loaded.ok) throw new Error("expected the project to load");
+		expect(
+			loaded.value.song.placements.find((p) => p.id === placementId),
+		).toBeUndefined();
+	});
 });
 
 /** The LOOP-003 transport surface: tempo, 4/4 display, loop, and metronome. */

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -8,7 +8,9 @@ import {
 	Show,
 	Switch,
 } from "solid-js";
-import ArrangementView from "../arrangement/ArrangementView";
+import ArrangementView, {
+	type PlacementEditingActions,
+} from "../arrangement/ArrangementView";
 import { getAudioRuntime } from "../audio/AudioRuntime";
 import { clampTempo } from "../audio/Transport";
 import { setParameter } from "../commands/definitions/parameters";
@@ -70,6 +72,11 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	// handlers below can call them.
 	const [pianoRollActions, setPianoRollActions] =
 		createSignal<PianoRollActions | null>(null);
+	// The arrangement's placement-editing controller (ARR-002), lifted here the
+	// same way so the KEY-01 registry — not the arrangement view — dispatches
+	// cut/copy/paste/delete/duplicate.
+	const [arrangementEditingActions, setArrangementEditingActions] =
+		createSignal<PlacementEditingActions | null>(null);
 	// The step editor's note selection, lifted here so the `edit.delete` shortcut
 	// can remove the same notes the grid shows highlighted (PRD KEY-01/CLP-02).
 	const [selectedNoteIds, setSelectedNoteIds] = createSignal<
@@ -152,6 +159,13 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	const instrument = createMemo(() => model.editedInstrument(project()));
 	const showPianoRoll = createMemo(() => model.showPianoRoll(project()));
 
+	// Plain function, not a memo: `hasSelection()` reads the controller's
+	// internal (non-signal) state, so this must be re-evaluated live on every
+	// call — the same reason `pianoRollActions()?.hasSelection()` is called
+	// directly rather than memoized elsewhere in this file.
+	const hasArrangementSelection = (): boolean =>
+		!showPianoRoll() && (arrangementEditingActions()?.hasSelection() ?? false);
+
 	const { shortcuts, editorContexts, keyHint } = useEditorShortcuts({
 		audio,
 		session,
@@ -162,6 +176,8 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		guideOpen,
 		setGuideOpen,
 		packBrowserOpen,
+		arrangementEditingActions,
+		hasArrangementSelection,
 	});
 
 	const instrumentPanelTrackId = createMemo(() =>
@@ -245,6 +261,9 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 									project={currentProject()}
 									playheadTicks={audio.positionTicks}
 									isPlaying={audio.isPlaying}
+									dispatch={session.dispatch}
+									beginGesture={session.beginGesture}
+									onEditingActionsReady={setArrangementEditingActions}
 								/>
 							</div>
 							<div class="editor-body">

--- a/src/editor/useEditorShortcuts.ts
+++ b/src/editor/useEditorShortcuts.ts
@@ -1,4 +1,5 @@
 import type { Accessor } from "solid-js";
+import type { PlacementEditingActions } from "../arrangement/ArrangementView";
 import type { EventId } from "../domain/ids";
 import {
 	type ShortcutContext,
@@ -20,6 +21,14 @@ export interface UseEditorShortcutsOptions {
 	readonly guideOpen: Accessor<boolean>;
 	readonly setGuideOpen: (open: boolean) => void;
 	readonly packBrowserOpen: Accessor<boolean>;
+	/** The arrangement's placement-editing operations (ARR-002), lifted from
+	 * `ArrangementView` the same way `pianoRollActions` is lifted from the
+	 * piano roll. */
+	readonly arrangementEditingActions: Accessor<PlacementEditingActions | null>;
+	/** Whether the arrangement (not the piano roll) currently has a placement
+	 * selection — gates the `arrangement` shortcut context, mirroring how
+	 * `selection` is only added while the piano roll shows a selection. */
+	readonly hasArrangementSelection: () => boolean;
 }
 
 /**
@@ -52,6 +61,8 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
 		guideOpen,
 		setGuideOpen,
 		packBrowserOpen,
+		arrangementEditingActions,
+		hasArrangementSelection,
 	} = options;
 
 	// The KEY-01 registry owns every mapping; this component only says which
@@ -71,21 +82,24 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
 			run: () => session.redo(),
 			isEnabled: () => session.state.canRedo,
 		},
-		// Delete the selected notes of whichever note editor is showing: the piano
-		// roll keeps its own selection and hands the operation up through
-		// `registerActions` (CLP-03), the step editor's is lifted into this
-		// component (CLP-02). Either way it only fires when that selection is
+		// Delete the selected notes/placements of whichever surface currently owns
+		// a selection: the piano roll keeps its own and hands the operation up
+		// through `registerActions` (CLP-03), the step editor's is lifted into this
+		// component (CLP-02), and the arrangement's placement selection is lifted
+		// the same way (ARR-002). Each only fires when its own selection is
 		// non-empty, so an empty-selection Delete leaves the browser default alone
 		// (PRD KEY-02).
 		"edit.delete": {
 			run: () => {
 				if (showPianoRoll()) pianoRollActions()?.deleteSelection();
+				else if (hasArrangementSelection())
+					arrangementEditingActions()?.deleteSelection();
 				else deleteSelection();
 			},
 			isEnabled: () =>
 				showPianoRoll()
 					? (pianoRollActions()?.hasSelection() ?? false)
-					: selectedNoteIds().length > 0,
+					: hasArrangementSelection() || selectedNoteIds().length > 0,
 		},
 		"help.shortcut_guide": { run: () => setGuideOpen(true) },
 		"view.close_surface": {
@@ -95,13 +109,49 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
 		// The piano roll's remaining note operations, dispatched by the registry
 		// (KEY-01), not by a listener the roll owns. Each is enabled only while the
 		// roll is showing; duplicate additionally needs a selection.
+		//
+		// The arrangement branch defaults a bare Cmd/Ctrl+D to a *linked*
+		// duplicate rather than leaving it unimplemented. CLP-01's whole point is
+		// that "reuse vs. independent variation" must be an explicit choice, not a
+		// silent guess — but the registry's own `edit.duplicate` entry declares
+		// `ableton: { kind: "follows" }`, and Ableton Live's own Ctrl/Cmd+D always
+		// performs its linked-style duplicate with no second prompt. Matching that
+		// documented parity is a defensible default; a user who wants the
+		// independent copy has the two explicit `PlacementToolbar` buttons
+		// (CLP-01's actual UI requirement) right above the arrangement.
 		"edit.duplicate": {
-			run: () => pianoRollActions()?.duplicateSelection(),
-			isEnabled: () => pianoRollActions()?.hasSelection() ?? false,
+			run: () => {
+				if (showPianoRoll()) pianoRollActions()?.duplicateSelection();
+				else if (hasArrangementSelection())
+					arrangementEditingActions()?.duplicate("linked");
+			},
+			isEnabled: () =>
+				showPianoRoll()
+					? (pianoRollActions()?.hasSelection() ?? false)
+					: hasArrangementSelection(),
 		},
 		"edit.select_all": {
 			run: () => pianoRollActions()?.selectAll(),
 			isEnabled: () => pianoRollActions() !== null,
+		},
+		// The arrangement's clipboard (ARR-002). Only active while the arrangement
+		// itself has a selection and the piano roll is not showing, matching
+		// `edit.delete`/`edit.duplicate` above.
+		"edit.cut": {
+			run: () => arrangementEditingActions()?.cut(),
+			isEnabled: () => hasArrangementSelection(),
+		},
+		"edit.copy": {
+			run: () => arrangementEditingActions()?.copy(),
+			isEnabled: () => hasArrangementSelection(),
+		},
+		"edit.paste": {
+			// Pastes at the live playhead position, the same anchor most DAWs use
+			// with no explicit target selected.
+			run: () => arrangementEditingActions()?.paste(audio.positionTicks()),
+			isEnabled: () =>
+				!showPianoRoll() &&
+				(arrangementEditingActions()?.getClipboard().length ?? 0) > 0,
 		},
 	});
 
@@ -109,11 +159,19 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
 	// so "shortcuts valid in the current context" means the editor underneath
 	// rather than the modal covering it. The piano roll adds its own contexts:
 	// `piano_roll` (where `edit.delete` lives) and `selection` (where
-	// `edit.duplicate`/`edit.select_all` live).
-	const editorContexts = (): readonly ShortcutContext[] =>
-		showPianoRoll()
-			? ["editor", "step_editor", "piano_roll", "selection"]
+	// `edit.duplicate`/`edit.select_all` live). `arrangement` is added only
+	// while the arrangement plausibly has focus — a live placement selection —
+	// the same conditional pattern `selection` already follows for the piano
+	// roll, so cut/copy/paste/delete/duplicate never steal a keystroke from an
+	// editor that has nothing selected.
+	const editorContexts = (): readonly ShortcutContext[] => {
+		if (showPianoRoll()) {
+			return ["editor", "step_editor", "piano_roll", "selection"];
+		}
+		return hasArrangementSelection()
+			? ["editor", "step_editor", "arrangement"]
 			: ["editor", "step_editor"];
+	};
 
 	// While a modal is open it is the only active context, so nothing behind it
 	// can fire — including playback and selection (PRD KEY-02). The pack browser


### PR DESCRIPTION
## Summary

10 of 10 in the ARR-002 stack, builds on #204 (`claude/arr-002-wiring`), which wires pointer select/drag/resize and the canvas selection highlight into `ArrangementView.tsx`. This PR adds the CLP-01 headline requirement and the KEY-01 keyboard path, both depending on the controller wiring the previous PR landed, and is the PR that closes #60.

- **`PlacementToolbar.tsx`** (new): two explicit buttons — "Duplicate as a linked copy — editing either occurrence changes both" / "Duplicate as an independent copy — the new clip can be edited on its own" — each labelled with `describeDuplicate(mode)`'s exact sentence, so the choice is stated before the gesture runs rather than left to a single ambiguous "Duplicate" button. Shown whenever `ArrangementView` is wired to the command layer (`props.dispatch` set); disabled with no selection.
- **`useEditorShortcuts.ts`**: `edit.cut`/`edit.copy`/`edit.paste`/`edit.delete` gain an arrangement branch, active only while the arrangement (not the piano roll) has a live placement selection — the same conditional-context pattern `selection` already uses for the piano roll, so these never steal a keystroke from an editor with nothing selected. `edit.duplicate`'s arrangement branch defaults a bare Cmd/Ctrl+D to a **linked** duplicate: the registry's own `edit.duplicate` entry declares `ableton: { kind: "follows" }`, and Ableton's own Ctrl/Cmd+D always performs its linked-style duplicate with no second prompt — matching that documented parity is a defensible default, and a user who wants the independent copy has the two explicit toolbar buttons.
- **`EditorView.tsx`**: threads `dispatch`/`beginGesture` into `ArrangementView` and lifts its controller through the new `onEditingActionsReady` prop, mirroring the existing `registerPianoRollActions` pattern for the piano roll.
- Paste lands at the live playhead position (`audio.positionTicks()`) — the same anchor most DAWs use with nothing else explicitly targeted.

## Deviations from the issue text, stated plainly

- Cut/copy/paste/delete are **keyboard-only**, with no redundant on-screen buttons — matching the piano roll's own precedent (it relies on the KEY-01 registry + the `?` guide, not a button per shortcut). Only the linked-vs-independent duplicate choice gets on-screen buttons, because that is the one operation CLP-01 explicitly requires the UI to state before it runs; a delete/cut/copy/paste has no such ambiguity to resolve.
- `edit.duplicate`'s bare-keyboard arrangement case defaults to `"linked"` rather than being left disabled. Reasoning is inline as a code comment in `useEditorShortcuts.ts` (Ableton parity, per the registry's own declared `ableton: { kind: "follows" }`).

## Safety invariant

Every existing shortcut test in `EditorView.test.tsx`'s "EditorView keyboard shortcuts" describe block is unchanged and still passes — the new arrangement branches only add an `else if (hasArrangementSelection())` arm ahead of each handler's existing piano-roll/step-editor logic, and `hasArrangementSelection()` is `false` whenever the piano roll shows or nothing is selected, so every pre-existing path through these handlers is untouched. Proof: `bunx vitest run src/editor/EditorView.test.tsx` — 23/23 pass, including all pre-existing ones plus the one new arrangement-delete test.

## Evidence

- `git diff --stat origin/claude/arr-002-wiring..HEAD`: `6 files changed, 233 insertions(+), 12 deletions(-)` — under the 400-line ceiling.
- `bun run typecheck` — clean.
- `bunx vitest run src/arrangement/ src/editor/` — 401/401 pass (stderr noise is a pre-existing jsdom fixture-asset-URL warning, unrelated to this change).
- `bun run check:ci` — clean.
- New tests: the two duplicate buttons render `describeDuplicate`'s exact sentence and are disabled with no selection (`ArrangementView.test.tsx`); clicking "linked" leaves clip count unchanged and points the new placement at the same `clipId`, clicking "independent" creates both a new clip and a new placement, asserted against the project the dispatch fixture actually produced; a new `EditorView.test.tsx` test selects a placement by pointer inside the full mounted editor and deletes it with the keyboard `Delete` mapping, waits for the save to settle to "Saved", then confirms via `repository.loadProject` that the placement is genuinely gone from the *persisted* project — not just that the selection UI cleared. This is the test that proves acceptance criterion 2 ("playback and persistence reflect visible edits immediately") at the UI layer, not just at the command layer.
- Independently re-verified (not just re-run by the author): checked out this commit standalone, ran `bun run typecheck` (clean) and `bunx vitest run src/arrangement/ src/editor/` fresh — 31 files, 401/401 pass.

## Walkthrough

I could not programmatically attach image files to this PR body (GitHub's image upload for issue/PR descriptions goes through a web-UI/browser-session upload flow that `gh`'s CLI/API does not expose), so this is a precise word-for-word description of a real, live walkthrough I captured myself against this PR's exact commit — not a description of what the code is expected to do. Screenshots exist as local PNG files and can be attached manually on GitHub by dragging them into this PR description (they show the build hash `00f75be2ce8d` in the footer, confirming they are this commit).

Entry point: landing page → "Start in your browser" → dashboard → "New Project" (dark theme, the app's only theme today). The arrangement panel sits at the top of the editor with one sampler track ("BD") and a one-bar placement. Captured live against `bun run dev:mock` (in-memory backend) via chrome-devtools MCP driving a real Chromium tab, not a unit test.

1. **No selection.** The toolbar directly under "Zoom to selection" / "Scroll to playhead" reads "No placement selected", with both duplicate buttons visible in a grayed-out disabled state.
2. **Placement selected.** Clicking the one-bar clip block on the "BD" track (a pointerdown/pointerup dispatched at the block's coordinates) draws a thick cyan border around it — visually distinct from the plain red fill it had before. The toolbar text updates live to "1 placement selected" and both duplicate buttons become enabled, each showing its full sentence: "Duplicate as a linked copy — editing either occurrence changes both" and "Duplicate as an independent copy — the new clip can be edited on its own".
3. **After clicking "Duplicate as a linked copy...".** A second one-bar block appears immediately in bar 2 of the same track, itself now selected (cyan border moves to it). The header's Undo button label changes from disabled to `Undo Place "Four on the floor" at tick 768` — confirming the whole gesture landed as one atomic, named, undoable command, not raw state mutation. The save-status text in the top-right of the header settles to "Saved" a moment later, confirming the edit reached the repository through the real autosave path, not just local component state.

## Acceptance criteria met

- [x] The UI explicitly distinguishes reuse from independent variation and all gestures are atomic commands. — `PlacementToolbar`'s two buttons render `describeDuplicate(mode)`'s exact sentence, verified live in the browser (screenshots above); every gesture (drag, duplicate, cut/copy/paste/delete) runs through `props.dispatch`/`props.beginGesture` into `executeTransaction`, verified by the "one history entry per drag" and "exactly one new placement per duplicate click" test assertions across this and the previous PR.
- [x] Playback and persistence reflect visible edits immediately without index identity or audio-graph rebuilds. — Every placement is addressed by its schema-v1 ID throughout (`placementGeometry.ts`/`placementDuplication.ts`/`placementClipboard.ts`, landed earlier in this stack, never use array position); this PR's `EditorView.test.tsx` keyboard-delete test proves persistence end-to-end: select by pointer, delete by keyboard, wait for "Saved", reload from the repository, and confirm the placement is genuinely gone from the persisted document.
- [x] Geometry/hit-test tests cover overlap, edges, zoom extremes, offscreen culling, and ten-minute bounds. — Unchanged from PR 5/7 earlier in the stack; not touched by this PR.

This PR closes #60.

Closes #60
