### PR TITLE
ARR-003 - core flows CF-002 and CF-003, registered and specced

### DIFF
--- a/docs/core-flows.md
+++ b/docs/core-flows.md
@@ -147,6 +147,72 @@ a sound reached a speaker. Playback is asserted in Chromium only — see
 and issue #43. It also does not prove persistence: this flow runs against the
 mock backend, which is empty again on the next page load.
 
+### CF-002 — A producer turns a loop into a song outline
+
+**Issue:** #61 · **Suite:** `e2e/flows/CF-002.spec.ts` · **Entrypoint:** the
+project dashboard
+
+**Preconditions:** signed in as a guest with no projects — where CF-001 ends.
+Building the loop in steps 2-5 depends on #223 (creating a sampler track) and
+#225 (loading a library sound onto a sampler); until both land, this flow cannot
+be walked by hand.
+
+1. Create a new project. It opens on the step editor with the starter kick,
+   four on the floor.
+2. Add a sampler track, load a closed hat onto it from the library, and put the
+   hat on every offbeat.
+3. Add a sampler track with a clap, on beats 2 and 4.
+4. Add a sampler track with a chord stab, on steps 1, 4, 7, 10, 13 and 16.
+5. Add a sampler track with a bass, following the kick.
+6. Play the loop — five parts, one bar, tight.
+7. Select the loop's bar range in the arrangement.
+8. Apply the structure template. The arrangement fills out: named, coloured
+   sections along the ruler, each carrying its own copy of all five tracks.
+9. Delete the hats and the claps from the "Intro", so the song opens on the
+   chord stab and the bass.
+10. Play from the top — the drums arrive at the section boundary.
+11. Undo twice.
+
+**Outcome:** a five-part loop became a multi-section song that opens quietly and
+lands its drums where the producer chose, and two undos put it back to the loop
+it started from.
+
+**Out of scope:** that any of it is *audible* — as in CF-001, a headless browser
+records no audio, so this proves the transport runs and the arrangement changed,
+not that a sound reached a speaker. It also does not prove that the source clips
+survive the outline untouched, which is asserted at the command layer; nor
+automation across the new sections (`ARR-004`); nor persistence, since this runs
+against the mock backend.
+
+Note that steps 1-6 exercise track management, the library browser, and the step
+editor before the flow reaches its own subject. That is deliberate — a loop-to-song
+outline stamped onto a single-track project demonstrates nothing — but it does
+mean a break in any of those surfaces will surface here as an `ARR-003` failure.
+
+### CF-003 — A producer names and rearranges the parts of their song
+
+**Issue:** #61 · **Suite:** `e2e/flows/CF-003.spec.ts` · **Entrypoint:** the
+project dashboard
+
+**Preconditions:** signed in as a guest with no projects.
+
+1. Create a new project and duplicate its placement further along the timeline,
+   so there are two distinct parts to label.
+2. Add a section over the first part and name it "Intro".
+3. Add a section over the second part, name it "Drop", and give it a different
+   colour.
+4. Move "Drop" ahead of "Intro".
+5. The two sections swap places on the ruler, and the placements inside each one
+   travel with it.
+6. Undo once.
+
+**Outcome:** the producer has labelled the parts of their song and reordered one,
+its clips moving with it, and a single undo puts the order back.
+
+**Out of scope:** the template-driven path, which is CF-002; section-aware
+automation (`ARR-004`); and whether sections survive a reload, which would belong
+to a flow in `e2e-emulator/flows/`.
+
 <!--
   New flows go here, in ascending ID order. Never renumber or reuse an ID: a
   retired flow keeps its number and gains a "**Retired:** why" line, because

--- a/docs/core-flows.md
+++ b/docs/core-flows.md
@@ -159,19 +159,20 @@ be walked by hand.
 
 1. Create a new project. It opens on the step editor with the starter kick,
    four on the floor.
