### PR TITLE
Have the feature workflow verify flow specs rather than write them

### DIFF
--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -65,11 +65,12 @@ one item at a time.
 | 3 | It links **at least one** core flow ID matching `CF-\d{3}` | search the body |
 | 4 | **Every** linked flow is registered in `docs/core-flows.md` on the **current `main`** | `git fetch origin main` first, then read the file at `origin/main` — not your working copy, which may be stale or carry local edits |
 | 5 | Each registered flow entry is **complete**, not a stub: it names an entrypoint, has numbered steps, and states an outcome | read the entries, per the anatomy in `docs/core-flows.md` |
+| 5a | Each linked flow has a **spec file on `main`** — `e2e/flows/<ID>.spec.ts` or `e2e-emulator/flows/<ID>.spec.ts` | the workflow does not write specs; it refuses to start without them, so this is where a missing one surfaces early |
 | 6 | The issue has acceptance criteria (checkboxes) | search the body |
 | 7 | Every issue in its `blocked_by` graph is **closed** | `gh api repos/afternoon/solid-groove/issues/<n>/dependencies/blocked_by --paginate`, then each blocker's state |
 | 8 | It is **not** labelled `human-input-required` | that label marks a decision only a human resolves |
 | 9 | No open PR already references or closes it | `gh pr list --search "<n>" --state open` |
