### PR TITLE
Add placementId to OPS-03 content rule opaque ID list

### DIFF
--- a/src/monitoring/replayPayload.test.ts
+++ b/src/monitoring/replayPayload.test.ts
@@ -381,6 +381,11 @@ describe("the OPS-03 content rule against the replay payload (ADR 0002 decision 
 			// PRD section 9.4 prefixed IDs. Opaque by construction.
 			"props.note.id",
 			"track.id",
+			// The `PlacementId`s of the placement-editing selection (ARR-002), in
+			// the arrangement's accessible mirror. A prefixed ID like the two above
+			// — the placement's *name* is never bound here, and the mirror's own
+			// track names are text inside `MASK_CONTENT`.
+			"placementId",
 			// A save state enum and its integer revision.
 			"props.saveStatus()?.state",
 			"props.saveStatus()?.revision",


### PR DESCRIPTION
## What & why

Adds `placementId` to the list of opaque prefixed IDs in the OPS-03 content rule test, documenting that placement IDs from the arrangement's accessible mirror (ARR-002) are safe to include in the replay payload without violating content masking requirements.

The placement's name is never bound in this context, and the mirror's track names are already masked as text content, so `placementId` qualifies as an opaque identifier like `props.note.id` and `track.id`.

## Walkthrough

No UI change

## Evidence

This is a test-only change documenting an existing safe pattern. The change adds a comment explaining the context (ARR-002 placement-editing selection) and clarifies why `placementId` is opaque by construction.

## Acceptance criteria met

- Documented `placementId` as an opaque ID in the OPS-03 content rule
- Added explanatory comment referencing ARR-002 and the masking context

https://claude.ai/code/session_018atdefdSoftVacpJ8TiSwX