-2. Add a sampler track, load a closed hat onto it from the library, and put the
-   hat on every offbeat.
-3. Add a sampler track with a clap, on beats 2 and 4.
-4. Add a sampler track with a chord stab, on steps 1, 4, 7, 10, 13 and 16.
-5. Add a sampler track with a bass, following the kick.
+2. Add a sampler track named "Hats", load a closed hat onto it from the library,
+   and put the hat on every offbeat.
+3. Add a sampler track named "Claps", with a clap on beats 2 and 4.
+4. Add a sampler track named "Chords", with a chord stab on steps 1, 4, 7, 10,
+   13 and 16.
+5. Add a sampler track named "Bass", following the kick.
 6. Play the loop — five parts, one bar, tight.
 7. Select the loop's bar range in the arrangement.
 8. Apply the structure template. The arrangement fills out: named, coloured
    sections along the ruler, each carrying its own copy of all five tracks.
-9. Delete the hats and the claps from the "Intro", so the song opens on the
-   chord stab and the bass.
+9. Select the hats and the claps in the "Intro" and delete them together, so the
+   song opens on the chord stab and the bass.
 10. Play from the top — the drums arrive at the section boundary.
-11. Undo twice.
+11. Undo twice: the drums come back, and then the outline collapses to the loop.
 
 **Outcome:** a five-part loop became a multi-section song that opens quietly and
 lands its drums where the producer chose, and two undos put it back to the loop

