### PR TITLE
Read the sample library from Cloud Storage rather than same-origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_AUTH_DOMAIN=
 VITE_FIREBASE_PROJECT_ID=
 VITE_FIREBASE_DATABASE_URL=
+# Also where the client reads the sample library from: the browser fetches the
+# pack index, pack manifests, and asset audio out of this bucket's `library/`
+# prefix (docs/sample-library.md section 12). Leave it unset and the library is
+# served same-origin from `public/samples/starter-library` instead, which is
+# what `bun run library:build` renders for local development.
 VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
@@ -42,7 +47,10 @@ VITE_FIREBASE_MEASUREMENT_ID=
 # bundle, and the service account belongs in CI secrets rather than on a
 # developer machine.
 #
-# Bucket to publish to. Falls back to VITE_FIREBASE_STORAGE_BUCKET above.
+# Bucket to publish to. Falls back to VITE_FIREBASE_STORAGE_BUCKET above, which
+# is also the bucket the client reads the library from — keep them the same
+# unless you are deliberately publishing somewhere else, or the browser will
+# read a library this never wrote to.
 # FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
 #
 # Credentials — set exactly one:

--- a/src/library/libraryClient.test.ts
+++ b/src/library/libraryClient.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import { fixtureFetcher } from "./__fixtures__/fixtures";
 import {
 	FetchClassifiedError,
+	httpJsonFetcher,
 	type JsonFetcher,
 	LibraryClient,
 	type LibraryIndexError,
 } from "./libraryClient";