-| 10 | `bun run verify:core-flows` passes at `origin/main` | a register already out of sync with its specs will only get worse |
+| 10 | `bun run verify:core-flows` passes at `origin/main` | a register already out of sync with its specs will only get worse — and since the workflow no longer authors specs, this check is what guarantees the contract exists at all |
 
 Two soft signals worth reporting but not blocking on: the issue carrying the
 `blocked` label with an open `DEC-*` blocker (the workflow handles it — the
@@ -93,18 +94,24 @@ Invoke the approved workflow, unmodified:
 - **Workflow name:** `solid-groove-feature`
 - **Args:** `{ "issue": <n> }`
 
-That is the whole of this stage. The workflow writes the flow specs, has them
-reviewed before any implementation exists, implements, reviews for up to two
-rounds, opens the stack, captures the walkthrough and requests the preview
-deploy. It runs in the background and takes a long time — a real feature is
+That is the whole of this stage. The workflow verifies that every linked flow is
+registered and specced on `main`, implements against that frozen contract,
+reviews for up to two rounds, opens the stack, captures the walkthrough and
+requests the preview deploy.
+
+It does **not** write the flow specs. The product owner lands the flow entry and
+its `test.fixme` spec together in their own reviewed PR before this runs, which
+is why preflight checks 4, 5, 5a and 10 are the gate they are. If a linked flow
+has no spec on `main`, the workflow returns `blocked-on-missing-contract` without
+building anything. It runs in the background and takes a long time — a real feature is
 tens of minutes, not seconds.
 
 While it runs: **do not** start your own agents to "help", do not begin
 implementing anything, and do not poll it in a loop. Wait for the completion
 notification.
 
-If the workflow returns a `status` of `blocked-on-spec` or `blocked-on-review`,
-it stopped on purpose. Skip Stage 3, report the blocking findings it returned
+If the workflow returns a `status` of `blocked-on-missing-contract` or
+`blocked-on-review`, it stopped on purpose. Skip Stage 3, report the blocking findings it returned
 verbatim, name the branch it left open, and stop. Do not implement the fixes
 yourself and do not re-run the workflow hoping for a different outcome.
 
@@ -118,12 +125,14 @@ self-report is a claim.
 
 ### The stack
 
-1. **Ordering and bases.** PR 1 (the flow specs) has base `main`. Every later
-   PR's base is the **previous PR's branch**, not `main`. Confirm with
-   `gh pr view <n> --json baseRefName,headRefName` for each.
+1. **Ordering and bases.** PR 1 is the first implementation slice and has base
+   `main` — the flow specs are not part of this stack, having merged separately
+   before the run. Every later PR's base is the **previous PR's branch**, not
+   `main`. Confirm with `gh pr view <n> --json baseRefName,headRefName` for each.
 2. **Issue references.** Every PR body says `Refs #<n>` **except the last**,
    which says `Closes #<n>`. Exactly one PR closes the issue.
-3. **Stack position.** Each body names its place ("2 of 4, builds on #NNN").
+3. **Stack position.** Each title ends with its position as `(i/n)` — `(1/3)`,
+   `(2/3)`, `(3/3)` — and each body names its place ("2/3, builds on #NNN").
 4. **Size.** Each PR is ≤400 changed lines, excluding generated files, lockfiles
    and vendored assets. `gh pr view <n> --json additions,deletions`. Report any
    PR over the ceiling — that is a re-slice, and the human's call.
@@ -140,11 +149,12 @@ self-report is a claim.
    report it loudly and do not paper over it.
 7. **The flows are live.** On the top branch, `bun run verify:core-flows` passes
    and reports **no** flow still at `test.fixme` for the issue's flow IDs.
-8. **The specs were not weakened.**
+8. **The specs were not weakened, or added to.**
    `git diff origin/main..<top-branch> -- e2e/flows e2e-emulator/flows` shows
    only removed `test.fixme` markers, plus any mechanical change the PR body
    explicitly called out and justified. A changed assertion that the body does
-   not mention is a failure.
+   not mention is a failure — and so is a **new** flow spec file, since the
+   contract is written before the run, never during it.
 
 ### The walkthrough
 

--- a/.claude/workflows/solid-groove-feature.js
+++ b/.claude/workflows/solid-groove-feature.js
@@ -1,12 +1,12 @@
 export const meta = {
   name: 'solid-groove-feature',
   description:
-    'Implement one Solid Groove issue core-flow first: spec the flows, review the spec, implement, review, land the stack, capture the walkthrough',
+    'Implement one Solid Groove issue against core flows already specced on main: verify the contract, implement, review, land the stack, capture the walkthrough',
   whenToUse:
-    'Run to implement ONE GitHub issue in afternoon/solid-groove that links core flow IDs (CF-001, ...). Pass the issue number: { issue: 123 } (or just 123). The pipeline writes each linked flow as a test.fixme Playwright spec and lands it as the first PR in the stack, has that spec adversarially reviewed BEFORE any implementation exists, implements the feature on top of it, reviews and fixes for up to two rounds, opens the rest of the stack, then removes the fixme markers, captures the screenshot walkthrough from the now-passing flows and labels the top PR deploy-preview. Use solid-groove-phase-1 instead to drain a whole milestone unattended.',
+    'Run to implement ONE GitHub issue in afternoon/solid-groove whose core flows (CF-001, ...) are already registered in docs/core-flows.md AND written as test.fixme Playwright specs on main. Pass the issue number: { issue: 123 } (or just 123). The pipeline verifies that contract exists, implements the feature against it, reviews and fixes for up to two rounds, opens the stack, then removes the fixme markers, captures the screenshot walkthrough from the now-passing flows and labels the top PR deploy-preview. It never writes or edits a flow spec. Use solid-groove-phase-1 instead to drain a whole milestone unattended.',
   phases: [
-    { title: 'Spec', detail: 'write each linked core flow as a test.fixme spec, and review it before anything is built' },
-    { title: 'Implement', detail: 'build the feature on top of the frozen spec' },
+    { title: 'Contract', detail: 'read the issue and verify every linked flow is registered and specced on main' },
+    { title: 'Implement', detail: 'build the feature against the frozen spec' },
     { title: 'Review', detail: 'adversarial Opus review, up to two rounds with fixes' },
     { title: 'Land', detail: 'open the stack of ≤400-line PRs' },
     { title: 'Walkthrough', detail: 'capture the screenshots from the passing flows and request a preview deploy' },
@@ -14,25 +14,33 @@ export const meta = {
 }
 
 // The ordering here is the whole point, so it is worth stating plainly: the
-// acceptance contract is written, reviewed and merged BEFORE the implementation
-// exists. An agent that writes the test and the code in one pass bends the test
-// toward the code, and nobody can tell afterwards. Splitting them across agents
-// and putting a review between them is what makes the contract mean something.
+// acceptance contract is written, reviewed and merged BEFORE this workflow runs.
+// An agent that writes the test and the code in one pass bends the test toward
+// the code, and nobody can tell afterwards. Keeping the contract entirely
+// outside this pipeline is what makes it mean something.
 //
-// The specs land as `test.fixme`. That is not a compromise — this repo requires
-// every slice to be green on its own commit so the front of a stack can merge
-// without the back (CLAUDE.md, "Landing work"), and a deliberately red PR 1 would
-// either block the stack or turn `main` red for every other parallel task. A
-// fixme spec is skipped, so PR 1 is honestly green, and the marker is the thing
-// the closing PR removes. The red->green evidence lives in the run log, which is
-// where it was always more useful than in a merge.
+// That is a change from the original design, where this workflow wrote the specs
+// itself as PR 1 of the stack. The product owner now writes the flow in
+// `docs/core-flows.md` and its `test.fixme` spec together, in one reviewed PR,
+// before triggering this. So the contract arrives here already frozen, and this
+// workflow's only obligation to it is to *check that it exists* and refuse to
+// start if it does not. It never authors a spec, and the implementer it invokes
+// is told the specs are not its to edit.
+//
+// The specs are `test.fixme` when they arrive. That is not a compromise — this
+// repo requires every slice to be green on its own commit so the front of a
+// stack can merge without the back (CLAUDE.md, "Landing work"), and a
+// deliberately red PR would either block the stack or turn `main` red for every
+// other parallel task. A fixme spec is skipped, so the contract PR is honestly
+// green, and the marker is the thing the closing PR removes. The red->green
+// evidence lives in the run log, which is where it was always more useful than
+// in a merge.
 const BASE_BRANCH = 'main'
 const MAX_REVIEW_ROUNDS = 2
 
 // Agents read their own definition from the repo: the agent registry is read once
 // at session start, so `agentType` cannot resolve a definition added or edited in
 // the same session, and these are edited often.
-const FLOW_AUTHOR = '.claude/agents/solid-groove-flow-author.md'
 const IMPLEMENTER = '.claude/agents/solid-groove-implementer.md'
 const REVIEWER = '.claude/agents/solid-groove-reviewer.md'
 const brief = (path) => `Read \`${path}\` and follow it as your operating instructions for this task.\n\n`
@@ -64,7 +72,7 @@ Your analytics obligation is not deferred: emit your task's PRD OPS-02 events th
 
 const ISSUE_SCHEMA = {
   type: 'object',
-  required: ['issue', 'taskId', 'title', 'flows', 'changesUi'],
+  required: ['issue', 'taskId', 'title', 'flows', 'changesUi', 'flowSpecs'],
   properties: {
     issue: { type: 'number' },
     taskId: { type: 'string', description: 'Task id parsed from the title, e.g. LOOP-004' },
@@ -74,25 +82,24 @@ const ISSUE_SCHEMA = {
       description: 'Core flow IDs the issue links, e.g. ["CF-004","CF-005"]. Empty if the issue links none.',
       items: { type: 'string' },
     },
+    flowSpecs: {
+      type: 'array',
+      description: 'One entry per linked flow, reporting the contract that already exists on main',
+      items: {
+        type: 'object',
+        required: ['flow', 'registered', 'spec', 'fixme'],
+        properties: {
+          flow: { type: 'string' },
+          registered: { type: 'boolean', description: 'True if docs/core-flows.md has a complete entry for it' },
+          spec: { type: 'string', description: 'Path of its spec file, or "" if there is none' },
+          fixme: { type: 'boolean', description: 'True if that spec is still marked test.fixme' },
+        },
+      },
+    },
     changesUi: { type: 'boolean', description: 'True if the task changes anything a user sees' },
     decisionBlockers: {
       type: 'array',
       description: 'Open DEC-* decision issues blocking this task, by DEC id',
-      items: { type: 'string' },
-    },
-  },
-}
-
-const SPEC_SCHEMA = {
-  type: 'object',
-  required: ['branch', 'specs', 'summary'],
-  properties: {
-    branch: { type: 'string' },
-    specs: { type: 'array', description: 'Spec file paths written', items: { type: 'string' } },
-    summary: { type: 'string' },
-    unspecified: {
-      type: 'array',
-      description: 'Flows that could NOT be specced, with the reason. Empty if all were.',
       items: { type: 'string' },
     },
   },
@@ -191,10 +198,14 @@ Read the issue with \`gh issue view ${issue} --json number,title,body,labels\` a
 
 - \`taskId\` and \`title\`, parsed from the title, which is formatted \`TASK-ID - Title\` (e.g. "LOOP-004 - Synth and one-shot sampler").
 - \`flows\`: every **core flow ID** the body references, matching \`CF-\` followed by three digits. These are the user journeys the feature must deliver; they are described in \`docs/core-flows.md\`. Return them in ascending order, de-duplicated. Return an empty array if the issue links none — do not invent one, and do not infer one from the acceptance criteria.
+- \`flowSpecs\`: one entry per flow in \`flows\`, describing the acceptance contract **as it already exists on \`main\`**. This workflow does not write specs; it refuses to start without them, so this is the check that decides. Fetch \`origin/${BASE_BRANCH}\` first and read it there, not from whatever your worktree happens to start at:
+  - \`registered\`: true if \`docs/core-flows.md\` at \`origin/${BASE_BRANCH}\` has an entry for that ID which names an entrypoint, has numbered steps and states an outcome. A heading with nothing under it is not registered.
+  - \`spec\`: the path of its spec file (\`e2e/flows/<ID>.spec.ts\` or \`e2e-emulator/flows/<ID>.spec.ts\`), or \`""\` if no such file exists.
+  - \`fixme\`: true if that spec is still marked \`test.fixme\`. A spec that is already live is not an error — it means the flow passes today — so report it truthfully rather than assuming.
 - \`changesUi\`: true if delivering this task changes anything a user sees — a new or changed component, layout, styling, copy or interaction. Judge from the issue body and its linked PRD requirements.
 - \`decisionBlockers\`: any open \`DEC-*\` decision issue in this issue's native \`blocked_by\` graph (\`gh api repos/afternoon/solid-groove/issues/${issue}/dependencies/blocked_by\`), by DEC id.
 
-Read every value from GitHub. Do not guess any of it.`
+Read every value from GitHub and from the repository at \`origin/${BASE_BRANCH}\`. Do not guess any of it, and do not create or edit anything to make a check pass.`
 
 const decisionBlocked = (decisions) => `
 
@@ -206,70 +217,19 @@ This task depends on ${decisions.map((d) => `\`${d}\``).join(' and ')}, which ${
 
 Implement everything that does not depend on the decision, and design the boundary so the decision drops in as configuration rather than a rewrite. List every acceptance checkbox you could not close in \`unmet\`, naming the decision, and comment the same on the issue.`
 
-const specPrompt = (t) => `${brief(FLOW_AUTHOR)}Write the core-flow specs for task ${t.taskId} - ${t.title}, tracked as issue #${t.issue}.
-
-The issue links ${t.flows.length === 1 ? 'this core flow' : 'these core flows'}: ${t.flows.join(', ')}. Each is described in plain English in \`docs/core-flows.md\`. Turn each into one Playwright spec, marked \`test.fixme\`, that reproduces it exactly. **Do not implement the feature.** ${gh}
-
-${WORKTREE}Branch from \`origin/${BASE_BRANCH}\`, name your branch \`claude/${t.taskId.toLowerCase()}-flows\`, and push it with \`git push -u origin claude/${t.taskId.toLowerCase()}-flows\`. Do not open a pull request — a reviewer runs before the PR is opened.
-
-${attribution}
-
-Report the branch, the spec files you wrote, and any flow you could not spec with the reason.`
-
-const specReviewPrompt = (t, spec, round) => `${brief(REVIEWER)}Review the **flow-spec branch** \`${spec.branch}\` for task ${t.taskId} - ${t.title} (issue #${t.issue}).
-
-Follow the "Reviewing a flow-spec branch" section of your instructions — this is the first PR in the stack, the specs are \`test.fixme\`, and no implementation exists yet. What you approve here becomes the frozen acceptance contract for everything that follows, so a vague spec approved now cannot be recovered later.${
-  round > 1 ? `\n\nThis is review round ${round}; a previous round returned blocking findings the author has since addressed. Verify the fixes rather than assuming them.` : ''
-}
-
-Flows under review: ${t.flows.join(', ')} — read each one in \`docs/core-flows.md\` and compare it step by step against the spec. ${gh}
-
-${WORKTREE}Fetch and check out \`${spec.branch}\`, then read its actual diff against \`origin/${BASE_BRANCH}\`. Run \`bun run verify:core-flows\` and \`bun run test:browser:chromium\` yourself.
-
-The author reported:
-${spec.summary}
-
-Flows it reports it could NOT spec: ${spec.unspecified?.length ? spec.unspecified.join('; ') : 'none'}
-
-Treat all of that as claims to verify, not findings to accept.`
-
-const specFixPrompt = (t, spec, review) => `${brief(FLOW_AUTHOR)}Address blocking review findings on the flow-spec branch \`${spec.branch}\` for task ${t.taskId} (issue #${t.issue}).
-
-${WORKTREE}Check the branch out from \`origin/${spec.branch}\`, fix every finding below, re-run \`bun run verify:core-flows\` and \`bun run test:browser:chromium\`, and push to the same branch. Do not widen scope, and do not start implementing the feature.
-
-${review.blocking
-  .map((b, i) => `${i + 1}. ${b.file}${b.line ? `:${b.line}` : ''} — ${b.issue}\n   Failure: ${b.failure}\n   Suggested resolution: ${b.resolution}`)
-  .join('\n\n')}
-
-Report the same structured result as the original spec run, describing the branch as it now stands.`
-
-const specPrPrompt = (t, spec) => `Open the **first PR in the stack** for task ${t.taskId} - ${t.title}: the core-flow specs on branch \`${spec.branch}\`. ${gh}
-
-\`gh pr create --base ${BASE_BRANCH} --head ${spec.branch}\`. Title it "${t.taskId} - core flow specs (1 of N)". Mirror \`.github/pull_request_template.md\`.
-
-The body must say, in its own words:
-- Which flows this specs (${t.flows.join(', ')}), linking \`docs/core-flows.md\`.
-- That the specs are \`test.fixme\` **on purpose**: the implementation does not exist yet, and this repo requires every slice to be green on its own commit, so a deliberately red PR would block the stack or redden \`main\`. The marker is removed by the PR that closes the issue, in the same diff that makes the flows pass.
-- That these specs are the frozen acceptance contract for the rest of the stack, and were reviewed on their own before any implementation began.
-- **Walkthrough:** "No UI change — this PR adds skipped test specs only."
-
-Use \`Refs #${t.issue}\`, never \`Closes\`. ${attribution}
-
-Return the PR you opened.`
-
-const implPrompt = (t, spec) => `${brief(IMPLEMENTER)}Implement task ${t.taskId} - ${t.title}, tracked as issue #${t.issue}.
+const implPrompt = (t) => `${brief(IMPLEMENTER)}Implement task ${t.taskId} - ${t.title}, tracked as issue #${t.issue}.
 
 Read the issue body — it is the specification — with \`gh issue view ${t.issue}\`, and every PRD requirement it links. ${gh}${NO_HOSTED_ENV}${
   t.decisionBlockers?.length ? decisionBlocked(t.decisionBlockers) : ''
 }
 
-## Your base is the flow-spec branch
+## The acceptance contract already exists
 
-${t.flows.length ? `The core flows ${t.flows.join(', ')} have already been written as Playwright specs on branch \`${spec.branch}\`, reviewed, and merged as PR 1 of your stack. **Branch your first slice off \`origin/${spec.branch}\`, not off \`${BASE_BRANCH}\`**, so your stack builds on the contract.
+${t.flows.length ? `The core flows ${t.flows.join(', ')} are already written as Playwright specs on \`${BASE_BRANCH}\` — ${t.flowSpecs.map((f) => `\`${f.spec}\``).join(', ')} — landed by the product owner in their own reviewed PR before this run started. Branch your first slice off \`origin/${BASE_BRANCH}\`.
 
-Those specs are frozen. Read them and \`docs/core-flows.md\` before writing code — they are what "done" means here. Do not edit their assertions to fit what you build; if one is genuinely wrong, say so on the issue and in your PR body and let the reviewer rule on it.
+Those specs are **frozen, and they are not yours to write**. Read them and \`docs/core-flows.md\` before writing code — together they are what "done" means here. Do not edit an assertion to fit what you build, and do not add a flow spec of your own: if a spec is genuinely wrong, impossible, or contradicted by the PRD, say so on the issue and in your PR body and let the reviewer rule on it. A spec bent toward an implementation proves nothing, which is the entire reason it was written and merged before you started.
 
-The slice that completes the feature removes \`test.fixme\` from every one of those specs, in the same diff that makes them pass, and captures the walkthrough. \`bun run verify:core-flows\` reports any flow still parked.` : `This issue links no core flows, so branch your first slice off \`origin/${BASE_BRANCH}\`.`}
+The slice that completes the feature removes \`test.fixme\` from every one of those specs, in the same diff that makes them pass, and captures the walkthrough. That marker removal is the **only** change to a spec file your stack may contain. \`bun run verify:core-flows\` reports any flow still parked.` : `This issue links no core flows, so there is no flow contract to build against. Branch your first slice off \`origin/${BASE_BRANCH}\`.`}
 
 ${WORKTREE}Name your branches \`claude/${t.taskId.toLowerCase()}\`, \`claude/${t.taskId.toLowerCase()}-2\`, and so on, one per ≤400-line slice, each branched off the previous. Push every branch. Do not open pull requests — a reviewer runs before they are opened.
 
@@ -281,7 +241,7 @@ const reviewPrompt = (t, impl, round) => `${brief(REVIEWER)}Review the implement
   round > 1 ? `\n\nThis is review round ${round}; a previous round returned blocking findings the implementer has since addressed. Verify the fixes rather than assuming them.` : ''
 }
 