--- a/e2e/flows/CF-002.spec.ts
+++ b/e2e/flows/CF-002.spec.ts
@@ -1,0 +1,217 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { walkthrough } from "../support/walkthrough";
+
+/**
+ * `CF-002` — a producer turns a loop into a song outline.
+ *
+ * Read the flow in `docs/core-flows.md`; the numbered comments below are its
+ * steps, in its words. This is the acceptance contract for `ARR-003` (#61) and
+ * is frozen once it lands: a later PR that changes an assertion here has to say
+ * so in its body and justify it.
+ *
+ * `test.fixme` because none of it is built yet. Two things are worth knowing
+ * about what that means here:
+ *
+ *  - Steps 2-5 depend on work outside `ARR-003` — creating a sampler track
+ *    (#223) and loading a library sound onto one by dragging (#225). Neither
+ *    affordance exists, so the selectors this file uses for them are the shape
+ *    those issues are expected to deliver, not names read off a built UI.
+ *  - Steps 7-11 are `ARR-003`'s own surface: the loop-range selection, the
+ *    structure template, and section markers on the ruler.
+ *
+ * Where an existing surface already has an accessible name — the dashboard, the
+ * step grid, the transport, undo, the arrangement's DOM mirror of its selection
+ * — this file uses the real one. Everything else is a requirement being placed
+ * on the implementation, and is called out where it appears.
+ */
+
+// Grid steps are 1-indexed, matching the accessible names the step editor emits.
+
+/** The "and" of each beat: the offbeat a closed hat sits on. */
+const OFFBEATS = [3, 7, 11, 15];
+/** Beats 2 and 4 — the backbeat, not beat 1, which would just double the kick. */
+const BACKBEAT = [5, 13];
+/** Every third 16th: the rave stab. */
+const RAVE_STAB = [1, 4, 7, 10, 13, 16];
+/** Four on the floor, with the starter kick. */
+const WITH_THE_KICK = [1, 5, 9, 13];
+
+/**
+ * One track's step grid.
+ *
+ * Every step editor on screen is currently labelled "Step editor"
+ * (`src/editor/StepEditor.tsx`), which is unambiguous only while a project has
+ * one track. This flow puts five on screen, so each track's grid has to carry
+ * its own name — for assistive technology first, and for this spec second.
+ */
+const stepGrid = (page: Page, track: string): Locator =>
+	page.getByRole("region", { name: `${track} step editor` });
+
+/** Turn on each step of a pattern, asserting each one took. */
+async function program(grid: Locator, steps: readonly number[]): Promise<void> {
+	for (const step of steps) {
+		await grid
+			.getByRole("button", { name: `Notes, step ${step}, off` })
+			.click();
+		await expect(
+			grid.getByRole("button", { name: `Notes, step ${step}, on` }),
+		).toBeVisible();
+	}
+}
+
+/**
+ * Add a named sampler track, drag a library sound onto its instrument, and
+ * program its pattern.
+ *
+ * The two affordances this leans on are the ones #223 and #225 exist to
+ * deliver: choosing the instrument kind when creating a track, and dropping a
+ * library asset onto a sampler. Today "Add track" always mints a synth, and the
+ * library's insert path is never wired into the editor.
+ */
+async function addSamplerTrack(
+	page: Page,
+	part: { name: string; sound: string; steps: readonly number[] },
+): Promise<void> {
+	await page.getByRole("button", { name: "Add sampler track" }).click();
+	await page.getByRole("textbox", { name: "Track name" }).fill(part.name);
+	await page.getByRole("textbox", { name: "Track name" }).press("Enter");
+
+	await page.getByRole("button", { name: "Library" }).click();
+	await page.getByRole("searchbox", { name: "Search sounds" }).fill(part.sound);
+	const asset = page.getByRole("listitem").filter({ hasText: part.sound });
+	await asset
+		.first()
+		.dragTo(page.getByRole("region", { name: `${part.name} instrument` }));
+
+	// The sampler names what it is holding, so the drop is visible rather than
+	// inferred from a later sound. #225 replaces the swap list with this label.
+	await expect(
+		page.getByRole("region", { name: `${part.name} instrument` }),
+	).toContainText(part.sound);
+	await page.getByRole("button", { name: "Library" }).click();
+
+	await program(stepGrid(page, part.name), part.steps);
+}
+
+/** The arrangement's DOM mirror of what is selected (`ArrangementView.tsx`). */
+const selectedPlacements = (page: Page): Locator =>
+	page.getByTestId("placement-selection").locator("li");
+
+test.describe("CF-002", () => {
+	test.fixme(
+		"a producer turns a loop into a song outline",
+		async ({ page }) => {
+			const step = walkthrough(page, {
+				id: "CF-002",
+				title: "A producer turns a loop into a song outline",
+			});
+
+			// 1. Create a new project. It opens on the step editor with the starter
+			//    kick, four on the floor.
+			await page.goto("/dashboard");
+			await page.getByRole("button", { name: "New Project" }).click();
+			await expect(page).toHaveURL(/\/projects\/prj_/);
+			await expect(
+				page.getByRole("button", { name: "Notes, step 1, on" }),
+			).toBeVisible();
+			await step("The new project opens on the starter kick");
+
+			// 2. Add a sampler track named "Hats", load a closed hat onto it from
+			//    the library, and put the hat on every offbeat.
+			await addSamplerTrack(page, {
+				name: "Hats",
+				sound: "closed hat",
+				steps: OFFBEATS,
+			});
+			await step("Add a hat track, on every offbeat");
+
+			// 3. Add a sampler track named "Claps", with a clap on beats 2 and 4.
+			await addSamplerTrack(page, {
+				name: "Claps",
+				sound: "clap",
+				steps: BACKBEAT,
+			});
+			await step("Add a clap track, on beats 2 and 4");
+
+			// 4. Add a sampler track named "Chords", with a chord stab on steps 1,
+			//    4, 7, 10, 13 and 16.
+			await addSamplerTrack(page, {
+				name: "Chords",
+				sound: "chord",
+				steps: RAVE_STAB,
+			});
+			await step("Add a chord stab");
+
+			// 5. Add a sampler track named "Bass", following the kick.
+			await addSamplerTrack(page, {
+				name: "Bass",
+				sound: "bass",
+				steps: WITH_THE_KICK,
+			});
+			await step("Add a bass, following the kick");
+
+			// 6. Play the loop — five parts, one bar, tight.
+			//
+			// As in CF-001, this asserts the transport is running, not that a sound
+			// reached a speaker: a headless browser records no audio.
+			await page.getByRole("button", { name: "Start playback" }).click();
+			await expect(
+				page.getByRole("button", { name: "Stop playback" }),
+			).toBeVisible();
+			await step("Play the loop — five parts, one bar");
+			await page.getByRole("button", { name: "Stop playback" }).click();
+
+			// 7. Select the loop's bar range in the arrangement.
+			await page.getByRole("button", { name: "Select Hats" }).click();
+			await expect(
+				page.getByTestId("arrangement-selection-live"),
+			).toContainText("bars 1 to 1");
+			await step("Select the loop's bar range in the arrangement");
+
+			// 8. Apply the structure template. The arrangement fills out: named,
+			//    coloured sections along the ruler, each carrying its own copy of
+			//    all five tracks.
+			//
+			// The template's full section list is ARR-003's to choose (#61); what
+			// the flow pins is that applying it produces several named sections,
+			// one of them the "Intro" step 9 works on, and that the loop was copied
+			// into them rather than moved out of bar 1.
+			await page.getByRole("button", { name: "Create song outline" }).click();
+			const sections = page.getByRole("list", { name: "Sections" });
+			await expect(sections.getByRole("listitem")).not.toHaveCount(0);
+			await expect(sections.getByRole("listitem").first()).toContainText(
+				"Intro",
+			);
+			await step("Apply the structure template — the arrangement fills out");
+
+			// 9. Select the hats and the claps in the "Intro" and delete them
+			//    together, so the song opens on the chord stab and the bass.
+			//
+			// One selection and one delete, so this is one undoable transaction —
+			// which is what makes step 11's two undos land back on the loop.
+			await page.getByRole("button", { name: "Select Hats in Intro" }).click();
+			await page
+				.getByRole("button", { name: "Select Claps in Intro" })
+				.click({ modifiers: ["Shift"] });
+			await expect(selectedPlacements(page)).toHaveCount(2);
+			await page.keyboard.press("Delete");
+			await expect(selectedPlacements(page)).toHaveCount(0);
+			await step("Delete the hats and claps from the Intro");
+
+			// 10. Play from the top — the drums arrive at the section boundary.
+			await page.getByRole("button", { name: "Start playback" }).click();
+			await expect(
+				page.getByRole("button", { name: "Stop playback" }),
+			).toBeVisible();
+			await step("Play from the top — the song opens on chords and bass");
+			await page.getByRole("button", { name: "Stop playback" }).click();
+
+			// 11. Undo twice: the drums come back, and then the outline collapses to
+			//     the loop.
+			await page.getByRole("button", { name: /^Undo/ }).click();
+			await page.getByRole("button", { name: /^Undo/ }).click();
+			await expect(sections.getByRole("listitem")).toHaveCount(0);
+			await step("Undo twice — back to the loop it started from");
+		},
+	);
+});

