### PR TITLE
Build the teardown-guard test's node from an OfflineAudioContext

### DIFF
--- a/src/audio/testAudioTeardown.test.ts
+++ b/src/audio/testAudioTeardown.test.ts
@@ -4,40 +4,47 @@ import { installWebAudioTeardownGuard } from "./testAudioTeardown";
 
 installWebAudioGlobals();
 
+/**
+ * An `AudioNode` to dispatch against, built without touching the output device.
+ *
+ * The guard patches `nwaa.AudioNode.prototype.dispatchEvent`, so any node that
+ * inherits from that prototype exercises it. An `OfflineAudioContext` renders
+ * into a buffer and never opens a CoreAudio output stream, so these tests no
+ * longer contend for the shared device the way a real `AudioContext` does —
+ * the contention that made this file flake under parallel worktrees (#203).
+ * Nothing about the assertion is weakened: the node, the prototype, and the
+ * inherited `dispatchEvent` are the same ones a real context would give us.
+ */
+async function createOfflineAudioNode() {
+	const nwaa = await import("node-web-audio-api");
+	// One channel, one render quantum, at a rate every backend accepts. The
+	// context is never started; it exists only to parent the node.
+	const ctx = new nwaa.OfflineAudioContext(1, 128, 44100);
+	return new nwaa.ConstantSourceNode(ctx);
+}
+
 describe("web audio teardown guard", () => {
 	it("swallows the stale-Event dispatch TypeError from a node-web-audio-api node", async () => {
 		installWebAudioTeardownGuard();
-		const nwaa = await import("node-web-audio-api");
-		const ctx = new nwaa.AudioContext();
-		try {
-			const node = new nwaa.ConstantSourceNode(ctx);
-			// A jsdom Event whose realm no longer matches the bound dispatchEvent
-			// is the shape of the post-teardown collision. We provoke the exact
-			// thrown TypeError by dispatching a non-Event value: the inherited
-			// (jsdom) dispatchEvent rejects it, and the guard must swallow *that*
-			// specific failure rather than let it escape as an unhandled error.
-			const dispatch = node.dispatchEvent as (e: unknown) => boolean;
-			expect(dispatch.call(node, { type: "ended" })).toBe(false);
-		} finally {
-			await ctx.close();
-		}
+		const node = await createOfflineAudioNode();
+		// A jsdom Event whose realm no longer matches the bound dispatchEvent
+		// is the shape of the post-teardown collision. We provoke the exact
+		// thrown TypeError by dispatching a non-Event value: the inherited
+		// (jsdom) dispatchEvent rejects it, and the guard must swallow *that*
+		// specific failure rather than let it escape as an unhandled error.
+		const dispatch = node.dispatchEvent as (e: unknown) => boolean;
+		expect(dispatch.call(node, { type: "ended" })).toBe(false);
 	});
 
 	it("is transparent for a well-formed event (happy path still dispatches)", async () => {
 		installWebAudioTeardownGuard();
-		const nwaa = await import("node-web-audio-api");
-		const ctx = new nwaa.AudioContext();
-		try {
-			const node = new nwaa.ConstantSourceNode(ctx);
-			let heard = false;
-			node.addEventListener("custom", () => {
-				heard = true;
-			});
-			// A real, in-realm jsdom Event must pass straight through the guard.
-			node.dispatchEvent(new Event("custom"));
-			expect(heard).toBe(true);
-		} finally {
-			await ctx.close();
-		}
+		const node = await createOfflineAudioNode();
+		let heard = false;
+		node.addEventListener("custom", () => {
+			heard = true;
+		});
+		// A real, in-realm jsdom Event must pass straight through the guard.
+		node.dispatchEvent(new Event("custom"));
+		expect(heard).toBe(true);
 	});
 });


### PR DESCRIPTION
Fixes the #203 flake by **Option B — remove the contention entirely**.

## What and why

Both tests in `src/audio/testAudioTeardown.test.ts` constructed a real `nwaa.AudioContext` purely to obtain an `AudioNode` to dispatch against. That opens a CoreAudio output stream and contends for the shared default device — which is what made the file flake under the parallel-worktree workflow.

The guard under test patches `nwaa.AudioNode.prototype.dispatchEvent`. It never plays audio, and the tests only dispatch events. The real context was incidental scaffolding, which is exactly why a `play_output_stream` failure was unrelated to the assertion.

An `OfflineAudioContext` parents a `ConstantSourceNode` that is the same `AudioNode.prototype` descendant with the same inherited `dispatchEvent`, so the identical code path runs with no output device involved.

This is **not** mocking, skipping, or weakening the guard — the constraint the issue and CLAUDE.md both set. Both assertions are byte-identical; `testAudioTeardown.ts` and `testAudioContext.ts` are untouched (`git diff` shows one test file).

One wrinkle beyond the issue's two-line sketch: `OfflineAudioContext` has no `close()`, so the `try/finally` blocks go with it.

## Evidence

**Reproduced the flake first.** Raw process count was *not* enough — 48 concurrent copies of the original test stayed green. It only fires with the genuinely *rendering* suites running alongside (they open the output streams that starve the device):

| Load | Original (real `AudioContext`) | This PR (`OfflineAudioContext`) |
| --- | --- | --- |
| 12 vs 12 interleaved, under 8 concurrent `src/audio/` suites | **12/12 failed** | **0/12 failed** |
| 24 runs, under 8 concurrent `src/audio/` suites | **23/24 failed** | **0/24 failed** |
| quiet machine, 5 consecutive runs | — | 5/5 passed |

Runtime drops from ~314ms to ~9ms.

**Not vacuous.** Neutering `installWebAudioTeardownGuard` to a no-op still fails test 1 with the jsdom `TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'` — so the offline context genuinely drives the guard's code path. Restored afterwards (empty diff on the product file).

**Honest caveat:** locally the original fails by *5s timeout*, not the literal `cpal ... OSStatus 1937010544` from the report. Same root cause (blocking on a contended device), different visible signature — worth knowing so a non-matching string isn't read as "didn't reproduce".

## Checks

- `bun run typecheck` — clean
- `bun run check` — clean, 473 files, no fixes applied
- `bun run test` — one **pre-existing** failure, `TrackAudioGraph.mixer.test.ts > stays correct with more than 50 tracks` (5s timeout). Verified it fails identically on unmodified `main`, so it is not from this change. Four other files that failed in that run (`reverb`, `StepEditor`, `PackBrowser`) were artifacts of my own contention experiments and pass once the machine is quiet.

Scope note: this removes contention for *this file only*. The four genuinely-rendering suites still contend, so if the flake proves broader, Options A/C from the issue thread remain the right investment.

## User-visible change

None — test-only change.

Refs #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)