-${t.flows.length ? `Pay particular attention to check **2a, the acceptance contract**. The flows ${t.flows.join(', ')} were specced and reviewed before this implementation existed, and merged as the base of this stack. Verify with \`git diff\` that \`docs/core-flows.md\`, \`docs/prd.md\` and the flow specs under \`e2e/flows\`/\`e2e-emulator/flows\` carry no changes beyond the removal of \`test.fixme\` markers and any mechanical change the PR body called out. A spec bent toward the implementation is the most expensive thing you can miss here. Then run the flows and confirm they pass.\n\n` : ''}The task's live record is issue #${t.issue}. Read it with \`gh issue view ${t.issue} --comments\` (${gh.toLowerCase()}) and treat every ticked acceptance checkbox as a claim to verify against the diff. A box ticked without the code to support it is a blocking finding. Do not tick, untick or close anything yourself.${
+${t.flows.length ? `Pay particular attention to check **2a, the acceptance contract**. The flows ${t.flows.join(', ')} were registered and specced on \`${BASE_BRANCH}\` by the product owner, in a reviewed PR that merged before this implementation began — the implementer did not write them and may not edit them. Verify with \`git diff origin/${BASE_BRANCH}..<top-branch>\` that \`docs/core-flows.md\`, \`docs/prd.md\` and the flow specs under \`e2e/flows\`/\`e2e-emulator/flows\` carry no changes beyond the removal of \`test.fixme\` markers and any mechanical change the PR body called out. A spec bent toward the implementation is the most expensive thing you can miss here, and a *newly added* flow spec is the same failure wearing a different hat. Then run the flows and confirm they pass.\n\n` : ''}The task's live record is issue #${t.issue}. Read it with \`gh issue view ${t.issue} --comments\` (${gh.toLowerCase()}) and treat every ticked acceptance checkbox as a claim to verify against the diff. A box ticked without the code to support it is a blocking finding. Do not tick, untick or close anything yourself.${
   t.decisionBlockers?.length
     ? `\n\nThis task is blocked on ${t.decisionBlockers.map((d) => `\`${d}\``).join(' and ')}, which ${t.decisionBlockers.length > 1 ? 'are' : 'is'} undecided. Check specifically that the implementer did **not** invent the decision: a hardcoded retention window, template list or licence policy that reads as deliberate product behavior is blocking no matter how reasonable it looks.`
     : ''
@@ -310,13 +270,16 @@ ${review.blocking
 
 Report the same structured result as the original implementation, describing the stack as it now stands.`
 