--- a/e2e/flows/CF-003.spec.ts
+++ b/e2e/flows/CF-003.spec.ts
@@ -1,0 +1,115 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { walkthrough } from "../support/walkthrough";
+
+/**
+ * `CF-003` — a producer names and rearranges the parts of their song.
+ *
+ * Read the flow in `docs/core-flows.md`; the numbered comments below are its
+ * steps, in its words. This is the acceptance contract for the section-editing
+ * half of `ARR-003` (#61) — CF-002 covers the template-driven half — and is
+ * frozen once it lands.
+ *
+ * `test.fixme` because section markers do not exist yet. Unlike CF-002, this
+ * flow depends on nothing outside `ARR-003`: step 1 uses the placement
+ * duplication `ARR-002` already shipped, so every selector before the first
+ * section is added is a real one read off the built UI.
+ *
+ * What it proves that CF-002 does not: that a section is a handle on a range of
+ * the timeline, so moving one carries the music inside it. That is the
+ * `ARR-02` acceptance criterion with a visible consequence — a section reorder
+ * that left its placements behind would still look correct on the ruler.
+ */
+
+/** The arrangement's DOM mirror of what is selected (`ArrangementView.tsx`). */
+const selectedPlacements = (page: Page): Locator =>
+	page.getByTestId("placement-selection").locator("li");
+
+/**
+ * The sections on the ruler, in order. Their order in the DOM is the order they
+ * sit on the timeline, which is what step 5 reads.
+ */
+const sections = (page: Page): Locator =>
+	page.getByRole("list", { name: "Sections" }).getByRole("listitem");
+
+test.describe("CF-003", () => {
+	test.fixme(
+		"a producer names and rearranges the parts of their song",
+		async ({ page }) => {
+			const step = walkthrough(page, {
+				id: "CF-003",
+				title: "A producer names and rearranges the parts of their song",
+			});
+
+			// 1. Create a new project and duplicate its placement further along the
+			//    timeline, so there are two distinct parts to label.
+			await page.goto("/dashboard");
+			await page.getByRole("button", { name: "New Project" }).click();
+			await expect(page).toHaveURL(/\/projects\/prj_/);
+			await page.getByTestId("arrangement-view-ready").waitFor();
+
+			await page
+				.getByRole("button", { name: /^Select / })
+				.first()
+				.click();
+			await expect(selectedPlacements(page)).toHaveCount(1);
+			await page
+				.getByRole("button", { name: /^Duplicate as a linked copy/ })
+				.click();
+			await expect(selectedPlacements(page)).toHaveCount(1);
+			await step("A project with two parts on the timeline");
+
+			// 2. Add a section over the first part and name it "Intro".
+			await page.getByRole("button", { name: "Add section" }).click();
+			await page.getByRole("textbox", { name: "Section name" }).fill("Intro");
+			await page.getByRole("textbox", { name: "Section name" }).press("Enter");
+			await expect(sections(page)).toHaveCount(1);
+			await expect(sections(page).first()).toContainText("Intro");
+			await step('Add a section over the first part and name it "Intro"');
+
+			// 3. Add a section over the second part, name it "Drop", and give it a
+			//    different colour.
+			await page.getByRole("button", { name: "Add section" }).click();
+			await page.getByRole("textbox", { name: "Section name" }).fill("Drop");
+			await page.getByRole("textbox", { name: "Section name" }).press("Enter");
+			await page.getByRole("button", { name: "Section colour" }).click();
+			await page.getByRole("option", { name: "Orange" }).click();
+			await expect(sections(page)).toHaveCount(2);
+			await step('Add a "Drop" over the second part, in a different colour');
+
+			// 4. Move "Drop" ahead of "Intro".
+			await page
+				.getByRole("listitem")
+				.filter({ hasText: "Drop" })
+				.getByRole("button", { name: "Move section earlier" })
+				.click();
+			await step('Move "Drop" ahead of "Intro"');
+
+			// 5. The two sections swap places on the ruler, and the placements
+			//    inside each one travel with it.
+			//
+			// Both halves matter. The ruler order is the visible half; the
+			// placement that moved with the section is the half a reorder could
+			// silently get wrong, so it is asserted through the arrangement's own
+			// selection mirror rather than by eye.
+			await expect(sections(page).first()).toContainText("Drop");
+			await expect(sections(page).nth(1)).toContainText("Intro");
+			await page
+				.getByRole("button", { name: "Select the placements in Drop" })
+				.click();
+			await expect(selectedPlacements(page)).toHaveCount(1);
+			await expect(
+				page.getByTestId("arrangement-selection-live"),
+			).toContainText("bars 1 to 1");
+			await step("The sections swap, and their clips travel with them");
+
+			// 6. Undo once.
+			//
+			// One reorder is one transaction, so a single undo restores both the
+			// section order and the placements that moved with it.
+			await page.getByRole("button", { name: /^Undo/ }).click();
+			await expect(sections(page).first()).toContainText("Intro");
+			await expect(sections(page).nth(1)).toContainText("Drop");
+			await step("Undo once — the order is back");
+		},
+	);
+});


