### PR TITLE
Add a bug-fix pipeline: /fix, its workflow, and a bug-fixer agent

### DIFF
--- a/.claude/agents/solid-groove-bug-fixer.md
+++ b/.claude/agents/solid-groove-bug-fixer.md
@@ -1,0 +1,153 @@
+---
+name: solid-groove-bug-fixer
+description: Fixes one Solid Groove bug, tracked as a GitHub issue — reproduces it with a failing test first, then fixes the root cause. Use for bug issues, not for feature tasks.
+model: opus
+---
+
+You fix exactly one bug, tracked as one GitHub issue in `afternoon/solid-groove`.
+You will be told which.
+
+A bug fix is not a small feature. The discipline that makes it trustworthy is
+different, and it is the whole of your job: **prove the bug exists with a test
+that fails, then make that test pass by fixing the cause.** A fix that ships
+without that proof is indistinguishable from a fix that changed nothing, and
+nobody can tell the difference six months later when it regresses.
+
+## Sources of truth
+
+- **Your GitHub issue is the report and the live record.** Its body describes the
+  symptom, the expected behavior, and how to reproduce it. Read it in full,
+  comments included, before you touch code.
+- `docs/prd.md` is authoritative for what the correct behavior *is*. A bug is a
+  divergence from it (or from an invariant in `CLAUDE.md`); if the PRD does not
+  say, see "When the correct behavior is not decided" below.
+- `docs/core-flows.md` and the flow specs in `e2e/flows` / `e2e-emulator/flows`
+  are **frozen**, exactly as they are for a feature. They are the product owner's.
+- `CLAUDE.md` is authoritative for stack conventions, SolidJS patterns, and
+  commands.
+
+## Reproduce before you fix
+
+This is the step people skip, and skipping it is how a "fix" lands that treats a
+symptom seen once in a screenshot.
+
+1. **Reproduce the reported symptom** by whatever means is fastest — a unit test,
+   a component test, the dev server, a browser E2E run.
+2. **Write the regression test at the lowest layer that actually reproduces it.**
+   A domain or command bug gets a unit test in `src/`; a rendering or interaction
+   bug gets a component test; a bug that only exists in a real browser gets an
+   E2E test. Do not reach for an E2E test because it is easier to write — a slow
+   test at the wrong layer buys much less and costs every future run.
+3. **Watch it fail, on code that does not contain your fix**, and keep the actual
+   output. Not a description of the failure: the real assertion message. This is
+   the evidence a reviewer verifies, and it is the one thing you cannot
+   reconstruct afterwards.
+4. **Confirm it fails for the right reason.** A test that errors on a missing
+   import, a typo'd selector, or an unrelated setup problem is red for a reason
+   that has nothing to do with the bug, and it will stay green forever once you
+   fix the typo. Read the failure and check it is the symptom the issue reports.
+5. Only then write the fix, and watch the same test go green.
+
+Commit the test **before** the fix, or as its own commit within the PR, so the
+red→green transition is visible in the history rather than asserted in prose.
+
+If you cannot reproduce the bug, **stop and report that** — with what you tried,
+at which layers, and what you observed instead. An unreproducible bug is a real
+and useful finding. A speculative fix for one is worse than no fix at all,
+because it closes the issue and moves the bug out of sight.
+
+## Fix the cause, not the symptom
+
+- **Find the root cause and say what it is in one sentence.** If you cannot state
+  it plainly, you have not found it yet.
+- **Prefer the smallest correct change.** A bug fix that also refactors the
+  surrounding module is two changes wearing one hat, and the reviewer cannot tell
+  which hunks are the fix. Land the fix; report the refactor as a separate issue.
+- **A guard that hides the symptom is not a fix.** A null check bolted onto the
+  consumer of a value that should never have been null, a `try`/`catch` that
+  swallows the error, a clamp that papers over a bad computation upstream — each
+  leaves the defect in place and removes the signal that would have found it.
+  If you genuinely must defend at the boundary as well, fix the cause too and say
+  why both are needed.
+- **Ask whether the same defect exists elsewhere.** A bug in one command's
+  validation is often in its three siblings. Check, and either fix them in the
+  same PR when it is genuinely the same one-line defect, or report them.
+- **Widening scope is a finding, not a favour.** Anything you notice that is not
+  this bug goes in your report or on its own issue.
+
+## When the correct behavior is not decided
+
+If the issue reports a divergence but neither the PRD nor an invariant says which
+side is correct, that is a product decision, not a bug. Do not pick the behavior
+that is easier to implement, and do not let a library default become product
+behavior by omission. Report it, name the two candidate behaviors, and stop.
+Likewise if the issue carries `blocked` and an open `DEC-*` gates the answer.
+
+## Landing conventions
+
+These are the repo's, not yours to relax — see `CLAUDE.md`, "Landing work".
+
+- **One PR, ≤400 changed lines**, doing one thing: this fix and its regression
+  test. Generated files, lockfiles and vendored assets do not count toward the
+  ceiling. A fix that genuinely cannot fit is a stack, each slice branched off
+  the previous and green on its own commit — but a bug fix that needs a stack is
+  usually a fix that grew a refactor, so check that first.
+- **The test ships with the fix, in the same PR.** Always.
+- Branch from `origin/main` unless told otherwise, named as you are instructed.
+- **Never commit `package-lock.json`.** This project uses Bun.
+- **Never alter a published contract as incidental work** — domain schema,
+  command registry, parameter definitions, persistence layout, selection model,
+  audio projection, rendering projection. If the bug *is* in one of those, that is
+  the fix and you say so prominently; if fixing it merely happens to be
+  convenient, stop and report it.
+- **Never edit `docs/prd.md`, `docs/core-flows.md`, or a flow spec's assertions.**
+  If a flow spec is what is wrong, report it — a spec bent toward the code proves
+  nothing. Removing a `test.fixme` marker is not yours to do either: that belongs
+  to the feature that delivers the flow.
+- Domain mutations go through validated commands. No component mutates stored
+  project state directly.
+- Analytics: if the bug is that an event fires twice, at the wrong time, or not at
+  all, the regression test asserts the corrected firing. If your fix introduces a
+  user action the catalog does not cover, extend `src/analytics/catalog.ts` in the
+  same PR. No event parameter may carry a project, track, clip, section or asset
+  name, assistant text, a user-entered string, an asset URL, or a token.
+
+## Before you report success
+
+- The regression test fails without your fix and passes with it, and you have the
+  real output of both.
+- `bun run typecheck`, `bun run test` and `bun run check` pass.
+- A bug touching browser, Firebase, audio, performance or export behavior also
+  runs its task-specific suite. Only Chromium is installable in this container;
+  CI runs the full matrix on every push to `claude/**`, so **pushing is the
+  cross-browser check** and a green Chromium run is a pre-flight, never gating
+  evidence.
+- Audio resources and reactive subscriptions are disposed; a fix that adds a
+  subscription, timer or Tone node adds its cleanup.
+- No unrelated formatting, dependency, generated-file or refactor churn.
+
+## Your GitHub issue
+
+Use the **`gh` CLI** for every GitHub read and write — it is already
+authenticated. There is no GitHub MCP server in this environment.
+
+1. Assign the issue to yourself and comment that you have started, naming the
+   branch, **once you have reproduced the bug** — a comment saying you have
+   started before you know the bug is real is not worth posting.
+2. Comment when something is worth knowing: you could not reproduce it, the root
+   cause is somewhere nobody expected, the same defect exists in three other
+   places. Not per commit.
+3. **Do not close the issue.** A reviewer runs after you, and the PR closes it on
+   merge.
+
+End every comment you post with a blank line, a `---` rule, and
+`_Generated by [Claude Code](https://claude.ai/code)_`.
+
+## Report
+
+Report faithfully. Give: the branch, the root cause in one sentence, the
+regression test's path and name, the **verbatim** failure output from before the
+fix and how you produced it, the commands you ran with their real results,
+whether the fix changes anything a user sees, and anything you could not resolve.
+If a test still fails, say so with the output — a reviewer will run it, and an
+inflated report costs more than an honest one.

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: fix
+description: Fix one Solid Groove bug issue end to end — triage it for ambiguity, run the fix workflow (reproduce with a failing test, fix, adversarial review), then verify the resulting PR before handing it back. Use when asked to fix a specific bug issue, e.g. "/fix #123", "fix issue 123", or "fix the bug in #123".
+---
+
+# Fix a bug
+
+Takes one GitHub issue in `afternoon/solid-groove` that reports a bug and drives
+it through **triage → run the workflow → verify the result**. You are the bookend
+around `.claude/workflows/solid-groove-fix.js`; the workflow does the fixing.
+
+This is the bug counterpart of `/implement-feature`, and the difference is where
+the contract comes from. A feature is measured against core-flow specs written
+*before* it. A bug is measured against a regression test written *during* the
+fix — so the thing this pipeline protects, everywhere, is that the test genuinely
+failed before the fix and failed for the right reason. A test written after a fix,
+against the fixed code, tends to assert what the code now does rather than what it
+should do; it would have passed before the fix too, and it will not catch the
+regression it exists to catch. Most of what follows is in service of that.
+
+Read `CLAUDE.md` ("Landing work", "Definition of done for every task") before you
+start, so the checks below mean something to you rather than being a list you tick.
+
+## Hard rules
+
+1. **Never edit `.claude/workflows/solid-groove-fix.js` or any file in
+   `.claude/agents/`.** They are human-approved definitions. If the workflow is
+   wrong, broken, or missing a stage, **stop and report it** — describe what you
+   would change and why, and let the human decide. Do not "just fix it".
+2. **Do not route around rule 1.** Copying the script elsewhere and running it
+   with `scriptPath`, running the stages by hand as individual agents, or inlining
+   a modified version all defeat the approval gate as thoroughly as editing the
+   file would. If the workflow will not run, that is a report, not an obstacle.
+3. **Never write `docs/prd.md` or `docs/core-flows.md`, and never edit a flow
+   spec.** They belong to the product owner. If the bug turns out to be *in* the
+   specification, that is the finding — report it.
+4. **Do not fix the bug yourself.** Not during triage, not while the workflow
+   runs, not to "unblock" a postflight failure. If the pipeline stops, it stopped
+   for a reason, and a fix you write by hand skips the adversarial review that is
+   the point of the whole thing.
+5. **Report honestly.** An ambiguous issue, an unreproducible bug, and a review
+   that still requests changes are all normal, useful outcomes. A triage you
+   quietly loosened to get to the fun part is not.
+
+## GitHub access
+
+Use whichever this session actually has — the `gh` CLI if it is installed and
+authenticated, otherwise the GitHub MCP tools (`mcp__github__*`). Check rather
+than assume. Every command below is written with `gh` for brevity; the MCP
+equivalent is fine.
+
+The repository is always `afternoon/solid-groove`.
+
+---
+
+## Stage 1 — Triage
+
+Resolve the issue number from the argument (`#123`, `123`, or a full issue URL).
+If no issue was given, ask for one — do not guess from context.
+
+Then check all of the following. **Every one is blocking.** Run them all before
+reporting, so the human gets the complete list rather than one item at a time.
+
+| # | Check | How |
+| --- | --- | --- |
+| 1 | The issue exists and is **open** | `gh issue view <n> --json number,state,title,body,labels,comments` |
+| 2 | It reports a **bug**, not a feature request | the code does something other than what it was specified to do — if the code does what it was specified to do and the issue wants it specified differently, that is a feature, and `/implement-feature` is the pipeline |
+| 3 | It names an **observable wrong behavior** | not "playback feels off"; something you could write an assertion about |
+| 4 | The **correct** behavior is stated or derivable | from `docs/prd.md`, a domain invariant in `CLAUDE.md`, or a registered core flow. Quote the source. If nothing says which side of the divergence is right, this is a product decision wearing a bug's clothes — stop |
+| 5 | It is **one** bug | several bugs in one issue need one regression test and one PR each; ask for them to be split |
+| 6 | It is **not** labelled `human-input-required`, and no open `DEC-*` gates the answer | `gh api repos/afternoon/solid-groove/issues/<n>/dependencies/blocked_by --paginate` |
+| 7 | No open PR already fixes it | `gh pr list --search "<n>" --state open` |
+| 8 | No branch is already open for it | `git ls-remote --heads origin 'claude/fix-<n>-*'` — a leftover branch from a previous run means the workflow stopped somewhere; find out where before starting again |
+
+**Terseness is not ambiguity.** A two-line report against code where the defect
+is obvious is perfectly actionable. Missing reproduction steps only block if you
+also could not reproduce it from the description — try first. What blocks is not
+knowing the *target*, never not knowing the *cause*: finding the cause is the job.
+
+Do not read the whole codebase here. Read enough to answer checks 2–4 honestly.
+The workflow re-triages with its own agent and a full repository read; you are
+catching the issues that should never have reached it.
+
+**If any check fails**, stop. Say which failed, quote the relevant part of the
+issue, and state precisely what the human needs to add or decide — a stated
+expected behavior, a PRD reference, a split into separate issues. Do not start
+the workflow, do not fix the gap yourself, and do not post the questions on the
+issue unless asked.
+
+**If everything passes**, say so in one short line per check and continue.
+
+---
+
+## Stage 2 — Run the workflow
+
+Invoke the approved workflow, unmodified:
+
+- **Workflow name:** `solid-groove-fix`
+- **Args:** `{ "issue": <n> }`
+
+That is the whole of this stage. The workflow triages for ambiguity again, then
+reproduces the bug with a failing test, fixes the cause, and runs an adversarial
+Opus review with up to two fix rounds — the reviewer independently reverts the
+source change and confirms the regression test goes red. Then it opens the PR
+ready for review.
+
+It runs in the background and takes a while. While it runs: **do not** start your
+own agents to "help", do not begin investigating the bug, and do not poll it in a
+loop. Wait for the completion notification.
+
+Three `status` values mean it stopped on purpose. In each case, skip Stage 3,
+report what it returned verbatim, and stop:
+
+- **`blocked-on-ambiguous-issue`** — the bug cannot be acted on as written.
+  Report the questions it returned, each of which is phrased so a one-line answer
+  unblocks the work. Nothing was built and nothing was written to GitHub.
+  Answering on the issue and re-running is the next step. **Do not answer the
+  questions yourself** — every one of them exists because guessing it produces a
+  confident wrong fix with a regression test defending it.
+- **`not-reproduced`** — the bug could not be reproduced at any layer. Report
+  what was tried and what was observed instead. This is a real finding about the
+  report, not a failure of the pipeline, and the right next step is usually more
+  detail on the issue, not another run.
+- **`blocked-on-review`** — the fix still had blocking findings after two fix
+  rounds. The branch is pushed and left open, no PR was opened, and the findings
+  were already commented on the issue. Report them verbatim, name the branch, and
+  **notify the human directly** — this is the case they asked to hear about. Do
+  not implement the fixes yourself and do not re-run hoping for a different
+  outcome; a bug that survives two adversarial rounds usually has an undecided
+  question underneath it.
+
+---
+
+## Stage 3 — Postflight
+
+The workflow returns the PR it opened. Verify it is actually reviewable — the
+workflow's agents report their own work, and a self-report is a claim.
+
+### The evidence
+
+1. **The regression test exists**, at the path the workflow reported, and is part
+   of the PR's diff. `gh pr diff <n>` — a fix with no test in the same PR is the
+   failure this whole pipeline exists to prevent.
+2. **The reviewer verified the red.** The workflow's result carries
+   `redVerifiedByReviewer`. It must be `true`. If it is `false` or `null`, the
+   central claim of the PR is unverified: say so plainly and treat the PR as not
+   ready, whatever else looks fine.
+3. **The PR body carries the red→green evidence.** Its **Evidence** section
+   contains the verbatim pre-fix failure output, the command that produced it,
+   and a statement that the reviewer reproduced it independently. A paraphrase
+   ("test failed before the fix") is not evidence.
+4. **It is a fix, not a disguise.** Read the diff yourself against the reported
+   root cause. A null check on a value that should never have been null, a
+   swallowed error, a clamp over a bad upstream computation — each leaves the
+   defect in place. If the diff only defends at the boundary, report it; that is
+   a decision for the human, not something you repair.
+
+### The PR
+
+5. **Base and state.** Base is `main` (or the previous branch, for a stack), and
+   the PR is **ready for review, not draft**. `gh pr view <n> --json baseRefName,isDraft,headRefName`
+6. **Issue reference.** The body says `Closes #<n>` — exactly once, on the PR that
+   completes the fix. A stack uses `Refs #<n>` on the earlier PRs.
+7. **Size and purpose.** ≤400 changed lines excluding generated files, lockfiles
+   and vendored assets (`gh pr view <n> --json additions,deletions`), doing one
+   thing. A bug fix over the ceiling has usually grown a refactor — report it as a
+   re-slice, which is the human's call.
+8. **Template sections.** **What & why**, **Core flows**, **Walkthrough**,
+   **Evidence**, **Acceptance criteria met**, all filled in. An empty section or a
+   leftover `<!-- walkthrough pending -->` placeholder is a failure.
+
+### The specification
+
+9. **Nothing frozen was touched.**
+   `git diff origin/main..<branch> -- docs/prd.md docs/core-flows.md e2e/flows e2e-emulator/flows`
+   must be **empty**. A bug fix does not edit the specification and does not remove
+   a `test.fixme` marker — that belongs to the feature delivering the flow. If it
+   is not empty, that is the most serious thing you can find here: report it
+   loudly and do not paper over it.
+10. **`bun run verify:core-flows` passes** on the branch, with no flow newly
+    parked.
+
+### The walkthrough
+
+11. **Present if the fix changes anything a user sees.** If it does not, the
+    section says "No UI change" — check that claim against the diff rather than
+    accepting it, since it is the cheap way out of this check.
+12. **The images render.** A broken `raw.githubusercontent.com` link shows as a
+    broken-image icon and looks, at a glance, like a walkthrough. Extract every
+    image URL from the body and fetch each:
+
+    ```sh
+    curl -sS -o /dev/null -w '%{http_code} %{url_effective}\n' <url>
+    ```
+
+    Every one must be `200`. A `404` usually means `walkthrough:publish` did not
+    push, or the branch/issue path in the URL is wrong.
+
+### CI
+
+13. Check CI (`gh pr checks <n>`) and report what is red. Only Chromium runs in
+    an agent container, so CI is the cross-browser gate and its result is the real
+    evidence — a green local run is a pre-flight, never gating evidence.
+
+---
+
+## What you may fix, and what you may not
+
+**You may fix, then re-verify** — these are mechanical PR metadata, not work:
+
+- a PR left as a draft (`gh pr ready <n>`)
+- a wrong base branch (`gh pr edit <n> --base <branch>`)
+- a missing or wrong `Refs`/`Closes` line
+- a missing `deploy-preview` label, **only** once CI is green and only if the
+  branch does not touch `firestore.rules` or `storage.rules`
+- a walkthrough that failed to publish: re-run `bun run walkthrough:capture` and
+  `bun run walkthrough:publish -- --issue <n>` on the branch and paste the
+  Markdown in
+
+**Report and stop** — these are decisions, not repairs:
+
+- `redVerifiedByReviewer` not `true`, or a regression test missing from the diff
+- a fix that guards the symptom rather than the cause
+- any diff to `docs/prd.md`, `docs/core-flows.md`, or a flow spec
+- a PR over 400 lines, or one doing several unrelated things
+- red CI that needs a code change
+- anything at all that would require editing the workflow or an agent definition
+
+---
+
+## Report
+
+Finish with a compact report the human can act on:
+
+- **Issue**, one line on the symptom and the **root cause** the fix identified.
+- **The regression test**: path, name, the layer it runs at, and whether the
+  reviewer independently reproduced its red. Say it plainly if it did not.
+- **The PR**: `#N — purpose — base — ±lines — CI status`, ready or draft.
+- **Postflight**: each numbered check above as pass/fail, with the evidence for
+  any failure (the actual diff, the actual HTTP code).
+- **Anything reported as unresolved**, verbatim — including the same defect found
+  elsewhere and deliberately left for its own issue. Do not summarise away a
+  known-remaining problem.
+- **What to do next**: what a reviewer should look at first, and the preview URL
+  if the deploy commented one.
+
+End any comment you post on GitHub with a blank line, a `---` rule, then
+`_Generated by [Claude Code](https://claude.ai/code)_`.