-const prPrompt = (t, impl, specPr) => `Open the pull requests for the implementation slices of task ${t.taskId} - ${t.title} (issue #${t.issue}). ${gh}
+const prPrompt = (t, impl) => `Open the pull requests for the implementation slices of task ${t.taskId} - ${t.title} (issue #${t.issue}). ${gh}
 
-PR 1 of the stack — the core-flow specs — is already open as ${specPr ? `#${specPr.number} on branch \`${specPr.branch}\`` : 'the flow-spec PR'}. Open one PR per implementation branch, in order: ${impl.branches.join(' -> ')}.
+Open one PR per implementation branch, in order: ${impl.branches.join(' -> ')}. There are **${impl.branches.length}** of them, so this stack is numbered 1/${impl.branches.length} through ${impl.branches.length}/${impl.branches.length}.
 
-- Each PR's base is the **previous branch in the stack**, not \`${BASE_BRANCH}\` (\`gh pr create --base <prev-branch>\`), so its diff shows only its own slice. The first implementation branch's base is ${specPr ? `\`${specPr.branch}\`` : 'the flow-spec branch'}.
+The core-flow specs are **not** part of this stack: they were landed separately by the product owner before the work began, so PR 1 here is the first implementation slice, based on \`${BASE_BRANCH}\`.
+
+- The **first** PR's base is \`${BASE_BRANCH}\`. Every later PR's base is the **previous branch in the stack** (\`gh pr create --base <prev-branch>\`), so each diff shows only its own slice.
 - Every PR is capped at **400 changed lines** (added + deleted in product and test code; generated files, lockfiles and vendored assets excluded) and does one clear thing. If a branch's diff exceeds that, do **not** open an oversized PR: report it in \`blocker\` so the work can be re-sliced.
-- Title each "${t.taskId} - <slice purpose>". In each body name its place in the stack ("3 of 4, builds on #<prev>"), describe that slice's change, link the PRD requirements it touches, list the acceptance checkboxes it satisfies, state the safety invariant that makes it mergeable on its own and how it was proved, and note that the branch passed an Opus review round before the PR was opened.
+- Title each "${t.taskId} - <slice purpose> (i/${impl.branches.length})", where \`i\` is its 1-based position in the stack — so the first is "(1/${impl.branches.length})" and the last is "(${impl.branches.length}/${impl.branches.length})". Use that exact bracketed form; it is how a reader tells stack order from a list of PR titles.
+- In each body name its place in the stack ("2/${impl.branches.length}, builds on #<prev>"; the first says it is based on \`${BASE_BRANCH}\`), describe that slice's change, link the PRD requirements it touches, list the acceptance checkboxes it satisfies, state the safety invariant that makes it mergeable on its own and how it was proved, and note that the branch passed an Opus review round before the PR was opened.
 - Mirror \`.github/pull_request_template.md\`.
 - \`Refs #${t.issue}\` on every PR except the last, which uses \`Closes #${t.issue}\`.
 - Leave the **Walkthrough** section of the last PR as the placeholder text \`<!-- walkthrough pending -->\`; a later stage fills it in from the captured screenshots. Mid-stack PRs with no user-visible change write "No UI change" instead.
@@ -348,84 +311,68 @@ const issueNumber = Number(config.issue ?? config.issueNumber)
 if (!Number.isInteger(issueNumber) || issueNumber <= 0)
   throw new Error(`solid-groove-feature needs a GitHub issue number: { issue: 123 }. Got ${JSON.stringify(args)}.`)
 
-phase('Spec')
+phase('Contract')
 const t = await agent(discoverPrompt(issueNumber), {
   model: 'sonnet',
   label: `read:#${issueNumber}`,
-  phase: 'Spec',
+  phase: 'Contract',
   schema: ISSUE_SCHEMA,
 })
 if (!t) throw new Error(`Could not read issue #${issueNumber}.`)
 t.flows = Array.isArray(t.flows) ? t.flows : []