### PR DESCRIPTION
## What & why

Registers the two core flows that are the acceptance contract for `ARR-003` — song sections and the loop-to-song workflow — in `docs/core-flows.md`, and lands each as a `test.fixme` Playwright spec in the same change.

- **CF-002 — A producer turns a loop into a song outline.** Builds a five-part loop (kick, offbeat hats, backbeat claps, chord stab, bass), applies the structure template, then deletes the hats and claps from the Intro so the drums arrive at a boundary.
- **CF-003 — A producer names and rearranges the parts of their song.** Manual section editing: add, name, colour, reorder, with the placements travelling with their section.

CF-002 spends its first six steps building material before it reaches its own subject. That is deliberate: the loop-to-song outline makes no musical decisions — it stamps a labelled canvas and copies the loop into every section — so the feature only demonstrates anything as *stamp then subtract*, and subtraction is invisible on a single-track project. The trade-off is noted in the register: a break in track management, the library browser, or the step editor will surface here as an `ARR-003` failure.

PRD: ARR-02, ARR-03.

Refs #61

## Core flows

**Specced.** CF-002 and CF-003 are `test.fixme` on purpose — the implementation does not exist, and a fixme test is skipped rather than red, so this slice is green on its own commit. The markers come off in the PR that closes #61, in the same diff that makes them pass.