-import { type LibraryPackSummary, PACK_INDEX_PATH } from "./manifest";
+import {
+	type LibraryPackSummary,
+	libraryUrl,
+	PACK_INDEX_PATH,
+} from "./manifest";
 
 async function loadedClient(): Promise<{
 	client: LibraryClient;
@@ -16,6 +21,40 @@ async function loadedClient(): Promise<{
 	const packs = await client.loadIndex();
 	return { client, packs };
 }
+
+describe("the default fetcher (issue #226)", () => {
+	it("requests the resolved delivery URL verbatim", async () => {
+		// The URL already carries its origin. Prefixing it here — as this did
+		// while the library was same-origin only — turns a Cloud Storage URL into
+		// a same-origin path that a SPA server answers with `index.html`.
+		const url = libraryUrl(
+			"packs/index.json",
+			"groove-test.firebasestorage.app",
+		);
+		const fetch = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(Response.json({ ok: true }));
+		try {
+			await httpJsonFetcher(url);
+			expect(fetch).toHaveBeenCalledWith(url);
+		} finally {
+			fetch.mockRestore();
+		}
+	});
+
+	it("classifies a 404 as not_found rather than corrupt", async () => {
+		const fetch = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("", { status: 404 }));
+		try {
+			await expect(httpJsonFetcher("/x.json")).rejects.toMatchObject({
+				reason: "not_found",
+			});
+		} finally {
+			fetch.mockRestore();
+		}
+	});
+});
 
 describe("lazy loading (sample-library section 12)", () => {
 	it("fetches the pack index and no manifest to open", async () => {

--- a/src/library/libraryClient.ts
+++ b/src/library/libraryClient.ts
@@ -25,8 +25,8 @@ import {
  * delivery, the mock backend, and a unit test.
  */
 
-/** Fetches a JSON document by served-root-relative path. Injected for tests. */
-export type JsonFetcher = (path: string) => Promise<unknown>;
+/** Fetches a JSON document by delivery URL. Injected for tests. */
+export type JsonFetcher = (url: string) => Promise<unknown>;
 
 /** Why a pack (or the index) could not be loaded — mapped to an analytics code. */
 export type LibraryLoadReason = "network" | "not_found" | "corrupt" | "timeout";
@@ -54,14 +54,18 @@ export type PackLoadResult =
 	| { readonly ok: false; readonly error: PackLoadError };
 
 /**
- * The default fetcher: a same-origin GET of a static delivery file.
+ * The default fetcher: a GET of a static delivery document.
+ *
+ * The URL is already resolved against the delivery origin by `manifest.ts` —
+ * Cloud Storage in a deployed build, same-origin `public/` in local
+ * development — so this never builds a path of its own.
  *
  * Classifies the failure so the browser can report an actionable, non-leaking
  * reason (and the analytics `error_code`) without the caller re-inspecting the
  * `Response`.
  */
-export function httpJsonFetcher(path: string): Promise<unknown> {
-	return fetch(`/${path}`).then(
+export function httpJsonFetcher(url: string): Promise<unknown> {
+	return fetch(url).then(
 		async (response) => {
 			if (!response.ok) {
 				const reason: LibraryLoadReason =

--- a/src/library/manifest.test.ts
+++ b/src/library/manifest.test.ts
@@ -6,25 +6,102 @@ import {
 import {
 	assetAudioUrl,
 	LIBRARY_ROOT,
+	libraryKey,
+	libraryUrl,
 	PACK_INDEX_PATH,
 	packAssets,
 	packManifestPath,
 	packSummaries,
 	parsePackIndex,
 	parsePackManifest,
+	resolveLibraryBucket,
+	STORAGE_PREFIX,
 } from "./manifest";
+
+const BUCKET = "groove-test.firebasestorage.app";
 
 describe("delivery layout", () => {
 	it("resolves the pack index and a manifest under the one library root", () => {
-		expect(PACK_INDEX_PATH).toBe(`${LIBRARY_ROOT}/packs/index.json`);
+		expect(PACK_INDEX_PATH).toBe(`/${LIBRARY_ROOT}/packs/index.json`);
 		expect(packManifestPath("core-electronic-drums", "1.0.0")).toBe(
-			`${LIBRARY_ROOT}/packs/core-electronic-drums/v1.0.0.json`,
+			`/${LIBRARY_ROOT}/packs/core-electronic-drums/v1.0.0.json`,
 		);
 	});
 
 	it("builds an asset audio URL from its storage key", () => {
 		expect(assetAudioUrl("sha256/ab/cd/abcd.wav")).toBe(
 			`/${LIBRARY_ROOT}/audio/sha256/ab/cd/abcd.wav`,
+		);
+	});
+});
+
+describe("delivery origin (issue #226)", () => {
+	it("reads the configured bucket, treating unset and blank as no bucket", () => {
+		expect(resolveLibraryBucket(BUCKET)).toBe(BUCKET);
+		expect(resolveLibraryBucket(undefined)).toBeNull();
+		expect(resolveLibraryBucket("")).toBeNull();
+		expect(resolveLibraryBucket("  ")).toBeNull();
+	});
+
+	it("serves from Cloud Storage when a bucket is configured", () => {
+		// `storage.rules` — not GCS IAM — is what opens `library/`, so the URL
+		// must be the endpoint that enforces those rules, with the object path
+		// encoded as one segment.
+		expect(libraryUrl("packs/index.json", BUCKET)).toBe(
+			`https://firebasestorage.googleapis.com/v0/b/${BUCKET}/o/` +
+				`${encodeURIComponent(`${STORAGE_PREFIX}/packs/index.json`)}?alt=media`,
+		);
+		expect(libraryUrl("audio/sha256/ab/cd/abcd.wav", BUCKET)).toContain(
+			encodeURIComponent(`${STORAGE_PREFIX}/audio/sha256/ab/cd/abcd.wav`),
+		);
+	});
+
+	it("falls back to same-origin so local development keeps working", () => {
+		expect(libraryUrl("packs/index.json", null)).toBe(
+			`/${LIBRARY_ROOT}/packs/index.json`,
+		);
+	});
+
+	it("normalizes the path forms the two publishers write", () => {
+		// build.mjs states them root-relative; upload.mjs rewrites them to bucket
+		// object keys. Both name the same object.
+		expect(libraryKey("packs/x/v1.0.0.json")).toBe("packs/x/v1.0.0.json");
+		expect(libraryKey(`${STORAGE_PREFIX}/packs/x/v1.0.0.json`)).toBe(
+			"packs/x/v1.0.0.json",
+		);
+		expect(libraryKey(`/${LIBRARY_ROOT}/packs/x/v1.0.0.json`)).toBe(
+			"packs/x/v1.0.0.json",
+		);
+	});
+
+	it("resolves an uploaded index's bucket-keyed manifestPath onto the bucket", () => {
+		const summaries = packSummaries(
+			parsePackIndex({
+				schemaVersion: 1,
+				generatedAt: "2026-01-01T00:00:00.000Z",
+				packs: [
+					{
+						id: "pak_SdlN_OazweXrwury0j27Y",
+						slug: "core-electronic-drums",
+						name: "Core Electronic Drums",
+						version: "1.0.0",
+						publisher: "Solid Groove",
+						kind: "factory",
+						description: "",
+						assetCount: 1,
+						// The form `upload.mjs:202` publishes.
+						manifestPath: `${STORAGE_PREFIX}/packs/core-electronic-drums/v1.0.0.json`,
+					},
+				],
+			}),
+		);
+		expect(summaries[0].manifestPath).toBe(
+			libraryUrl("packs/core-electronic-drums/v1.0.0.json"),
+		);
+		// Never the raw object key: fetching that verbatim is what a SPA server
+		// answers with `index.html`.
+		expect(summaries[0].manifestPath).not.toBe(
+			`${STORAGE_PREFIX}/packs/core-electronic-drums/v1.0.0.json`,
 		);
 	});
 });

--- a/src/library/manifest.ts
+++ b/src/library/manifest.ts
@@ -27,19 +27,94 @@ import { packIdSchema } from "../domain/ids";
 // ---------------------------------------------------------------------------
 
 /**
- * The served root the generator writes under (`scripts/starter-library/`'s
- * `RUNTIME_AUDIO_PREFIX` and delivery layout). Assets, the pack index, and pack
- * manifests all live below it, so one prefix resolves every library URL and no
- * caller hand-writes a path (sample-library principle 10).
+ * The bucket prefix every library object lives under, matching
+ * `scripts/starter-library/upload.mjs`'s `STORAGE_PREFIX` — and the one path
+ * `storage.rules` opens for unauthenticated reads.
+ */
+export const STORAGE_PREFIX = "library";
+
+/**
+ * The same-origin root `bun run library:build` renders into
+ * (`public/samples/starter-library`), used when no bucket is configured.
+ *
+ * The two layouts are identical below their root — build.mjs mirrors the bucket
+ * "exactly, so `upload.mjs` is a straight copy" — so a delivery key is the same
+ * string either way and only the origin in front of it differs.
  */
 export const LIBRARY_ROOT = "samples/starter-library";
 
 /** The compact pack index a client fetches before any pack manifest. */
-export const PACK_INDEX_PATH = `${LIBRARY_ROOT}/packs/index.json`;
+export const PACK_INDEX_KEY = "packs/index.json";
+
+/**
+ * The bucket the library is delivered from, or `null` for same-origin delivery.
+ *
+ * Production reads the library out of Cloud Storage (sample-library section 12,
+ * "Store the complete alpha library in Cloud Storage for Firebase"): that is
+ * where `bun run library:upload` publishes it, and the only path
+ * `storage.rules` makes publicly readable. Same-origin is the fallback for
+ * local development, the mock backend, and the browser suites, which serve
+ * `library:build`'s output out of `public/` and have no bucket at all.
+ *
+ * Falling back rather than throwing is deliberate: every non-production mode
+ * legitimately has no bucket, and `VITE_DEV_BACKEND` already owns the "which
+ * backend" decision loudly. What must not happen is the reverse — a deployed
+ * build silently fetching a library that was never rendered into its own
+ * Hosting artefact, which is what issue #226 reported.
+ */
+export function resolveLibraryBucket(
+	raw: string | undefined = import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+): string | null {
+	const bucket = raw?.trim();
+	return bucket ? bucket : null;
+}
+
+/** The bucket this page load delivers the library from. */
+export const libraryBucket: string | null = resolveLibraryBucket();
+
+/**
+ * Normalize a delivered path to a key relative to the library root.
+ *
+ * A manifest states its own paths, and the two publishers state them
+ * differently: `build.mjs` writes them root-relative (`packs/…`) while
+ * `upload.mjs` rewrites them to bucket object keys (`library/packs/…`). Both
+ * name the same object, so both are normalized here rather than at each call
+ * site.
+ */
+export function libraryKey(path: string): string {
+	const trimmed = path.replace(/^\/+/, "");
+	for (const prefix of [`${STORAGE_PREFIX}/`, `${LIBRARY_ROOT}/`])
+		if (trimmed.startsWith(prefix)) return trimmed.slice(prefix.length);
+	return trimmed;
+}
+
+/**
+ * The URL one library key is fetched from — the single place either delivery
+ * origin is written down, so no caller hand-writes a path (sample-library
+ * principle 10).
+ *
+ * The bucket form is Firebase Storage's download endpoint rather than
+ * `storage.googleapis.com`, because it is `storage.rules` — not GCS IAM — that
+ * makes `library/` publicly readable, and only this endpoint enforces those
+ * rules. The object path is a single encoded path segment, so its slashes are
+ * escaped.
+ */
+export function libraryUrl(
+	key: string,
+	bucket: string | null = libraryBucket,
+): string {
+	const normalized = libraryKey(key);
+	if (!bucket) return `/${LIBRARY_ROOT}/${normalized}`;
+	const object = encodeURIComponent(`${STORAGE_PREFIX}/${normalized}`);
+	return `https://firebasestorage.googleapis.com/v0/b/${bucket}/o/${object}?alt=media`;
+}
+
+/** The pack index URL for this page load's delivery origin. */
+export const PACK_INDEX_PATH = libraryUrl(PACK_INDEX_KEY);
 
 /** The immutable manifest URL for one pack version. */
 export function packManifestPath(slug: string, version: string): string {
-	return `${LIBRARY_ROOT}/packs/${slug}/v${version}.json`;
+	return libraryUrl(`packs/${slug}/v${version}.json`);
 }
 
 /**
@@ -48,7 +123,7 @@ export function packManifestPath(slug: string, version: string): string {
  * library root, mirroring the bucket exactly.
  */
 export function assetAudioUrl(storageKey: string): string {
-	return `/${LIBRARY_ROOT}/audio/${storageKey}`;
+	return libraryUrl(`audio/${storageKey}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -218,11 +293,11 @@ export function packSummaries(index: PackIndex): LibraryPackSummary[] {
 		kind: entry.kind,
 		description: entry.description,
 		assetCount: entry.assetCount,
-		// The index states `manifestPath` relative to the library root
-		// (`packs/<slug>/v...`); resolve it to a served-root path so the client
-		// fetches `samples/starter-library/packs/...` rather than `/packs/...`,
-		// which a SPA dev server would answer with `index.html` (a "corrupt"
-		// non-JSON body).
+		// The index states `manifestPath` in its publisher's own terms — root
+		// relative from `build.mjs`, a `library/…` object key from `upload.mjs` —
+		// so resolve it to a full delivery URL here. Fetching it verbatim would
+		// ask a SPA server for `/packs/...` and get `index.html` back: a 200 with
+		// a non-JSON body, reported as "corrupt" (issue #226).
 		manifestPath: resolveManifestPath(
 			entry.manifestPath,
 			entry.slug,
@@ -232,10 +307,9 @@ export function packSummaries(index: PackIndex): LibraryPackSummary[] {
 }
 
 /**
- * Resolve an index row's `manifestPath` to a served-root path. Accepts either a
- * library-root-relative path (`packs/...`, the delivery layout) or an already
- * absolute/rooted one, and falls back to the canonical layout when the index
- * omits it.
+ * Resolve an index row's `manifestPath` to a full delivery URL. Accepts any of
+ * the forms a publisher writes — root-relative, bucket-object-keyed, or already
+ * rooted — and falls back to the canonical layout when the index omits it.
  */
 function resolveManifestPath(
 	manifestPath: string | undefined,
@@ -243,10 +317,7 @@ function resolveManifestPath(
 	version: string,
 ): string {
 	if (!manifestPath) return packManifestPath(slug, version);
-	if (manifestPath.startsWith(`${LIBRARY_ROOT}/`)) return manifestPath;
-	if (manifestPath.startsWith("packs/"))
-		return `${LIBRARY_ROOT}/${manifestPath}`;
-	return manifestPath;
+	return libraryUrl(manifestPath);
 }
 
 /** Parse a fetched pack manifest, throwing when it is malformed. */


### PR DESCRIPTION
## What & why

The library browser reported "The library data could not be read." on production. The pack index was never there to read.

`library:build` is not in the deploy chain (`deploy → predeploy → build → prebuild → samples`, which runs `generate-samples.mjs` and `emitRuntime.mjs` only), and `public/samples` is gitignored, so the deployed artefact carries just the three bootstrap assets. Reproduced locally with `bun run samples`:

```
public/samples/starter-library/audio/sha256/f1/66/f166266c….wav
public/samples/starter-library/audio/sha256/0a/d8/0ad83302….wav
public/samples/starter-library/audio/sha256/82/f8/82f89d1d….wav
packs/index.json present? -> NO
```

Hosting's `"source": "**"` → `/index.html` rewrite then answers the index fetch with 200 + the SPA shell, `response.json()` throws, and a *missing* library is reported as a *corrupt* one.

Publishing the library would not have fixed it either, which is the finding that shaped this PR: `upload.mjs` writes to Cloud Storage under `library/`, and the client only ever fetched same-origin (`libraryClient.ts:64`, `manifest.ts:35`). The two halves of the delivery pipeline never met. `docs/sample-library.md` §12 is explicit that the library lives in Cloud Storage, and `storage.rules` already opens `library/` to unauthenticated reads — only the client was missing.

So every library URL now resolves through one `libraryUrl()` against a configured bucket, falling back to same-origin when there is none:

- **Bucket configured** → `https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<encoded library/…>?alt=media`. Firebase Storage's download endpoint, not `storage.googleapis.com`, because it is `storage.rules` — not GCS IAM — that makes `library/` public, and only this endpoint enforces those rules.
- **Unset** → `/samples/starter-library/…` exactly as before, so local development, the mock backend, and both browser suites keep serving `library:build`'s output out of `public/` unchanged.

The two layouts are identical below their root (build.mjs mirrors the bucket "exactly, so `upload.mjs` is a straight copy"), so a delivery key is the same string either way and only the origin differs. `libraryKey()` also normalizes the two forms the publishers write — root-relative from `build.mjs`, `library/…` object keys from `upload.mjs:202` — which the old `resolveManifestPath` did not handle.

**Configuration:** none new for production. `VITE_FIREBASE_STORAGE_BUCKET` is already a build input in both `ci.yml` and `preview.yml`. `.env.example` now documents that it feeds the client's library delivery as well as the SDK, and that `FIREBASE_STORAGE_BUCKET` (the uploader's) should match it.

**Deliberately out of scope**, per the product owner on #226:

- **Rendering the library in the deploy chain.** At ~42 MiB it belongs in the bucket, which is what this now reads. Tracked separately.
- **The `not_found` classifier.** A genuine 404 becomes reachable once the client fetches cross-origin, but the same-origin fallback keeps the catch-all-rewrite trap, so distinguishing an HTML body from a JSON one is still worth doing on its own. `Refs`, not `Closes`, for that reason.

**The bootstrap set is untouched.** `factoryLibrary.ts:109` builds its own same-origin URLs from `storageRef`, and those three files do ship in the Hosting artefact, so the starter project keeps working before any manifest fetch — §12's "keep only the bootstrap set in the initial application cache".

Refs #226

## Core flows

**Untouched.** #226 is a bug report and links no flow IDs. No spec was added, removed, or edited — `e2e/flows/CF-002.spec.ts` is the only flow file mentioning the library and it remains at `test.fixme` (it belongs to ARR-003, landed by #227). Verified: `git diff --stat origin/main -- e2e/ e2e-emulator/ docs/core-flows.md docs/prd.md` is empty.

Worth flagging for whoever picks up the follow-up: no e2e currently exercises the library browser against real delivery. `LibraryBrowser.tsx` → `useLibraryBrowser` → `new LibraryClient()` uses the real `httpJsonFetcher`, but every test injects a fetcher over `__fixtures__`. That is precisely why this shipped broken and stayed invisible.

## Walkthrough

**No UI change.** No component, layout, styling, copy, or interaction is touched — this changes only which origin the existing browser fetches from. The user-visible effect (the browser populating instead of showing the red error) cannot be captured here anyway: it needs the library published to the bucket, which is an ops step this PR does not perform.

## Evidence

```
$ bun run typecheck
$ tsc --noEmit                                    (clean)

$ bun run test
Test Files  167 passed (167)
     Tests  2255 passed (2255)

$ bun run check
Checked 483 files in 1074ms. Fixed 1 file.        (import ordering, committed)
```

Red before green — with the old `fetch(`/${url}`)` prefix restored, the new guard fails and everything else still passes:

```
× the default fetcher (issue #226) > requests the resolved delivery URL verbatim
✓ the default fetcher (issue #226) > classifies a 404 as not_found rather than corrupt
✓ lazy loading (sample-library section 12) > fetches the pack index and no manifest to open
  … 8 more passing
```

`bun run test:browser:chromium` — result appended as a comment when it finishes. Chromium-only is what this environment can install (it cannot reach `cdn.playwright.dev`), so it is a pre-flight, **not** PRD section 10 gating evidence; CI's full matrix on push is the cross-browser check.

Not run, with reasons: `test:emulator` and `test:browser:emulator` (no Firestore/Auth rules, persistence, or auth behavior touched); `library:test` (no script under `scripts/starter-library/` is modified — the bucket layout is read here, not changed).

## Acceptance criteria met

#226 has no acceptance checkboxes. Against its "Expected":

- ✅ **"Whatever guarantees the library is present in a deployed build is explicit."** It is delivered from the bucket `library:upload` publishes to, which is where §12 always said it lives, rather than depending on an undocumented local build step.
- ⬜ **"A missing library reports as missing, rather than as corrupt."** Not addressed — see out-of-scope above. Behind the same-origin fallback a missing library still reports `corrupt`.

One thing the PR cannot establish: I could not reach `https://groove-35c07.web.app` from my session (egress policy, 403 on CONNECT), so the production failure is diagnosed from the pipeline and reproduced locally, never observed live. Publishing the library to the bucket and confirming the browser populates is an ops step still outstanding — this change is what makes that publish take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017soVbsGgTHzA8Ek8ueuBs4

---
_Generated by [Claude Code](https://claude.ai/code/session_017soVbsGgTHzA8Ek8ueuBs4)_