+t.flowSpecs = Array.isArray(t.flowSpecs) ? t.flowSpecs : []
 
 log(`#${t.issue} ${t.taskId} - ${t.title} — ${t.flows.length ? `flows ${t.flows.join(', ')}` : 'no core flows linked'}${t.changesUi ? ', changes the UI' : ''}`)
 
 // A feature with no linked flow has no acceptance contract to write, review, or
 // capture a walkthrough from. That is legitimate for a pure-refactor or
 // infrastructure issue and wrong for anything a user can see, so say which
-// rather than silently skipping three stages.
+// rather than silently skipping two stages.
 if (t.flows.length === 0) {
   log(
     t.changesUi
       ? `#${t.issue} links no core flow but changes the UI. Proceeding without a flow contract or a captured walkthrough — the closing PR will need a walkthrough by hand. Consider adding a flow to docs/core-flows.md and re-running.`
-      : `#${t.issue} links no core flow and changes nothing a user sees; skipping the spec and walkthrough stages.`,
+      : `#${t.issue} links no core flow and changes nothing a user sees; skipping the contract check and the walkthrough.`,
   )
 }
 
-// Stage 1: write the acceptance contract, review it, land it as PR 1.
-let spec = null
-let specPr = null
+// Stage 1: verify the acceptance contract exists. This workflow does not write
+// it — the product owner registers the flow and lands its `test.fixme` spec in
+// their own reviewed PR first. So the only question here is whether that
+// happened, and the only honest answer to "it did not" is to stop.
+//
+// Starting anyway would produce exactly the failure the core-flow convention
+// exists to prevent: an implementation with no contract, and an implementer
+// under pressure to write one that its own code already satisfies.
 if (t.flows.length > 0) {
-  spec = await agent(specPrompt(t), { model: 'opus', label: `spec:${t.taskId}`, phase: 'Spec', isolation: 'worktree', schema: SPEC_SCHEMA })
-  if (!spec) throw new Error(`Flow author returned nothing for ${t.taskId}.`)
+  const missing = t.flows.filter((flow) => {
+    const found = t.flowSpecs.find((entry) => entry.flow === flow)
+    return !found || !found.registered || !found.spec
+  })
 
-  let specReview = null
-  for (let round = 1; round <= MAX_REVIEW_ROUNDS; round++) {
-    specReview = await agent(specReviewPrompt(t, spec, round), {
-      model: 'opus',
-      effort: 'high',
-      label: `spec-review:${t.taskId}#${round}`,
-      phase: 'Spec',
-      isolation: 'worktree',
-      schema: REVIEW_SCHEMA,
-    })
-    if (!specReview) throw new Error(`Spec reviewer returned nothing for ${t.taskId}.`)
-    if (specReview.approved) break
-
-    log(`${t.taskId}: spec review round ${round} returned ${specReview.blocking.length} blocking finding(s)`)
-    if (round === MAX_REVIEW_ROUNDS) break
-
-    const fixed = await agent(specFixPrompt(t, spec, specReview), {
-      model: 'opus',
-      label: `spec-fix:${t.taskId}#${round}`,
-      phase: 'Spec',
-      isolation: 'worktree',
-      schema: SPEC_SCHEMA,
-    })
-    if (fixed) spec = fixed
-  }
-
-  // The contract gates everything downstream, so an unapproved spec stops the
-  // run. Building on a spec the reviewer rejected is strictly worse than
-  // stopping: the implementation would be measured against it anyway.
-  if (!specReview.approved)
+  if (missing.length > 0)
     return {
       issue: t.issue,
-      status: 'blocked-on-spec',
-      stage: 'Spec',
-      branch: spec.branch,
-      blocking: specReview.blocking,
-      note: `Flow specs not approved after ${MAX_REVIEW_ROUNDS} rounds. Branch left open, no PR. Implementation deliberately not started — it would be measured against a contract the reviewer rejected.`,
+      taskId: t.taskId,
+      status: 'blocked-on-missing-contract',
+      stage: 'Contract',
+      flows: t.flows,
+      flowSpecs: t.flowSpecs,
+      missing,
+      note: `${missing.join(', ')} ${missing.length > 1 ? 'are' : 'is'} linked by #${t.issue} but ${missing.length > 1 ? 'do' : 'does'} not have both a complete entry in docs/core-flows.md and a spec file on ${BASE_BRANCH}. This workflow no longer writes flow specs: the product owner lands the flow and its test.fixme spec in one reviewed PR before implementation starts. Nothing was built.`,
     }
 
-  const opened = await agent(specPrPrompt(t, spec), { model: 'sonnet', label: `pr:${t.taskId}-flows`, phase: 'Spec', schema: PR_SCHEMA })
-  specPr = opened?.pullRequests?.[0] ?? null
-  log(`${t.taskId}: flow specs open as ${specPr ? `#${specPr.number}` : 'a PR (number not reported)'} — merge it before the stack lands`)
+  const live = t.flowSpecs.filter((entry) => entry.spec && !entry.fixme).map((entry) => entry.flow)
+  log(
+    `${t.taskId}: contract present for ${t.flows.join(', ')}${
+      live.length ? ` — note ${live.join(', ')} ${live.length > 1 ? 'are' : 'is'} already live (not test.fixme), so ${live.length > 1 ? 'those flows pass' : 'that flow passes'} before this run` : ''
+    }`,
+  )
 }
 
-// Stage 2: implement on top of the frozen contract.
+// Stage 2: implement against the frozen contract.
 phase('Implement')
-let impl = await agent(implPrompt(t, spec ?? { branch: BASE_BRANCH }), {
+let impl = await agent(implPrompt(t), {
   model: 'opus',
   label: `impl:${t.taskId}`,
   phase: 'Implement',
@@ -471,16 +418,15 @@ if (!review.approved)
     issue: t.issue,
     status: 'blocked-on-review',
     stage: 'Review',
-    flowSpecPr: specPr,
     branches: impl.branches,
     blocking: review.blocking,
     unmet: impl.unmet,
     note: `Not approved after ${MAX_REVIEW_ROUNDS} rounds. Implementation branches left open, no PRs opened.`,
   }
 
-// Stage 4: open the rest of the stack.
+// Stage 4: open the stack.
 phase('Land')
-const landed = await agent(prPrompt(t, impl, specPr), { model: 'sonnet', label: `pr:${t.taskId}`, phase: 'Land', schema: PR_SCHEMA })
+const landed = await agent(prPrompt(t, impl), { model: 'sonnet', label: `pr:${t.taskId}`, phase: 'Land', schema: PR_SCHEMA })
 const pullRequests = landed?.pullRequests ?? []
 const topPr = pullRequests.find((pr) => pr.closesIssue) ?? pullRequests[pullRequests.length - 1] ?? null
 
@@ -512,7 +458,7 @@ return {
   taskId: t.taskId,
   status: 'open-for-review',
   flows: t.flows,
-  flowSpecPr: specPr,
+  flowSpecs: t.flowSpecs,
   pullRequests,
   closingPr: topPr,
   walkthrough,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,15 +165,19 @@ what matters here is how the flows shape the work:
 1. **The product owner writes the flows and links them from the issue.** A flow
    that depends on work which does not exist yet gets that dependency broken out
    as its own issue first.
-2. **The first PR in a feature's stack is the flow specs alone** —
-   `e2e/flows/<ID>.spec.ts` (or `e2e-emulator/flows/<ID>.spec.ts`), marked
-   `test.fixme` because the implementation does not exist. It is reviewed on its
-   own, before anything is built, because it is the contract everything else is
-   measured against. `test.fixme` is what keeps it honest *and* mergeable: a
-   skipped test is green, so the slice satisfies the same "green on its own
-   commit" rule as every other PR, and a deliberately red PR 1 would either block
-   the stack or redden `main` for every parallel task. The red→green evidence
-   belongs in the run log, not in a merge.
+2. **The flow and its spec land together, before implementation starts** —
+   the entry in `docs/core-flows.md` and `e2e/flows/<ID>.spec.ts` (or
+   `e2e-emulator/flows/<ID>.spec.ts`) in one PR, marked `test.fixme` because the
+   implementation does not exist. That PR is the product owner's, and it is
+   reviewed on its own, before anything is built, because it is the contract
+   everything else is measured against — which is exactly why the implementation
+   pipeline does not write it. `test.fixme` is what keeps it honest *and*
+   mergeable: a skipped test is green, so the slice satisfies the same "green on
+   its own commit" rule as every other PR, and a deliberately red PR would either
+   block the work or redden `main` for every parallel task. The red→green
+   evidence belongs in the run log, not in a merge. It also has to land as one
+   PR: `bun run verify:core-flows` fails a registered flow that has no spec, so
+   a register edit on its own cannot merge green.
 3. **From then on the spec is frozen.** A later PR that changes its assertions
    must say so in its body and justify it; a reviewer treats an unexplained
    change as blocking. If the implementer can edit the test, the test proves
@@ -186,15 +190,17 @@ what matters here is how the flows shape the work:
    that passing run. `bun run verify:core-flows` enforces the 1:1 mapping between
    registered flows and specs, and reports any flow still parked.
 
-`.claude/workflows/solid-groove-feature.js` runs this pipeline for one issue —
-spec → spec review → implement → review → land → walkthrough. Invoke it through
-the **`/implement-feature #123`** skill (`.claude/skills/implement-feature/`),
-from a terminal, claude.ai/code, or the mobile app: the skill verifies the
-prework first (the issue links flows, every flow is registered and complete, the
+`.claude/workflows/solid-groove-feature.js` runs the rest of the pipeline for
+one issue — verify the contract → implement → review → land → walkthrough. It
+never writes a flow spec: if a linked flow is not registered and specced on
+`main`, it stops without building anything. Invoke it through the
+**`/implement-feature #123`** skill (`.claude/skills/implement-feature/`), from a
+terminal, claude.ai/code, or the mobile app: the skill verifies the prework first
+(the issue links flows, every flow is registered, complete, and specced, the
 `blocked_by` graph is closed), runs the workflow, and then verifies the resulting
-stack — bases, `Refs`/`Closes`, PR size, an untouched specification, no flow left
-at `test.fixme`, and that the walkthrough images actually return `200` rather
-than rendering as broken icons. The workflow and agent definitions are
+stack — bases, `(i/n)` titles, `Refs`/`Closes`, PR size, an untouched
+specification, no flow left at `test.fixme`, and that the walkthrough images
+actually return `200` rather than rendering as broken icons. The workflow and agent definitions are
 human-approved: an agent running the skill reports a problem with them and never
 edits them.
 


### PR DESCRIPTION
## What & why

The core-flow-first process changed: the product owner now lands the flow entry in `docs/core-flows.md` and its `test.fixme` spec **together, in one reviewed PR**, before triggering implementation — as #227 just did for `ARR-003`. That left `solid-groove-feature.js`'s `Spec` phase with nothing to author, and an agent rewriting a contract that is already frozen is the precise failure the freeze rule exists to prevent.

So the `Spec` phase becomes a **`Contract`** phase that checks rather than writes:

- Discovery now reports, per linked flow, whether it is `registered` in `docs/core-flows.md` and which `spec` file backs it on `main`, plus whether that spec is still `fixme`. It reads `origin/main`, not whatever the worktree started at.
- If any linked flow lacks either half, the run returns **`blocked-on-missing-contract`** and builds nothing.
- A flow whose spec is already live is logged, not treated as an error — it just means that flow passes today.

Removed with it: the flow-author agent from this pipeline, the spec review rounds, the spec-fix round, and the spec PR. The stack is now implementation slices only.

**PR numbering.** The first implementation PR is based on `main` (there is no spec PR ahead of it), and titles now carry their stack position as `(i/n)` — `ARR-003 - section commands (1/2)`, `ARR-003 - loop-to-song action (2/2)` — so order is readable from a list of titles. `n` is computed from the branch count the implementer reports, so the workflow states it rather than asking an agent to guess.

Two coupled files move with it, because they describe the shape this workflow produces and would otherwise contradict it:

- **`.claude/skills/implement-feature/SKILL.md`** — new preflight check 5a (each linked flow has a spec on `main`); check 10 noted as now load-bearing; Stage 2 describes verification rather than authoring; `blocked-on-spec` → `blocked-on-missing-contract`; postflight check 1 expects PR 1 based on `main`; check 3 expects `(i/n)` titles; check 8 treats a **newly added** flow spec as the same failure as a weakened one.
- **`CLAUDE.md`** — item 2 of "Core flows are the acceptance contract" now describes the flow and its spec landing as one product-owner PR, and says why they cannot be split: `verify:core-flows` fails a registered flow with no spec, so a register edit alone cannot merge green. The pipeline sentence drops `spec → spec review`.

`.claude/agents/solid-groove-flow-author.md` is left in place but is no longer invoked by any workflow — worth deciding separately whether it should be deleted or kept for writing specs by hand. `solid-groove-phase-1.js` never used the flow-spec stages and is untouched.

## Core flows

None — this changes the pipeline that implements features, not the product. CF-001, CF-002 and CF-003 are unaffected; `verify:core-flows` still reports 3 flows, each with exactly one spec.

## Walkthrough

No UI change — this PR touches only `.claude/` and `CLAUDE.md`.

## Evidence

```
$ bun run check:ci
$ tsc --noEmit && biome check
Checked 483 files in 606ms. No fixes applied.

$ bun run verify:core-flows
  note: CF-002 is still test.fixme in e2e/flows/CF-002.spec.ts — in flight, or abandoned mid-stack.
  note: CF-003 is still test.fixme in e2e/flows/CF-003.spec.ts — in flight, or abandoned mid-stack.
check-core-flows — 3 flow(s), each with exactly one spec.
```

The workflow script is not covered by any suite and is not parsed by `tsc` or Biome, so it was syntax-checked directly — wrapped in an async function, since the runtime supplies that context and the script's top-level `return` statements are illegal without it. Both the version on `main` and this one parse clean under identical treatment:

```
origin/main: SYNTAX OK
this branch: SYNTAX OK
```

That is a parse check, not an execution: the pipeline itself is only exercised by running it against a real issue. `#61` is the first candidate, and its contract is now on `main`.

Diff is 316 changed lines across 3 files, under the 400 ceiling.

## Acceptance criteria met

No issue — this is a process change requested directly. It closes nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCpeiSDSccJwQP84A7roLe)_