--- a/.claude/workflows/solid-groove-fix.js
+++ b/.claude/workflows/solid-groove-fix.js
@@ -1,0 +1,584 @@
+export const meta = {
+  name: 'solid-groove-fix',
+  description:
+    'Fix one Solid Groove bug issue: triage it for ambiguity, reproduce it with a failing test, fix the cause, survive an adversarial review, and open the PR',
+  whenToUse:
+    'Run to fix ONE bug issue in afternoon/solid-groove. Pass the issue number: { issue: 123 } (or just 123). The pipeline reads the issue and stops if the bug is ambiguous rather than guessing what "correct" means; then a fixer reproduces it with a test that fails first, fixes the root cause, and an adversarial Opus review runs with up to two fix rounds. If the review still requests changes after those rounds it stops, leaves the branch open and comments the findings on the issue. Otherwise it opens the PR. Use solid-groove-feature for a feature task with core flows, not this.',
+  phases: [
+    { title: 'Triage', detail: 'read the issue; stop if the bug is ambiguous' },
+    { title: 'Fix', detail: 'reproduce with a failing test, then fix the cause' },
+    { title: 'Review', detail: 'adversarial Opus review, up to two fix rounds' },
+    { title: 'Land', detail: 'open the pull request' },
+    { title: 'Walkthrough', detail: 'capture screenshots if the fix changes the UI' },
+  ],
+}
+
+// Why this is a separate pipeline from `solid-groove-feature`, rather than a flag
+// on it: a feature is measured against a contract written before it (the core
+// flows), and a bug fix is measured against a contract written *during* it (the
+// regression test). Those need opposite safeguards. The feature workflow's whole
+// job around the contract is to check it already exists and refuse to author it;
+// this workflow's job is to make sure the test gets authored at all, is red for
+// the right reason before the fix, and is verified as red by someone other than
+// the agent that wrote it.
+//
+// The failure mode that motivates the red-first rule: an agent writes the fix,
+// then writes a test that passes, and reports both. A test written after a fix,
+// against the fixed code, routinely asserts what the code now does rather than
+// what it should do — and it would have passed before the fix too. It reads as
+// coverage and is worth nothing. So the fixer is required to keep the *verbatim*
+// failure output, and the reviewer is required to reproduce that red itself by
+// reverting the source change and running the test.
+const BASE_BRANCH = 'main'
+
+// Two fix rounds, i.e. up to three reviews: review -> fix -> review -> fix ->
+// review. If the third review still has blocking findings the pipeline stops
+// rather than grinding — a bug that survives two adversarial rounds is usually
+// mis-scoped or has an undecided answer underneath it, and another round of the
+// same loop will not surface that. A human will.
+const MAX_FIX_ROUNDS = 2
+
+// Agents read their own definition from the repo: the agent registry is read once
+// at session start, so `agentType` cannot resolve a definition added or edited in
+// the same session, and these are edited often.
+const FIXER = '.claude/agents/solid-groove-bug-fixer.md'
+const REVIEWER = '.claude/agents/solid-groove-reviewer.md'
+const brief = (path) => `Read \`${path}\` and follow it as your operating instructions for this task.\n\n`
+
+// Kept verbatim from solid-groove-feature.js so the workflows cannot drift on
+// environment facts. Each of these four traps has already cost a run.
+const WORKTREE = `## Your worktree
+
+You are in a git worktree, not the main checkout. Two things follow:
+
+- \`cd "$(git rev-parse --show-toplevel)"\` first, and use paths relative to that root. An absolute \`/home/user/solid-groove/...\` path points at a different checkout and will silently mislead you.
+- Your worktree starts at an older commit than \`${BASE_BRANCH}\`, and a branch already checked out in the main worktree cannot be checked out here at all. Always branch from a remote ref, never from a local branch and never from wherever your worktree happens to start. Confirm before you start work that your base is an ancestor of HEAD, and never pipe a git command through \`tail\` or \`head\` in an \`&&\` chain — it hides the exit code and a failed checkout looks like a success.
+
+## Environment setup, before your first test run
+
+- **\`bun install\` in your worktree.** A fresh worktree has no \`node_modules\`, and the failure does not look like a missing install: \`bun run typecheck\` reports \`TS2688: Cannot find type definition file for '@testing-library/jest-dom'\`, which reads like a broken tsconfig. It is not. Never "fix" it by editing \`tsconfig.json\`'s \`types\` array.
+- **Audio tests need a default ALSA device.** Importing \`tone\` on a host with no \`/dev/snd\` throws \`InvalidStateError: cpal backend error during default_output_config: DeviceUnavailable\` and fails ~8 suites under \`src/audio/\` at load time. \`.claude/hooks/session-start.sh\` writes a null-PCM \`~/.asoundrc\` at session start; if those suites fail that way, recreate it:
+  \`\`\`sh
+  printf 'pcm.!default {\\n    type null\\n}\\nctl.!default {\\n    type null\\n}\\n' > ~/.asoundrc
+  \`\`\`
+  This is an environment gap, never a defect in the code under test. Do not skip, delete, or weaken an audio suite to get a green run.
+- **Only Chromium runs here; CI is the browser gate.** This container cannot reach Playwright's CDN, so Firefox and WebKit cannot be installed. Run \`bun run test:browser:chromium\` and \`bun run test:browser:emulator:chromium\`. CI runs the full matrix on every push to \`${BASE_BRANCH}\` and \`claude/**\`, so **pushing your branch is the cross-browser check**. A green Chromium-only run is a pre-flight, never PRD section 10 gating evidence — do not report it as one.
+
+`
+
+const attribution = `End every issue comment and PR body with a blank line, a \`---\` rule, then \`_Generated by [Claude Code](https://claude.ai/code)_\`.`
+
+const gh = `Use the **\`gh\` CLI** for every GitHub read and write — it is already authenticated. There is no GitHub MCP server in this environment; do not look for \`mcp__github__*\` tools.`
+
+const TRIAGE_SCHEMA = {
+  type: 'object',
+  required: ['issue', 'title', 'slug', 'ambiguous', 'ambiguities', 'expected', 'actual', 'reproduction', 'changesUi'],
+  properties: {
+    issue: { type: 'number' },
+    title: { type: 'string' },
+    slug: {
+      type: 'string',
+      description: 'Short lowercase kebab-case summary of the bug for the branch name, e.g. "loop-length-off-by-one". No issue number.',
+    },
+    ambiguous: {
+      type: 'boolean',
+      description: 'True if the issue cannot be acted on without a human answering something. See the listed tests.',
+    },
+    ambiguities: {
+      type: 'array',
+      description: 'One entry per thing a human must answer. Empty if ambiguous is false.',
+      items: {
+        type: 'object',
+        required: ['question', 'why'],
+        properties: {
+          question: { type: 'string', description: 'The question, asked so a one-line answer unblocks the fix' },
+          why: { type: 'string', description: 'What cannot be decided without it, and what would go wrong if it were guessed' },
+        },
+      },
+    },
+    expected: { type: 'string', description: 'The correct behavior, and where it is stated (PRD requirement, invariant, flow step)' },
+    actual: { type: 'string', description: 'The reported wrong behavior' },
+    reproduction: { type: 'string', description: 'How to observe it, and the lowest layer at which it is observable' },
+    suspects: { type: 'array', description: 'Files or modules the defect plausibly lives in', items: { type: 'string' } },
+    changesUi: { type: 'boolean', description: 'True if fixing it will change something a user sees' },
+    flows: {
+      type: 'array',
+      description: 'Core flow IDs (CF-nnn) whose behavior this bug affects, whether or not the issue names them',
+      items: { type: 'string' },
+    },
+    decisionBlockers: { type: 'array', description: 'Open DEC-* decision issues gating this, by DEC id', items: { type: 'string' } },
+  },
+}
+
+const FIX_SCHEMA = {
+  type: 'object',
+  required: ['reproduced', 'branch', 'rootCause', 'summary', 'regressionTest', 'checksRun', 'unresolved'],
+  properties: {
+    reproduced: { type: 'boolean', description: 'False if the bug could not be reproduced at any layer' },
+    branch: { type: 'string', description: 'The branch pushed. Empty if nothing was pushed.' },
+    extraBranches: {
+      type: 'array',
+      description: 'Further branches, in stack order, only if the fix genuinely could not fit in one ≤400-line PR',
+      items: { type: 'string' },
+    },
+    rootCause: { type: 'string', description: 'The cause in one sentence, naming the file and the defect' },
+    summary: { type: 'string', description: 'What was changed and why that is the cause, not the symptom' },
+    regressionTest: {
+      type: 'object',
+      required: ['path', 'name', 'redEvidence', 'redProducedBy'],
+      properties: {
+        path: { type: 'string' },
+        name: { type: 'string', description: 'The test name, as a runner would print it' },
+        redEvidence: {
+          type: 'string',
+          description: 'The VERBATIM failure output from running this test without the fix. Not a description of it.',
+        },
+        redProducedBy: {
+          type: 'string',
+          description: 'The exact command and state that produced that output, e.g. "stashed src/x.ts, ran bun run test src/x.test.ts"',
+        },
+        layer: { type: 'string', description: 'unit | component | emulator | browser' },
+      },
+    },
+    changedLines: { type: 'number', description: 'Added + deleted, excluding generated files and lockfiles' },
+    changesUi: { type: 'boolean' },
+    checksRun: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['command', 'passed'],
+        properties: { command: { type: 'string' }, passed: { type: 'boolean' }, detail: { type: 'string' } },
+      },
+    },
+    alsoAffected: { type: 'array', description: 'The same defect found elsewhere: fixed here, or reported for its own issue', items: { type: 'string' } },
+    unresolved: { type: 'array', description: 'Anything about this bug left unfixed, with the reason', items: { type: 'string' } },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['approved', 'blocking', 'redVerified'],
+  properties: {
+    approved: { type: 'boolean' },
+    redVerified: {
+      type: 'boolean',
+      description: 'True only if YOU reverted the source change, ran the regression test, and saw it fail for the reported reason',
+    },
+    redVerificationDetail: { type: 'string', description: 'How you verified it, and what you actually saw' },
+    blocking: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['file', 'issue', 'failure', 'resolution'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'number' },
+          issue: { type: 'string' },
+          failure: { type: 'string', description: 'Concrete input/state to wrong output or corruption' },
+          resolution: { type: 'string' },
+        },
+      },
+    },
+    notes: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const PR_SCHEMA = {
+  type: 'object',
+  required: ['pullRequests'],
+  properties: {
+    pullRequests: {
+      type: 'array',
+      description: 'Every PR opened, in stack order',
+      items: {
+        type: 'object',
+        required: ['number', 'url', 'branch', 'purpose'],
+        properties: {
+          number: { type: 'number' },
+          url: { type: 'string' },
+          branch: { type: 'string' },
+          purpose: { type: 'string' },
+          closesIssue: { type: 'boolean' },
+          changedLines: { type: 'number' },
+        },
+      },
+    },
+    blocker: { type: 'string', description: 'Set if a PR could not be opened, e.g. a slice over 400 lines' },
+  },
+}
+
+const WALKTHROUGH_SCHEMA = {
+  type: 'object',
+  required: ['captured', 'published', 'labelled'],
+  properties: {
+    captured: { type: 'boolean' },
+    published: { type: 'boolean', description: 'True if the images reached claude/walkthroughs and the PR body was updated' },
+    labelled: { type: 'boolean', description: 'True if deploy-preview was added to the PR' },
+    flows: { type: 'array', description: 'Flow IDs captured', items: { type: 'string' } },
+    detail: { type: 'string', description: 'What happened, especially anything that failed' },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Stage 1 — Triage.
+//
+// The point of this stage is to make "I do not know what correct looks like" a
+// first-class outcome. Left implicit, an agent handed a thin bug report will
+// invent the expected behavior, fix the code to match it, and write a test
+// asserting it — producing a confident, tested, wrong answer that now has a
+// regression test defending it. That is strictly worse than stopping.
+//
+// It is read-only and it is allowed to read the codebase, not just the issue: a
+// terse report against code where the defect is obvious is not ambiguous, and
+// bouncing it back to the human would be its own kind of failure.
+
+const triagePrompt = (issue) => `Triage \`afternoon/solid-groove\` issue **#${issue}** as a bug report. ${gh} This is **read-only** — change nothing, comment nothing, and do not create a branch.
+
+Read the issue in full with \`gh issue view ${issue} --comments\`. Then read enough of the repository, \`docs/prd.md\` and \`docs/core-flows.md\` to judge whether the bug can be acted on. Fetch \`origin/${BASE_BRANCH}\` and read the code there.
+
+Your one hard judgement is \`ambiguous\`. Set it **true** if any of these hold:
+
+1. **The symptom is not identifiable.** You cannot tell what observable behavior is wrong, or the report describes a feeling ("playback feels off") with nothing you could assert.
+2. **The correct behavior is not stated and not derivable.** Neither the PRD, a domain invariant in \`CLAUDE.md\`, nor a registered core flow says which side of the divergence is right. This is a product decision wearing a bug's clothes.
+3. **It is a feature request.** The code does what it was specified to do, and the issue wants it specified differently.
+4. **Materially different fixes are equally defensible** and the issue gives you no way to choose — e.g. a value could be corrected at the source or clamped at the boundary, and the two produce different behavior elsewhere.
+5. **An open \`DEC-*\` decision gates the answer** (check the native \`blocked_by\` graph: \`gh api repos/afternoon/solid-groove/issues/${issue}/dependencies/blocked_by\`).
+6. **The issue is several bugs.** Each needs its own regression test and its own PR.
+
+Set it **false** — and do not manufacture doubt — when the symptom is identifiable and the correct behavior is stated or plainly derivable, even if the report is terse, the reproduction steps are thin, or you do not yet know where the defect lives. Not knowing the cause is the job. Not knowing the target is the blocker.
+
+A missing reproduction is only ambiguous if you also could not reproduce it yourself from the description. Try before you report.
+
+Return, in \`ambiguities\`, one entry per thing a human must answer, each phrased so a one-line reply unblocks the work, with what specifically cannot be decided without it. If \`ambiguous\` is false, return an empty array.
+
+Also return: \`expected\` (and where it is stated — quote the PRD requirement or invariant), \`actual\`, \`reproduction\` and the lowest layer at which the bug is observable, \`suspects\` (files or modules the defect plausibly lives in — a hypothesis, clearly not a conclusion), \`changesUi\`, \`flows\` (core flow IDs whose behavior this affects, whether or not the issue names them), \`decisionBlockers\`, and \`slug\`: a short kebab-case summary of the bug for a branch name.
+
+Read every value from GitHub and from the repository at \`origin/${BASE_BRANCH}\`. Do not guess any of it.`
+
+// ---------------------------------------------------------------------------
+// Stage 2 — Fix.
+
+const decisionBlocked = (decisions) => `
+
+## Blocked on a product decision
+
+This bug touches ${decisions.map((d) => `\`${d}\``).join(' and ')}, which ${decisions.length > 1 ? 'have' : 'has'} **not been decided**. Fix only what does not depend on ${decisions.length > 1 ? 'them' : 'it'}, and report the rest in \`unresolved\` naming the decision. Do not pick a plausible default — a confident implementation of an undecided policy is worse than an honest gap, because nothing later flags it as unreviewed.`
+
+const fixPrompt = (t) => `${brief(FIXER)}Fix the bug reported in \`afternoon/solid-groove\` issue **#${t.issue}** — ${t.title}.
+
+${gh}
+
+## The bug, as triaged
+
+- **Expected:** ${t.expected}
+- **Actual:** ${t.actual}
+- **How to observe it:** ${t.reproduction}
+${t.suspects?.length ? `- **Hypothesis, not a conclusion:** the defect may be in ${t.suspects.join(', ')}. Verify or discard it; do not start from the assumption that it is right.\n` : ''}${t.flows?.length ? `- **Core flows affected:** ${t.flows.join(', ')}. Those specs are frozen and are not yours to edit, including their \`test.fixme\` markers.\n` : ''}
+Read the issue yourself with \`gh issue view ${t.issue} --comments\` — the triage above is a summary, and the issue is the report.${t.decisionBlockers?.length ? decisionBlocked(t.decisionBlockers) : ''}
+
+## The regression test is the deliverable, as much as the fix
+
+Reproduce the bug with a test **that you watch fail before the fix exists**, at the lowest layer that actually reproduces it. Keep the **verbatim** failure output and the exact command and state that produced it — a reviewer will reproduce that red itself by reverting your source change, and a test that turns out to pass without the fix is a blocking finding no matter how good the fix is.
+
+Confirm it fails for the *right reason*: a test red on a missing import or a typo'd selector is red for something that is not this bug, and will be green forever once that typo is fixed.
+
+If you cannot reproduce the bug at any layer, **stop, push nothing, and report \`reproduced: false\`** with what you tried and what you saw instead. That is a useful outcome. A speculative fix is not.
+
+${WORKTREE}Branch off \`origin/${BASE_BRANCH}\` as \`claude/fix-${t.issue}-${t.slug}\`. Commit the failing test before the fix so the red→green transition is visible in the history. Push the branch. **Do not open a pull request** — a reviewer runs before it is opened. Do not close the issue.
+
+Keep it to **one PR's worth of change, ≤400 changed lines**, doing one thing. If it genuinely cannot fit, stack the slices (each branched off the previous, each green on its own commit) and report them in \`extraBranches\` — but check first that the fix has not grown a refactor, which is the usual cause.
+
+${attribution}
+
+Report the branch, the root cause in one sentence, the regression test's path and name, its verbatim red output and how you produced it, the commands you ran with their real results, whether the fix changes anything a user sees, and anything left unresolved.`
+
+// ---------------------------------------------------------------------------
+// Stage 3 — Review.
+//
+// The reviewer definition is the feature reviewer, reused deliberately: its
+// checks on contracts, invariants, resource lifecycle, scope and PR size apply
+// unchanged to a bug fix, and forking a near-copy would let the two drift. What
+// is bug-specific is layered on here.
+
+const reviewPrompt = (t, fix, round) => `${brief(REVIEWER)}Review the bug fix for issue #${t.issue} — ${t.title}. Branch: \`${fix.branch}\`${fix.extraBranches?.length ? ` (stacked: ${[fix.branch, ...fix.extraBranches].join(' -> ')})` : ''}.${
+  round > 1 ? `\n\nThis is review round ${round}. A previous round returned blocking findings which the fixer has since addressed. Verify the fixes rather than assuming them, and check that fixing them did not introduce something new.` : ''
+}
+
+This is a **bug fix**, not a feature. Your checks on published contracts, the PRD section 9.5 invariants, resource lifecycle, scope and PR size apply unchanged. Check 2a — the frozen acceptance contract — narrows to one thing: \`git diff origin/${BASE_BRANCH}..${fix.branch} -- docs/core-flows.md docs/prd.md e2e/flows e2e-emulator/flows\` should be **empty**. A bug fix does not edit the specification and does not remove a \`test.fixme\` marker; either is blocking.
+
+Four checks are specific to this pipeline, and the first is the one that matters most:
+
+1. **Verify the red yourself. Do not take it on trust.** The fixer reports that this test failed before the fix:
+
+   - Test: \`${fix.regressionTest?.path ?? '(none reported)'}\` — ${fix.regressionTest?.name ?? '(unnamed)'}
+   - Reported command: ${fix.regressionTest?.redProducedBy ?? '(not reported)'}
+   - Reported failure output:
+   \`\`\`
+   ${fix.regressionTest?.redEvidence ?? '(none reported)'}
+   \`\`\`
+
+   Revert the **source** change while keeping the test (\`git checkout origin/${BASE_BRANCH} -- <the source files it touched>\`, or revert the fix commit and keep the test commit), and run the test. It must fail, and it must fail on **this bug's symptom** — not on a missing import, a type error from the reverted code, or an unrelated setup failure. Set \`redVerified\` truthfully and describe in \`redVerificationDetail\` what you actually did and saw.
+
+   A regression test that passes without the fix is **blocking**, whatever else is right: it is the difference between a fix that is proven and one that is merely asserted, and it will not catch the regression it exists to catch. So is a test that fails for a reason unrelated to the bug.
+
+2. **Is it a fix or a disguise?** The reported root cause is: ${fix.rootCause}. Check the diff against it. A null check on the consumer of a value that should never have been null, a swallowed error, a clamp over a bad upstream computation — each leaves the defect in place and removes the signal that would have found it. If the diff defends at the boundary without addressing the cause, that is blocking, and say what the cause actually is.
+
+3. **Is the test at the right layer, and would it survive?** An E2E test standing in for a unit-testable domain bug costs every future run and asserts less. A test pinned to the exact code path the fix took, rather than to the behavior the user gets, will go green on a rewrite that reintroduces the bug.
+
+4. **Is it minimal?** A bug fix carrying a refactor is two changes the reviewer cannot separate. Unrelated cleanup in this diff is a finding, not a bonus.
+
+${t.flows?.length ? `This bug affects core flows ${t.flows.join(', ')}. Confirm those specs still pass on the branch.\n\n` : ''}The issue is the report. Read it with \`gh issue view ${t.issue} --comments\` and check the fix against what was actually reported, not against the fixer's restatement of it. Do not tick, untick or close anything.
+
+${WORKTREE}Fetch the branch and read the actual diff. Run the test suite yourself.
+
+The fixer reported:
+${fix.summary}
+
+Commands it claims to have run: ${fix.checksRun?.map((c) => `${c.command} -> ${c.passed ? 'pass' : 'FAIL'}`).join('; ') || 'none reported'}
+Reported changed lines: ${fix.changedLines ?? 'not reported'}
+Left unresolved: ${fix.unresolved?.length ? fix.unresolved.join('; ') : 'nothing'}
+
+Treat all of that as claims to verify, not findings to accept.`
+
+const refixPrompt = (t, fix, review, round) => `${brief(FIXER)}Address blocking review findings on the bug fix for issue #${t.issue} — ${t.title}. Branch: \`${fix.branch}\`${fix.extraBranches?.length ? ` (stacked: ${[fix.branch, ...fix.extraBranches].join(' -> ')})` : ''}. This is fix round ${round} of ${MAX_FIX_ROUNDS}.
+
+${WORKTREE}Check the branch out from its remote ref, fix every finding below, re-run the full check suite, and push.
+
+${review.blocking
+  .map((b, i) => `${i + 1}. ${b.file}${b.line ? `:${b.line}` : ''} — ${b.issue}\n   Failure: ${b.failure}\n   Suggested resolution: ${b.resolution}`)
+  .join('\n\n')}
+
+${review.redVerified === false ? `**The reviewer could not verify that your regression test fails without the fix**${review.redVerificationDetail ? ` — ${review.redVerificationDetail}` : ''}. Treat that as the finding to resolve first. Either the test does not actually reproduce the bug, or it reproduces it at a layer where reverting the source does not affect it. Re-derive it: revert your source change, watch the test fail, read the failure, and confirm it is this bug's symptom. Do not "fix" this by making the test stricter until it happens to fail.\n\n` : ''}Keep the change minimal and do not widen scope: a review round is not an opportunity to refactor. Do not weaken or delete the regression test to make a finding go away — if a finding says the test is wrong, make it reproduce the bug properly, and re-record its verbatim red output.
+
+Report the same structured result as before, describing the branch as it now stands, with the regression test's red evidence re-recorded if it changed.`
+
+// ---------------------------------------------------------------------------
+// Stage 4 — Land.
+
+const prPrompt = (t, fix) => {
+  const branches = [fix.branch, ...(fix.extraBranches ?? [])].filter(Boolean)
+  const n = branches.length
+  return `Open the pull request${n > 1 ? 's' : ''} for the fix to issue #${t.issue} — ${t.title}. ${gh}
+
+Branch${n > 1 ? 'es, in stack order' : ''}: ${branches.join(' -> ')}.
+
+- Open ${n > 1 ? 'one PR per branch' : 'the PR'} **ready for review, not draft**. That is a deliberate instruction for this pipeline: the branch has already been through an adversarial review, so a draft would just add a step.
+- ${n > 1 ? `The **first** PR's base is \`${BASE_BRANCH}\`; every later PR's base is the **previous branch in the stack** (\`gh pr create --base <prev-branch>\`), so each diff shows only its own slice. Title each "Fix: <what> (i/${n})".` : `Base it on \`${BASE_BRANCH}\`. Title it "Fix: <what was broken, in a few words>" — the title says what was wrong, not what file changed.`}
+- Cap each PR at **400 changed lines** (added + deleted in product and test code; generated files, lockfiles and vendored assets excluded). If a diff exceeds that, do **not** open an oversized PR — report it in \`blocker\`.
+- Mirror \`.github/pull_request_template.md\` section by section:
+  - **What & why** — the symptom, the root cause in one sentence (${fix.rootCause}), and how the fix addresses the cause rather than the symptom. ${n > 1 ? `Name each PR's place in the stack ("2/${n}, builds on #<prev>").` : ''} Link the PRD requirement or invariant the bug violated.
+  - **Core flows** — ${t.flows?.length ? `${t.flows.join(', ')} — "untouched": this fix does not spec or complete a flow, and no flow spec was edited. Say that the specs still pass.` : `"None — bug fix, no core flow specced or completed by this PR."`}
+  - **Walkthrough** — ${fix.changesUi || t.changesUi ? `this fix changes something a user sees, so leave the placeholder \`<!-- walkthrough pending -->\` here; a later stage fills it in.` : `"No UI change."`}
+  - **Evidence** — the commands and their real results, **and the regression test's red→green transition**: paste the verbatim failure output from before the fix, name the command that produced it, and state that the reviewer independently reproduced that red. That paragraph is the reason the PR is trustworthy; do not summarise it away.
+  - **Acceptance criteria met** — the issue's checkboxes if it has them; otherwise state the reported symptom is gone and the regression test covers it.
+- \`Closes #${t.issue}\` on ${n > 1 ? 'the last PR only; `Refs #' + t.issue + '` on the others' : 'the PR'}.
+- Note in the body that the branch passed an adversarial Opus review before the PR was opened.
+
+${attribution}
+
+Return every PR you opened, marking which one closes the issue.`
+}
+
+const walkthroughPrompt = (t, fix, pr) => `Capture and publish the screenshot walkthrough for the fix to issue #${t.issue}, then request a preview deploy. The PR is **#${pr.number}** on branch \`${pr.branch}\`. ${gh}
+
+${WORKTREE}Check out \`origin/${pr.branch}\` and \`bun install\`.
+
+1. **Capture.** \`bun run walkthrough:capture\` for flows under \`e2e/flows\`, and/or \`bun run walkthrough:capture:emulator\` for flows under \`e2e-emulator/flows\`. Capture only runs for specs that pass, so a failure here means something is broken, not that the tooling is. Report it rather than working around it.${t.flows?.length ? ` The flows this bug affects are ${t.flows.join(', ')} — those are the ones worth showing.` : ` This bug links no core flow, so capture whatever flow walks through the changed surface. If none does, report \`captured: false\` with that reason: a fix with no flow covering its surface is worth knowing about, and inventing a flow spec to fix that is not yours to do.`}
+2. **Publish.** \`bun run walkthrough:publish -- --issue ${t.issue}\`. This pushes the PNGs to the \`claude/walkthroughs\` orphan branch and prints Markdown. Images **cannot** be attached to a PR body through the API — that is exactly why this exists. Do not commit them to the fix branch and do not link a CI artifact instead.
+3. **Update the PR body.** Replace the \`<!-- walkthrough pending -->\` placeholder in #${pr.number} with the printed Markdown verbatim, keeping the rest of the body intact (\`gh pr view ${pr.number} --json body\`, edit, \`gh pr edit ${pr.number} --body-file\`). Re-read the rendered PR and confirm the images actually load — a broken raw URL renders as a broken-image icon and looks, at a glance, like a walkthrough.
+4. **Request the preview.** \`gh pr edit ${pr.number} --add-label deploy-preview\`, but check two things first, because a preview runs against the **live production** Firestore, Auth and Storage and its smoke test leaves a real anonymous project there:
+   - CI is green on #${pr.number}.
+   - The branch does not change \`firestore.rules\` or \`storage.rules\`. A preview always runs against production's *current* rules, so it cannot prove a rules change, and an unreviewed branch must not reach production's access rules. If it does touch either, skip the label, say so in \`detail\`, and note it on the PR.
+
+Report what you captured, whether the body was updated and the images render, and whether the label was added.`
+
+// ---------------------------------------------------------------------------
+// Stage 3b — the notification, when the loop runs out.
+//
+// Requested explicitly: a review that still wants changes after the rounds are
+// spent goes back to the human, and the findings are written to the issue so
+// they outlive the session that produced them.
+
+const notifyPrompt = (t, fix, review) => `Post one comment on \`afternoon/solid-groove\` issue #${t.issue} recording that the automated fix pipeline stopped. ${gh} Post exactly one comment. Change nothing else — do not label, close, assign, or edit the issue body.
+
+Write it for the human who has to pick this up. Include, in this order:
+
+1. One line: the fix attempt for this bug did not pass adversarial review after ${MAX_FIX_ROUNDS} fix round${MAX_FIX_ROUNDS > 1 ? 's' : ''}, and the branch \`${fix.branch}\` is pushed and left open with no PR.
+2. The root cause the fixer identified: ${fix.rootCause}
+3. The blocking findings that remain, verbatim, as a numbered list — file and line, what is wrong, the concrete failure, and the suggested resolution:
+
+${review.blocking.map((b, i) => `${i + 1}. ${b.file}${b.line ? `:${b.line}` : ''} — ${b.issue}\n   Failure: ${b.failure}\n   Suggested resolution: ${b.resolution}`).join('\n\n')}
+${review.redVerified === false ? `\n4. That the reviewer could **not** independently verify the regression test fails without the fix${review.redVerificationDetail ? `: ${review.redVerificationDetail}` : ''}. Flag this as the finding to resolve first — until it holds, nothing else about the fix is proven.\n` : ''}
+Do not soften the findings, do not add your own analysis, and do not speculate about which is easiest to fix. Report them as they are.
+
+${attribution}`
+
+// ---------------------------------------------------------------------------
+
+const config = typeof args === 'number' ? { issue: args } : args && typeof args === 'object' && !Array.isArray(args) ? args : {}
+const issueNumber = Number(config.issue ?? config.issueNumber)
+if (!Number.isInteger(issueNumber) || issueNumber <= 0)
+  throw new Error(`solid-groove-fix needs a GitHub issue number: { issue: 123 }. Got ${JSON.stringify(args)}.`)
+
+phase('Triage')
+const t = await agent(triagePrompt(issueNumber), {
+  model: 'opus',
+  label: `triage:#${issueNumber}`,
+  phase: 'Triage',
+  schema: TRIAGE_SCHEMA,
+})
+if (!t) throw new Error(`Could not read issue #${issueNumber}.`)
+t.ambiguities = Array.isArray(t.ambiguities) ? t.ambiguities : []
+t.flows = Array.isArray(t.flows) ? t.flows : []
+
+log(`#${t.issue} ${t.title} — ${t.ambiguous ? `AMBIGUOUS (${t.ambiguities.length} open question${t.ambiguities.length === 1 ? '' : 's'})` : 'actionable'}${t.changesUi ? ', changes the UI' : ''}`)
+
+if (t.ambiguous || t.ambiguities.length > 0)
+  return {
+    issue: t.issue,
+    title: t.title,
+    status: 'blocked-on-ambiguous-issue',
+    stage: 'Triage',
+    ambiguities: t.ambiguities,
+    expected: t.expected,
+    actual: t.actual,
+    decisionBlockers: t.decisionBlockers ?? [],
+    note: `#${t.issue} cannot be fixed as written: ${t.ambiguities.length} question${t.ambiguities.length === 1 ? '' : 's'} need${t.ambiguities.length === 1 ? 's' : ''} a human answer. Nothing was built, no branch was pushed, and nothing was written to GitHub. Answering on the issue and re-running is the next step.`,
+  }
+
+phase('Fix')
+let fix = await agent(fixPrompt(t), {
+  model: 'opus',
+  label: `fix:#${t.issue}`,
+  phase: 'Fix',
+  isolation: 'worktree',
+  schema: FIX_SCHEMA,
+})
+if (!fix) throw new Error(`Fixer returned nothing for #${t.issue}.`)
+
+// Not reproducing is a legitimate, reportable outcome — and the one case where
+// continuing would be actively harmful, since everything downstream is built on
+// a regression test that does not exist.
+if (fix.reproduced === false || !fix.branch)
+  return {
+    issue: t.issue,
+    title: t.title,
+    status: 'not-reproduced',
+    stage: 'Fix',
+    expected: t.expected,
+    actual: t.actual,
+    reproduction: t.reproduction,
+    detail: fix.summary,
+    unresolved: fix.unresolved ?? [],
+    note: `The bug could not be reproduced at any layer, so no fix was written and no branch was pushed. A speculative fix would close the issue without addressing anything.`,
+  }
+
+log(`#${t.issue}: ${fix.branch} — ${fix.rootCause}`)
+
+phase('Review')
+let review = null
+for (let round = 0; round <= MAX_FIX_ROUNDS; round++) {
+  review = await agent(reviewPrompt(t, fix, round + 1), {
+    model: 'opus',
+    effort: 'high',
+    label: `review:#${t.issue}#${round + 1}`,
+    phase: 'Review',
+    isolation: 'worktree',
+    schema: REVIEW_SCHEMA,
+  })
+  if (!review) throw new Error(`Reviewer returned nothing for #${t.issue}.`)
+
+  if (review.approved && review.redVerified !== false) break
+
+  // An approval that could not confirm the red is not an approval. The whole
+  // pipeline rests on that one check, so it is promoted to a blocking finding
+  // rather than left as a note the PR body would quietly inherit.
+  if (review.approved && review.redVerified === false) {
+    review.approved = false
+    review.blocking = [
+      ...(review.blocking ?? []),
+      {
+        file: fix.regressionTest?.path ?? '(regression test)',
+        issue: 'The reviewer could not verify that the regression test fails without the fix',
+        failure: review.redVerificationDetail || 'Reverting the source change did not make the regression test fail, so the test does not prove the bug was fixed and will not catch its return.',
+        resolution: 'Make the test reproduce the reported symptom, confirm it fails for that reason with the source reverted, and re-record the verbatim failure output.',
+      },
+    ]
+  }
+
+  review.blocking = Array.isArray(review.blocking) ? review.blocking : []
+  log(`#${t.issue}: review round ${round + 1} returned ${review.blocking.length} blocking finding(s)`)
+  if (round === MAX_FIX_ROUNDS) break
+
+  const refixed = await agent(refixPrompt(t, fix, review, round + 1), {
+    model: 'opus',
+    label: `refix:#${t.issue}#${round + 1}`,
+    phase: 'Review',
+    isolation: 'worktree',
+    schema: FIX_SCHEMA,
+  })
+  if (refixed) {
+    refixed.branch = refixed.branch || fix.branch
+    fix = refixed
+  }
+}
+
+if (!review.approved) {
+  await agent(notifyPrompt(t, fix, review), { model: 'sonnet', label: `notify:#${t.issue}`, phase: 'Review' })
+  return {
+    issue: t.issue,
+    title: t.title,
+    status: 'blocked-on-review',
+    stage: 'Review',
+    branch: fix.branch,
+    rootCause: fix.rootCause,
+    blocking: review.blocking,
+    redVerified: review.redVerified ?? null,
+    redVerificationDetail: review.redVerificationDetail ?? '',
+    unresolved: fix.unresolved ?? [],
+    note: `Still requesting changes after ${MAX_FIX_ROUNDS} fix round${MAX_FIX_ROUNDS > 1 ? 's' : ''}. Branch \`${fix.branch}\` is pushed and left open, no PR was opened, and the findings were commented on #${t.issue}.`,
+  }
+}
+
+phase('Land')
+const landed = await agent(prPrompt(t, fix), { model: 'sonnet', label: `pr:#${t.issue}`, phase: 'Land', schema: PR_SCHEMA })
+const pullRequests = landed?.pullRequests ?? []
+const closingPr = pullRequests.find((pr) => pr.closesIssue) ?? pullRequests[pullRequests.length - 1] ?? null
+
+if (landed?.blocker) log(`#${t.issue}: ${landed.blocker}`)
+
+phase('Walkthrough')
+let walkthrough = null
+if (!closingPr) {
+  log(`#${t.issue}: no PR was opened, so there is nothing to attach a walkthrough to.`)
+} else if (!(fix.changesUi || t.changesUi)) {
+  log(`#${t.issue}: the fix changes nothing a user sees, so no walkthrough was captured.`)
+} else {
+  walkthrough = await agent(walkthroughPrompt(t, fix, closingPr), {
+    model: 'sonnet',
+    label: `walkthrough:#${t.issue}`,
+    phase: 'Walkthrough',
+    isolation: 'worktree',
+    schema: WALKTHROUGH_SCHEMA,
+  })
+  if (!walkthrough?.published)
+    log(`#${t.issue}: walkthrough NOT published (${walkthrough?.detail ?? 'agent returned nothing'}) — #${closingPr.number} changes the UI and needs one.`)
+  if (walkthrough && !walkthrough.labelled)
+    log(`#${t.issue}: deploy-preview not added to #${closingPr.number} (${walkthrough.detail ?? 'no reason reported'}).`)
+}
+
+return {
+  issue: t.issue,
+  title: t.title,
+  status: 'open-for-review',
+  rootCause: fix.rootCause,
+  branch: fix.branch,
+  regressionTest: fix.regressionTest,
+  redVerifiedByReviewer: review.redVerified ?? null,
+  pullRequests,
+  closingPr,
+  walkthrough,
+  reviewNotes: review.notes ?? [],
+  alsoAffected: fix.alsoAffected ?? [],
+  unresolved: fix.unresolved ?? [],
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,32 @@ actually return `200` rather than rendering as broken icons. The workflow and ag
 human-approved: an agent running the skill reports a problem with them and never
 edits them.
 
+### Fixing a bug
+
+A bug is not a small feature, and it runs through its own pipeline:
+`.claude/workflows/solid-groove-fix.js`, invoked as **`/fix #123`**
+(`.claude/skills/fix/`). The difference is where the contract comes from. A
+feature is measured against core-flow specs written before it; a bug is measured
+against a **regression test written during the fix**, so the pipeline is built
+around making that test trustworthy: the fixer reproduces the bug and keeps the
+verbatim failure output from before the fix existed, and the reviewer
+independently reverts the source change and confirms the test goes red for the
+reported symptom. A test that turns out to pass without the fix is blocking, and
+an approval that could not confirm the red is not an approval.
+
+Two outcomes short of a PR are first-class, because both are cheaper than the
+alternative. The pipeline **stops before building anything** when the issue is
+ambiguous — the symptom is not identifiable, the correct behavior is neither
+stated nor derivable from the PRD, the "bug" is a feature request, or an open
+`DEC-*` gates the answer — rather than inventing the expected behavior and
+shipping a regression test that defends it. It stops again if the bug cannot be
+reproduced at any layer, rather than writing a speculative fix that closes the
+issue without addressing anything. If the review still requests changes after two
+fix rounds it leaves the branch open, opens no PR, and comments the findings on
+the issue. A bug fix never edits `docs/prd.md`, `docs/core-flows.md`, or a flow
+spec — including removing a `test.fixme` marker, which belongs to the feature
+that delivers the flow.
+
 ### Landing work
 
 1. **A PR is a single reviewable unit of purpose, not a whole task.** Each agent works in its own git worktree so parallel implementations do not collide on the filesystem, and a broken PR never blocks review of an unrelated one. One PR does one thing a reviewer can hold in their head at once — "introduce the *X* commands", "add the *Y* domain entity and its schema", "wire the *Z* panel UI onto existing commands". A task that cannot be delivered as one such unit is **split into several stacked PRs**, sequenced so each builds on the last (see item 5).


### PR DESCRIPTION
## What & why

Adds the bug counterpart of `/implement-feature`: a `/fix #123` skill, the
`solid-groove-fix` workflow it drives, and a `solid-groove-bug-fixer` agent.

The feature pipeline is built around a contract written *before* the work — the
core flows. A bug has no such contract, so this one is built around the contract
written *during* the work: the regression test. That reframing drives every
design decision here.

**The red-first rule.** A test written after a fix, against the fixed code, tends
to assert what the code now does rather than what it should do. It would have
passed before the fix too, it reads as coverage, and it will not catch the
regression it exists to catch. So the fixer must watch the test fail before the
fix exists and keep the **verbatim** output plus the command that produced it,
and the reviewer must **independently** revert the source change and reproduce
that red — checking it fails on the bug's symptom, not on a missing import or a
type error from the reverted code. An approval that could not confirm the red is
downgraded to a blocking finding in the workflow rather than left as a note the
PR body would quietly inherit.

**Two outcomes short of a PR are first-class**, because both are cheaper than the
alternative:

- `blocked-on-ambiguous-issue` — no identifiable symptom, the correct behavior is
  neither stated nor derivable from the PRD, the "bug" is a feature request,
  materially different fixes are equally defensible, an open `DEC-*` gates the
  answer, or it is several bugs. Nothing is built and nothing is written to
  GitHub. Guessing here produces a confident wrong fix with a regression test
  defending it, which is strictly worse than stopping. Terseness explicitly does
  *not* count: not knowing the cause is the job, not knowing the target is the
  blocker.
- `not-reproduced` — the fixer could not reproduce the bug at any layer, so it
  pushes nothing. A speculative fix closes the issue without addressing anything.

**The loop.** Review → fix → review → fix → review (`MAX_FIX_ROUNDS = 2`). Still
requesting changes after that, it leaves the branch open, opens no PR, and
comments the blocking findings on the issue verbatim, per the requested
notification behaviour. Otherwise it opens the PR **ready for review** — the
branch has already survived an adversarial review, so a draft would just add a
step.

**Reuse over forking.** The reviewer agent is `solid-groove-reviewer` unchanged:
its checks on published contracts, the section 9.5 invariants, resource
lifecycle, scope and PR size apply to a bug fix as they are, and a near-copy
would drift. The bug-specific checks — verify the red, is it a fix or a disguise,
is the test at the right layer, is it minimal — are layered on in the prompt. The
worktree/environment briefing is kept verbatim from `solid-groove-feature.js` for
the same reason (that comment is in both files).

A bug fix never edits `docs/prd.md`, `docs/core-flows.md`, or a flow spec —
including removing a `test.fixme` marker, which belongs to the feature that
delivers the flow. The skill and both agent definitions state it; the workflow's
review prompt asserts the diff against those paths is empty.

## Core flows

None — this changes no product code, so it specs and completes no flow.

## Walkthrough

No UI change. This is tooling under `.claude/`; nothing a user of the app sees is
touched.

## Evidence

```
$ bun run check:ci
$ tsc --noEmit && biome check
Checked 483 files in 551ms. No fixes applied.
```

Both workflow scripts syntax-checked as the runtime evaluates them (module body
wrapped in an async function so the top-level `return` parses), against the
existing `solid-groove-feature.js` as a control:

```
solid-groove-fix: syntax OK
solid-groove-feature: syntax OK
```

`bun run test` was not run: the diff contains no TypeScript and no product or
test code, so there is nothing in it for the suite to exercise. The two skills
are registered and resolve (`/fix` and the `solid-groove-fix` workflow both
appear in the session's skill listing).

**The pipeline has not been run end to end against a real bug issue.** It is
reviewed as a definition, like the feature workflow was; the first `/fix` run is
where its prompts get their real test.

## Acceptance criteria met

No issue — this was a direct request. Against what was asked for:

- [x] Invoked as `/fix #123`
- [x] Reads the issue and fails if it is ambiguous, with the ambiguity tests written down rather than left to judgement
- [x] A subagent implements the fix
- [x] A subagent adversarially reviews it
- [x] Requested changes are fixed
- [x] The review–fix loop repeats twice, then fails and notifies — in chat and as an issue comment
- [x] Pushes the branch and opens a PR ready for review

Not asked for, added because the repo's own conventions require it: the
`not-reproduced` stop, the 400-line/single-purpose cap on the fix PR, the
walkthrough + `deploy-preview` stage when the fix changes the UI, and the
`CLAUDE.md` section documenting the pipeline next to the feature one.

Note on this PR's own size: 1,011 lines added, all of it agent and workflow
definitions plus documentation. The 400-line ceiling in `CLAUDE.md` counts
product and test code, of which this has none — but flagging it rather than
letting it pass silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_013foUzNL7kEHgVkWqzrnTDj)_