### PR TITLE
Open the library by default, beside the arrangement (#221)

### DIFF
--- a/src/editor/EditorView.css
+++ b/src/editor/EditorView.css
@@ -186,6 +186,21 @@
 	opacity: 0.75;
 }
 
+/*
+ * Arrangement over workspace, as one column to the right of the library panel
+ * (#221). The arrangement is a fixed strip at the top of this column and the
+ * workspace takes the rest, so the library stays a full-height column beside
+ * both rather than sitting under the arrangement.
+ */
+.editor-main {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-divider);
+	flex: 1 1 auto;
+	min-width: 0;
+	min-height: 0;
+}
+
 .arrangement-panel {
 	box-sizing: border-box;
 	/* A bounded height so the arrangement's own native scroll container owns
@@ -231,8 +246,9 @@
 }
 
 /*
- * The library panel (LOOP-013). Opened from the header toggle, it is a narrow
- * left-hand column beside the workspace rather than a band beneath it: a
+ * The library panel (LOOP-013). Open by default and closed from the header
+ * toggle, it is a narrow left-hand column running the full height of the editor
+ * beside the arrangement and the workspace, rather than a band beneath them: a
  * browser is something you keep open while you work, and a fixed-height band
  * had to be tall enough to be useful, which cost the editor its vertical room.
  *
@@ -254,7 +270,7 @@
 }
 
 /* The workspace takes the page's old job: it is what scrolls, inside itself. */
-.editor-body .workspace {
+.editor-main .workspace {
 	flex: 1 1 auto;
 	min-width: 0;
 	min-height: 0;

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -63,6 +63,24 @@ function paintStep(name: string): void {
 	fireEvent.pointerUp(cell);
 }
 
+/**
+ * The header's save-status group. Save-failure assertions are scoped to it
+ * rather than queried across the document: the library panel is open from the
+ * first paint (#221) and reports its own failed load — with the same "Check
+ * your connection." wording and its own Retry button — whenever its manifest
+ * fetch fails, which it always does under jsdom.
+ */
+function saveStatusGroup(): HTMLElement {
+	const group = document.querySelector<HTMLElement>(".save-status-group");
+	if (!group) throw new Error("expected the header's save-status group");
+	return group;
+}
+
+/** Null when the save state offers no retry: non-retryable, or not failed. */
+function saveRetryButton(): HTMLElement | null {
+	return within(saveStatusGroup()).queryByRole("button", { name: "Retry" });
+}
+
 // EditorView links back to the dashboard with <A>, which needs a matched Route
 // context to resolve against — a bare MemoryRouter isn't enough.
 function renderEditor(
@@ -285,16 +303,17 @@ describe("EditorView", () => {
 		paintStep("Notes, step 2, off");
 
 		await screen.findByText("Save failed", {}, { timeout: 3_000 });
-		expect(screen.getByText("Check your connection.")).toBeInTheDocument();
-		const retryButton = await screen.findByRole("button", { name: "Retry" });
+		expect(
+			within(saveStatusGroup()).getByText("Check your connection."),
+		).toBeInTheDocument();
+		const retryButton = saveRetryButton();
+		expect(retryButton).not.toBeNull();
 
-		fireEvent.click(retryButton);
+		fireEvent.click(retryButton as HTMLElement);
 
 		await screen.findByText("Saved", {}, { timeout: 3_000 });
 		expect(screen.queryByText("Save failed")).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole("button", { name: "Retry" }),
-		).not.toBeInTheDocument();
+		expect(saveRetryButton()).toBeNull();
 
 		const loaded = await repository.loadProject(project.metadata.id);
 		if (!loaded.ok) throw new Error("expected the project to load");
@@ -332,9 +351,7 @@ describe("EditorView", () => {
 		expect(
 			screen.getByText("This project changed in another tab or session."),
 		).toBeInTheDocument();
-		expect(
-			screen.queryByRole("button", { name: "Retry" }),
-		).not.toBeInTheDocument();
+		expect(saveRetryButton()).toBeNull();
 	});
 });
 
@@ -371,8 +388,8 @@ describe("EditorView library audition engine lifecycle", () => {
 	it("builds a fresh, live engine on each open and disposes the closed one", async () => {
 		const { engines } = await renderWithLibrary();
 
-		// First open builds one engine.
-		toggleLibrary();
+		// The panel is open from the first paint (#221), so mounting the editor is
+		// itself the first open and builds one engine.
 		await screen.findByRole("complementary", { name: "Library" });
 		expect(engines).toHaveLength(1);
 		expect(engines[0].disposed()).toBe(false);
@@ -389,7 +406,8 @@ describe("EditorView library audition engine lifecycle", () => {
 		// Reopening builds a second, distinct, undisposed engine — never the dead
 		// first one. Under the old cached-singleton bug this would still be
 		// engines[0], now disposed, and audition would fail for the rest of the
-		// session.
+		// session. Opening by default does not change that: the toggle still
+		// unmounts and remounts the panel.
 		toggleLibrary();
 		await screen.findByRole("complementary", { name: "Library" });
 		expect(engines).toHaveLength(2);
@@ -402,6 +420,77 @@ describe("EditorView library audition engine lifecycle", () => {
 				sync: false,
 			}),
 		).resolves.toBeDefined();
+	});
+});
+
+/**
+ * Where the library sits and whether it is there to begin with (#221). A sound
+ * browser is the first thing a new project needs, so it is open on arrival, and
+ * it is a column to the left of the arrangement rather than a band under it.
+ */
+describe("EditorView library panel placement", () => {
+	async function renderSlice() {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+		renderEditor(project.metadata.id, {
+			createAuditionEngine: () => fakePreviewEngine(),
+		});
+		await screen.findByRole("region", { name: "Step editor" });
+	}
+
+	it("shows the library without anyone touching the toggle", async () => {
+		await renderSlice();
+
+		expect(
+			await screen.findByRole("complementary", { name: "Library" }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Library" })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+	});
+
+	it("puts the library beside the arrangement, not above or below it", async () => {
+		await renderSlice();
+		const library = await screen.findByRole("complementary", {
+			name: "Library",
+		});
+		const arrangement = screen.getByTestId("arrangement-view-ready");
+
+		// Siblings in the same row: the library's parent is the flex row that also
+		// holds the column the arrangement lives in. If the arrangement were still
+		// stacked above the library, the two would not share a row — the library
+		// would sit inside a container that follows the arrangement's own.
+		const row = library.parentElement;
+		expect(row).not.toBeNull();
+		expect(row).toHaveClass("editor-body");
+		const arrangementColumn = row?.querySelector(".editor-main");
+		expect(arrangementColumn).not.toBeNull();
+		expect(arrangementColumn?.contains(arrangement)).toBe(true);
+		// To the left: the library comes first among that row's children.
+		expect(row?.firstElementChild).toBe(library);
+	});
+
+	it("still closes and reopens from the header toggle", async () => {
+		await renderSlice();
+		const toggle = screen.getByRole("button", { name: "Library" });
+
+		fireEvent.click(toggle);
+
+		await waitFor(() =>
+			expect(
+				screen.queryByRole("complementary", { name: "Library" }),
+			).not.toBeInTheDocument(),
+		);
+		expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+		fireEvent.click(toggle);
+
+		expect(
+			await screen.findByRole("complementary", { name: "Library" }),
+		).toBeInTheDocument();
 	});
 });
 
@@ -493,8 +582,8 @@ describe("EditorView keyboard shortcuts", () => {
 		await renderSlice();
 
 		// The pack browser is a modal surface like the guide, so it takes the
-		// keyboard the same way (PRD KEY-02).
-		fireEvent.click(screen.getByRole("button", { name: "Library" }));
+		// keyboard the same way (PRD KEY-02). The library panel it opens from is
+		// already on screen — it starts open (#221).
 		fireEvent.click(
 			await screen.findByRole("button", { name: /Browse packs/ }),
 		);

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -83,7 +83,11 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	const [selectedNoteIds, setSelectedNoteIds] = createSignal<
 		readonly EventId[]
 	>([]);
-	const [libraryOpen, setLibraryOpen] = createSignal(false);
+	// The library is a browser you keep open while you work, so it starts open
+	// (#221) — a new project's first move is picking a sound, and having to find
+	// the header toggle first hid the library from anyone who had not met it.
+	// The header toggle still closes it for the session.
+	const [libraryOpen, setLibraryOpen] = createSignal(true);
 	const [packBrowserOpen, setPackBrowserOpen] = createSignal(false);
 
 	// The packs this editing session has added on top of the project's own
@@ -257,16 +261,6 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 								saveStatus={saveStatus}
 								onRetrySave={() => void session.retry()}
 							/>
-							<div class="arrangement-panel">
-								<ArrangementView
-									project={currentProject()}
-									playheadTicks={audio.positionTicks}
-									isPlaying={audio.isPlaying}
-									dispatch={session.dispatch}
-									beginGesture={session.beginGesture}
-									onEditingActionsReady={setArrangementEditingActions}
-								/>
-							</div>
 							<div class="editor-body">
 								<Show when={libraryOpen()}>
 									{/*
@@ -292,72 +286,89 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 										/>
 									</aside>
 								</Show>
-								<div class="workspace">
-									<For each={loopClips()}>
-										{(entry) => (
-											<LoopInfo
-												clip={entry.clip}
-												asset={entry.asset}
-												songTempo={tempo()}
-											/>
-										)}
-									</For>
-									<Show when={drumTrack()}>
-										{(drum) => (
-											<div class="drum-machine-editor">
-												<div class="track-info">
-													<span class={`track-name ${MASK_CONTENT}`}>
-														{drum().name}
-													</span>
-												</div>
-												<DrumMachinePanel
-													track={drum()}
-													assets={sampleAssets()}
-													dispatch={session.dispatch}
-													audition={(padId) =>
-														void audio.auditionPad(drum().id, padId)
-													}
+								{/*
+								 * Arrangement and workspace stack vertically to the right of the
+								 * library, so the library is a full-height column beside them
+								 * rather than a band beneath the arrangement (#221).
+								 */}
+								<div class="editor-main">
+									<div class="arrangement-panel">
+										<ArrangementView
+											project={currentProject()}
+											playheadTicks={audio.positionTicks}
+											isPlaying={audio.isPlaying}
+											dispatch={session.dispatch}
+											beginGesture={session.beginGesture}
+											onEditingActionsReady={setArrangementEditingActions}
+										/>
+									</div>
+									<div class="workspace">
+										<For each={loopClips()}>
+											{(entry) => (
+												<LoopInfo
+													clip={entry.clip}
+													asset={entry.asset}
+													songTempo={tempo()}
 												/>
-											</div>
-										)}
-									</Show>
-									<Show
-										when={clip()}
-										fallback={
-											<p class="no-track">
-												This project has no sampler track yet.
-											</p>
-										}
-									>
-										{(currentClip) => (
-											<TrackEditor
-												clip={currentClip()}
-												trackName={track()?.name}
-												packDependencyLabel={packDependencyLabel()}
-												showPianoRoll={showPianoRoll}
-												instrument={instrument()}
-												dispatch={session.dispatch}
-												beginGesture={session.beginGesture}
-												editorPlaybackStep={editorPlaybackStep}
-												selectedNoteIds={selectedNoteIds}
-												setSelectedNoteIds={setSelectedNoteIds}
-												project={currentProject()}
-												playheadTicks={audio.positionTicks()}
-												registerPianoRollActions={setPianoRollActions}
-												instrumentPanelTrackId={instrumentPanelTrackId()}
-												sampleName={sampleName()}
-												replacementOptions={replacementOptions()}
-												auditionInstrument={auditionInstrument}
-											/>
-										)}
-									</Show>
-									<Mixer
-										project={currentProject()}
-										dispatch={session.dispatch}
-										beginGesture={session.beginGesture}
-										trackLevelDb={audio.trackLevelDb}
-										isPlaying={audio.isPlaying}
-									/>
+											)}
+										</For>
+										<Show when={drumTrack()}>
+											{(drum) => (
+												<div class="drum-machine-editor">
+													<div class="track-info">
+														<span class={`track-name ${MASK_CONTENT}`}>
+															{drum().name}
+														</span>
+													</div>
+													<DrumMachinePanel
+														track={drum()}
+														assets={sampleAssets()}
+														dispatch={session.dispatch}
+														audition={(padId) =>
+															void audio.auditionPad(drum().id, padId)
+														}
+													/>
+												</div>
+											)}
+										</Show>
+										<Show
+											when={clip()}
+											fallback={
+												<p class="no-track">
+													This project has no sampler track yet.
+												</p>
+											}
+										>
+											{(currentClip) => (
+												<TrackEditor
+													clip={currentClip()}
+													trackName={track()?.name}
+													packDependencyLabel={packDependencyLabel()}
+													showPianoRoll={showPianoRoll}
+													instrument={instrument()}
+													dispatch={session.dispatch}
+													beginGesture={session.beginGesture}
+													editorPlaybackStep={editorPlaybackStep}
+													selectedNoteIds={selectedNoteIds}
+													setSelectedNoteIds={setSelectedNoteIds}
+													project={currentProject()}
+													playheadTicks={audio.positionTicks()}
+													registerPianoRollActions={setPianoRollActions}
+													instrumentPanelTrackId={instrumentPanelTrackId()}
+													sampleName={sampleName()}
+													replacementOptions={replacementOptions()}
+													auditionInstrument={auditionInstrument}
+												/>
+											)}
+										</Show>
+										<Mixer
+											project={currentProject()}
+											dispatch={session.dispatch}
+											beginGesture={session.beginGesture}
+											trackLevelDb={audio.trackLevelDb}
+											isPlaying={audio.isPlaying}
+										/>
+									</div>
 								</div>
 							</div>
 							<Show when={guideOpen()}>


### PR DESCRIPTION
## What & why

The library panel was closed on arrival, and once opened it sat *under* the
arrangement view rather than beside it (#221). Picking a sound is the first
thing a new project needs, so a browser you have to discover behind a header
toggle is a browser most people never meet.

Two changes, both in the editor shell:

- **Open by default.** `libraryOpen` starts `true`. The header toggle still
  closes it for the session, and the panel keeps its one-audition-engine-per-
  mount lifecycle (LOOP-013) — the toggle unmounts and remounts it exactly as
  before, so a reopen still gets a fresh, undisposed engine.
- **Beside the arrangement, not beneath it.** The arrangement strip and the
  workspace now stack inside a new `.editor-main` column, which is the library
  panel's sibling in the `.editor-body` flex row. The library is therefore a
  full-height left column running alongside both, instead of a column beside
  only the workspace with the arrangement stacked above the pair.

No domain, command, persistence, or audio contract is touched — this is layout
and one initial signal value.

Closes #221

## Core flows

Untouched. `CF-001` walks through the editor and is the flow the walkthrough
below is captured from, but neither its assertions nor `docs/core-flows.md`
changed — `git diff origin/main --stat -- e2e/ docs/` is empty. This issue is a
UI bug report and links no flow of its own.

## Walkthrough

### CF-001 — A visitor with no account reaches a playing loop

**1. Open the landing page**

![CF-001 step 1](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/221/CF-001/01-open-the-landing-page.png)

**2. You arrive at the dashboard as a guest, with no projects yet**

![CF-001 step 2](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/221/CF-001/02.png)

**3. The new project opens on a step editor with a starter pattern**

![CF-001 step 3](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/221/CF-001/03.png)

**4. Turn on a step that was off**

![CF-001 step 4](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/221/CF-001/04-turn-on-a-step-that-was-off.png)

**5. Start playback — the transport is running**

![CF-001 step 5](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/221/CF-001/05-start-playback-the-transport-is-running.png)

<sub>Captured by `bun run walkthrough:capture` from the core-flow specs, in Chromium. Flows are defined in [`docs/core-flows.md`](https://github.com/afternoon/solid-groove/blob/main/docs/core-flows.md).</sub>

Step 3 is the fix: the library is on screen without anyone having touched the
toggle, and it runs the full height of the editor to the left of the
arrangement. Compare it against the screenshot on #221.

Steps 2 and 3 link short-named copies of those two captures. `walkthrough:publish`
names a file after its caption, and GitHub's PR-body sanitizer mangles a link
past roughly 150 characters — it backtick-quoted these two as Markdown and
stripped the `src` off them as HTML, while the three shorter ones came through
untouched both times. The images are identical; only the filenames are shorter.
Worth capping the slug length in `scripts/walkthrough/publish.mjs` so no future
walkthrough hits this.

## Evidence

- `bun run typecheck` — clean.
- `bun run test` — `Test Files 167 passed (167)`, `Tests 2248 passed (2248)`.
- `bun run check` — `Checked 481 files. No fixes applied.`
- `bun run test:browser:chromium` — `18 passed (1.0m)`, including
  `smoke.spec.ts › keeps the arrangement shell inside its panel, above the step
  grid`, which is the assertion the layout change could most plausibly have
  broken. Chromium only: this environment cannot reach `cdn.playwright.dev` for
  the Firefox/WebKit binaries, so Firefox and WebKit were left to CI.

New tests in `EditorView.test.tsx` (`EditorView library panel placement`): the
panel is present with `aria-pressed="true"` on arrival; the library and the
arrangement's column are siblings in the `.editor-body` row with the library
first; and the toggle still closes and reopens it.

Three save-failure assertions in the same file are now scoped to the header's
save-status group rather than queried across the document. That is a test-only
change forced by this one: the library is on screen from the first paint and
reports its own failed load with the same "Check your connection." wording and
its own Retry button, so a document-wide query for either now finds two. The
behavior asserted is unchanged.

## Acceptance criteria met

The issue has no checkboxes; both symptoms it names are fixed —

- [x] The library is open by default, with no toolbar click needed.
- [x] The library sits to the left of the arrangement view rather than under it.

One thing worth flagging that this PR does not change: the library's contents
are served from `public/samples/starter-library/`, which is gitignored and built
by `bun run library:build`. In an environment where that has not been run, the
panel renders its "The library data could not be read." state — which, now that
the panel is open by default, is the first thing on screen rather than something
hidden behind a toggle. The walkthrough above was captured after running
`library:build`, so it shows the populated panel. Worth confirming the deployed
environments publish the library before this reaches users.