Both specs use real accessible names where the surface already exists (the dashboard, the step grid, the transport, undo, the arrangement's `placement-selection` and `arrangement-selection-live` mirrors) and proposed ones where it does not. Every proposed name is flagged at the point it appears, so a reviewer can tell a requirement being placed on the implementation from a name read off built UI.

Two register corrections that writing the specs surfaced, both in this diff:

- Step 9 deletes the hats and claps as **one** selection. Two separate deletes are two transactions, so step 11's "undo twice" would have restored the drums without ever reaching the outline — the flow would not have returned to the loop it claims to.
- The added tracks are **named**, so five step grids can be told apart. That exposes a requirement on #223: every grid is currently labelled "Step editor" (`src/editor/StepEditor.tsx`), which is unambiguous only while a project has one track — an accessibility problem before it is a testing one.

**CF-002 is not walkable until #223 and #225 land**, independent of `ARR-003`. Found while writing it, filed against Alpha Milestone 1:

- #223 — Add track always creates a synth; no way to create a sampler or drum machine track.
- #224 — No way to change a track's instrument type (`instrument.set` exists in the command layer; no component dispatches it).
- #225 — A library sound cannot be loaded onto a sampler (`onInsert` is threaded through `LibraryBrowser` but never supplied by `EditorView`; the sampler's swap list only offers assets the project already carries).

Also filed #226, unrelated to these flows: a missing `public/samples` build reports as "The library data could not be read", because the SPA catch-all rewrite turns the absent file into an HTTP 200 HTML body that fails JSON parsing and classifies as `corrupt`.

## Walkthrough

No UI change — this PR adds a register entry and two skipped specs.

## Evidence

```
$ bun run check:ci
$ tsc --noEmit && biome check
Checked 483 files in 546ms. No fixes applied.

$ bun run verify:core-flows
  note: CF-002 is still test.fixme in e2e/flows/CF-002.spec.ts — in flight, or abandoned mid-stack.
  note: CF-003 is still test.fixme in e2e/flows/CF-003.spec.ts — in flight, or abandoned mid-stack.
check-core-flows — 3 flow(s), each with exactly one spec.

$ bun run test:browser:chromium
  2 skipped
  18 passed (36.4s)
```

The two skips are CF-002 and CF-003; CF-001 and the rest of the suite pass unchanged. Chromium-only, per `CLAUDE.md` — this environment cannot reach `cdn.playwright.dev`, so Firefox and WebKit are gated by CI on push. `bun run test` was not run: the diff adds no product code and no unit-tested module.

## Acceptance criteria met

None — `ARR-003`'s criteria are satisfied by the implementation stack, not by this PR. This lands the contract those criteria will be measured against, and #61 links both flows.

## Note for whoever runs `/implement-feature #61`

Two things in the approved pipeline assume the specs do **not** exist yet, so they are worth knowing before triggering it. Reporting rather than changing, per `CLAUDE.md`:

- **Preflight check 9** is "no open PR already references or closes it". This PR carries `Refs #61`, so the skill will refuse to start until it is merged or closed.
- **Stage 2's `Spec` phase** always writes the flow specs and opens "PR 1 of N — core flow specs". With the specs already on `main`, that phase has nothing to write, and the flow-author agent rewriting a frozen contract is exactly what the freeze rule exists to prevent.