### PR TITLE
Offer sampler, drum machine and synth when adding a track

### DIFF
--- a/e2e/mixer.spec.ts
+++ b/e2e/mixer.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { walkthrough } from "./support/walkthrough";
 
 // `LOOP-007`: the mixer's continuous controls are the shared fill slider
 // (`src/instrument/FillSlider.tsx`, design mock `06c-slider`) — a real range
@@ -149,5 +150,62 @@ test.describe("mixer", () => {
 		await solo.hover();
 		await page.waitForTimeout(600);
 		expect(await brightness()).toBeGreaterThan(200);
+	});
+
+	// Creating a track of a chosen instrument (#223). Asserted in a real browser
+	// because the affordance's job is only done when the new track is *reachable*
+	// — a strip in the mixer and a bar-1 clip in the arrangement — and both of
+	// those live outside the component a jsdom test renders.
+	test("creates a track of the instrument the button names", async ({
+		page,
+	}) => {
+		const step = walkthrough(page, {
+			id: "mixer-add-track",
+			title: "Add a sampler, a drum machine or a synth track",
+		});
+
+		await page.goto("/dashboard");
+		await page.getByRole("button", { name: "New Project" }).click();
+		await expect(page).toHaveURL(/\/projects\/prj_/);
+
+		const mixer = page.getByRole("region", { name: "Mixer" });
+		await mixer.scrollIntoViewIfNeeded();
+		await expect(mixer).toContainText("1 track");
+		await step("A new project opens with one track: the starter kick");
+
+		await page.getByRole("button", { name: "Add sampler track" }).click();
+		await expect(mixer).toContainText("2 tracks");
+		await expect(
+			page.getByRole("button", { name: "Mute Sampler" }),
+		).toBeVisible();
+		await step("Add a sampler track — a strip for it appears in the mixer");
+
+		await page.getByRole("button", { name: "Add drum machine track" }).click();
+		await expect(mixer).toContainText("3 tracks");
+		await expect(
+			page.getByRole("button", { name: "Mute Drum machine" }),
+		).toBeVisible();
+		await step("Add a drum machine track beside it");
+
+		// The new track arrives with a clip at bar 1, so there is something to
+		// program rather than an empty strip. The arrangement's track list is the
+		// DOM mirror of a canvas (`ArrangementView.tsx`) and so is visually hidden
+		// — dispatched rather than clicked, because a pointer cannot reach a
+		// clipped element and `force` would only paper over that.
+		await page
+			.getByRole("button", { name: "Select Sampler" })
+			.dispatchEvent("click");
+		await expect(page.getByTestId("arrangement-selection-live")).toContainText(
+			"Selected Sampler",
+		);
+		await step("Each new track arrives with an empty one-bar clip at bar 1");
+
+		// That clip is real, not a projection artefact: deleting the track warns
+		// that it would take one with it (PRD TRK-01).
+		await page.getByRole("button", { name: "Delete Sampler" }).click();
+		await expect(page.getByRole("alertdialog")).toContainText(
+			"This track has 1 clip",
+		);
+		await page.getByRole("button", { name: "Cancel" }).click();
 	});
 });

--- a/src/editor/Mixer.css
+++ b/src/editor/Mixer.css
@@ -33,13 +33,23 @@
 	font-variant-numeric: tabular-nums;
 }
 
-/* Ghost: no fill until hover, for a low-stakes repeated action (mock 06b).
-   It sits with the count rather than across the panel, so it stays next to the
-   strips it adds to however wide the workspace gets. */
+/* The three kinds sit together as one control, next to the count rather than
+   across the panel, so they stay beside the strips they add to however wide the
+   workspace gets. */
+.mixer-add-track-group {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	margin: 0 auto 0 0;
+	padding: 0;
+	border: 0;
+	min-inline-size: auto;
+}
+
+/* Ghost: no fill until hover, for a low-stakes repeated action (mock 06b). */
 .mixer-add-track {
 	display: inline-flex;
 	align-items: center;
-	margin-right: auto;
 	gap: 5px;
 	height: 22px;
 	padding: 0 8px;

--- a/src/editor/Mixer.test.tsx
+++ b/src/editor/Mixer.test.tsx
@@ -15,6 +15,7 @@ import {
 	createDrumMachineFixtureProject,
 	createSliceFixtureProject,
 } from "../domain/fixtures";
+import { TICKS_PER_BAR } from "../domain/time";
 import { memoryStorage } from "../testing/storage";
 import Mixer from "./Mixer";
 
@@ -89,7 +90,7 @@ describe("Mixer track management (TRK-01)", () => {
 		const { history, transport } = renderMixer();
 		const before = history.project.song.tracks.length;
 
-		fireEvent.click(screen.getByRole("button", { name: "Add track" }));
+		fireEvent.click(screen.getByRole("button", { name: "Add synth track" }));
 
 		expect(history.project.song.tracks.length).toBe(before + 1);
 		const added = transport.events.filter((e) => e.name === "track_added");
@@ -104,8 +105,8 @@ describe("Mixer track management (TRK-01)", () => {
 
 	it("emits the mixer feature key at most once across several adds", () => {
 		const { transport } = renderMixer();
-		fireEvent.click(screen.getByRole("button", { name: "Add track" }));
-		fireEvent.click(screen.getByRole("button", { name: "Add track" }));
+		fireEvent.click(screen.getByRole("button", { name: "Add synth track" }));
+		fireEvent.click(screen.getByRole("button", { name: "Add sampler track" }));
 		expect(
 			transport.events.filter((e) => e.name === "feature_first_use"),
 		).toHaveLength(1);
@@ -113,6 +114,89 @@ describe("Mixer track management (TRK-01)", () => {
 		expect(
 			transport.events.filter((e) => e.name === "track_added"),
 		).toHaveLength(2);
+	});
+
+	it("creates a track of the instrument the user asked for (#223)", () => {
+		const { history, transport } = renderMixer();
+
+		for (const [button, kind, analyticsType] of [
+			["Add sampler track", "sampler", "sampler"],
+			["Add drum machine track", "drumMachine", "drum_machine"],
+			["Add synth track", "synth", "synth"],
+		] as const) {
+			fireEvent.click(screen.getByRole("button", { name: button }));
+			const added = history.project.song.tracks.at(-1);
+			expect(added?.instrument?.kind, button).toBe(kind);
+			expect(
+				transport.events.filter((e) => e.name === "track_added").at(-1)?.params
+					.instrument_type,
+			).toBe(analyticsType);
+		}
+	});
+
+	it("gives a new track an empty one-bar clip to program, in one transaction", () => {
+		const { history } = renderMixer();
+		const revisionBefore = history.project.metadata.revision;
+
+		fireEvent.click(screen.getByRole("button", { name: "Add sampler track" }));
+
+		const track = history.project.song.tracks.at(-1);
+		const clip = history.project.clips.find((c) => c.trackId === track?.id);
+		expect(clip?.content).toEqual({ kind: "notes", events: [] });
+		expect(clip?.lengthTicks).toBe(TICKS_PER_BAR);
+		const placement = history.project.song.placements.find(
+			(p) => p.clipId === clip?.id,
+		);
+		expect(placement?.startTicks).toBe(0);
+		expect(placement?.durationTicks).toBe(TICKS_PER_BAR);
+
+		// Track, clip and placement arrive together: one revision, one undo.
+		expect(history.project.metadata.revision).toBe(revisionBefore + 1);
+		history.undo();
+		expect(history.project.song.tracks).toHaveLength(1);
+		expect(history.project.clips.some((c) => c.id === clip?.id)).toBe(false);
+	});
+
+	it("opens a new drum machine with a kit of empty pads", () => {
+		const { history } = renderMixer();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Add drum machine track" }),
+		);
+
+		const instrument = history.project.song.tracks.at(-1)?.instrument;
+		expect(instrument?.kind === "drumMachine" && instrument.pads).toMatchObject(
+			[
+				{ name: "BD", assetId: null },
+				{ name: "SD", assetId: null },
+				{ name: "HH", assetId: null },
+				{ name: "CP", assetId: null },
+			],
+		);
+	});
+
+	it("names each new track for its instrument, without repeating a name", () => {
+		const { history } = renderMixer();
+
+		fireEvent.click(screen.getByRole("button", { name: "Add sampler track" }));
+		fireEvent.click(screen.getByRole("button", { name: "Add sampler track" }));
+
+		expect(history.project.song.tracks.map((track) => track.name)).toEqual([
+			"BD",
+			"Sampler",
+			"Sampler 2",
+		]);
+	});
+
+	it("reports the duplicated track's own instrument on track_added", () => {
+		const { transport } = renderMixer(createDrumMachineFixtureProject());
+
+		fireEvent.click(screen.getAllByRole("button", { name: /^Duplicate / })[0]);
+
+		expect(
+			transport.events.filter((e) => e.name === "track_added").at(-1)?.params
+				.instrument_type,
+		).toBe("drum_machine");
 	});
 
 	it("renames a track through a command", () => {

--- a/src/editor/Mixer.tsx
+++ b/src/editor/Mixer.tsx
@@ -33,11 +33,7 @@ import {
 import ConfirmDialog from "../components/ConfirmDialog";
 import { duplicateTrack } from "../domain/duplicateTrack";
 import type { Project, Track } from "../domain/entities";
-import {
-	createFactoryContext,
-	createSynthInstrument,
-	createTrack,
-} from "../domain/factories";
+import { createFactoryContext } from "../domain/factories";
 import {
 	dbToFaderPosition,
 	faderPositionToDb,
@@ -48,6 +44,12 @@ import type { TrackId } from "../domain/ids";
 import { TRACK_PAN, TRACK_VOLUME } from "../domain/parameters";
 import FillSlider from "../instrument/FillSlider";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
+import {
+	createNewTrack,
+	instrumentTypeKey,
+	NEW_TRACK_KINDS,
+	type NewTrackKindSpec,
+} from "./trackCreation";
 import "./Mixer.css";
 
 /**
@@ -115,11 +117,25 @@ export default function Mixer(props: MixerProps): JSX.Element {
 			.length;
 	}
 
-	function handleAddTrack(): void {
-		const order = tracks().length;
-		const track = createTrackRecord(order);
-		props.dispatch(addTrack(track));
-		analytics().log("track_added", { track_type: "instrument" });
+	// Creating a track says which instrument it carries (#223). The new track
+	// arrives with an empty one-bar clip so it can be programmed straight away,
+	// and the whole thing is one `track.add` command: one revision, one undo.
+	function handleAddTrack(spec: NewTrackKindSpec): void {
+		const added = createNewTrack(factoryContext, {
+			kind: spec.kind,
+			order: tracks().length,
+			existingNames: tracks().map((track) => track.name),
+		});
+		props.dispatch(
+			addTrack(added.track, {
+				clips: [added.clip],
+				placements: [added.placement],
+			}),
+		);
+		analytics().log("track_added", {
+			track_type: "instrument",
+			instrument_type: spec.analyticsType,
+		});
 		analytics().logFeatureFirstUse("mixer");
 	}
 
@@ -134,7 +150,10 @@ export default function Mixer(props: MixerProps): JSX.Element {
 				automation: duplicate.automation,
 			}),
 		);
-		analytics().log("track_added", { track_type: trackTypeKey(track) });
+		analytics().log("track_added", {
+			track_type: trackTypeKey(track),
+			instrument_type: instrumentTypeKey(track.instrument),
+		});
 		analytics().logFeatureFirstUse("mixer");
 	}
 
@@ -162,10 +181,26 @@ export default function Mixer(props: MixerProps): JSX.Element {
 				<span class="mixer-track-count">
 					{trackIds().length} {trackIds().length === 1 ? "track" : "tracks"}
 				</span>
-				<button type="button" class="mixer-add-track" onClick={handleAddTrack}>
-					<HiSolidPlus size={13} />
-					<span>Add track</span>
-				</button>
+				{/* One button per instrument rather than one "Add track" plus a kind
+				    picker: adding a track is a two-decision action ("another track",
+				    "a sampler"), and a button per kind makes the second decision the
+				    click itself instead of a mode set beforehand. */}
+				<fieldset class="mixer-add-track-group" aria-label="Add track">
+					<For each={NEW_TRACK_KINDS}>
+						{(spec) => (
+							<button
+								type="button"
+								class="mixer-add-track"
+								aria-label={spec.actionLabel}
+								title={spec.actionLabel}
+								onClick={() => handleAddTrack(spec)}
+							>
+								<HiSolidPlus size={13} />
+								<span>{spec.label}</span>
+							</button>
+						)}
+					</For>
+				</fieldset>
 			</header>
 			<div class="mixer-tracks">
 				<For each={trackIds()}>
@@ -559,15 +594,6 @@ function LevelMeter(props: LevelMeterProps): JSX.Element {
 			/>
 		</div>
 	);
-}
-
-function createTrackRecord(order: number): Track {
-	return createTrack(factoryContext, {
-		name: `Track ${order + 1}`,
-		order,
-		type: "instrument",
-		instrument: createSynthInstrument(),
-	});
 }
 
 function trackTypeKey(track: Track): "instrument" | "audio" {


### PR DESCRIPTION
## What & why

**2 of 2. #232 has merged**, so this is now based on `main` and is the PR that
closes the issue. The mixer's one **Add track** button always minted a synth,
so a sampler or a drum machine could only arrive with the starter project or a
fixture — even though both instruments, their panels, and their domain
factories all exist. Building a multi-part loop (Alpha Milestone 1's exit
criterion) needed both by hand.

The mixer now offers all three kinds, one button per instrument — `Add sampler
track`, `Add drum machine track`, `Add synth track` — over the kind table
#232 landed. A button per kind rather than one button plus a picker: adding a
track is a two-decision action ("another track", "a sampler"), and this makes
the second decision the click itself instead of a mode set beforehand.

Each new track arrives ready to use: its instrument (a drum machine with four
empty pads), a name taken from that instrument, and an empty one-bar clip
placed at bar 1. Track, clip and placement land in **one `track.add`
transaction** — one revision, one undo — through the existing command layer
(PRD section 9.6, `TRK-01`). No new command, no new mutation path.

`track_added` now reports which instrument the user chose, and duplicating a
track reports the duplicated track's own instrument, using the optional
`instrument_type` parameter registered in #232.

**Deliberately out of scope:** the issue's "the new track opens on the matching
editor". The editor still edits `song.tracks[0]`
(`editorViewModel.editedTrack`), and selecting a track to see its instrument
and devices is #228 — the whole of that issue. Nothing here forecloses it: the
new track's clip is already in the project and drawn in the arrangement, so
#228 is a selection change, not a creation one. Flagged rather than
half-built.

Closes #223

## Core flows

**Untouched.** #223 is a bug and links no flow; `docs/core-flows.md`,
`docs/prd.md`, and all three flow specs are byte-identical to `main`
(`git diff main -- docs/ e2e/flows/` is empty). `bun run verify:core-flows`
passes: 3 flows, one spec each, CF-002 and CF-003 still parked as `test.fixme`
for ARR-003 (#61).

Worth knowing for whoever picks up ARR-003: CF-002 already writes this
affordance's selector as
`page.getByRole("button", { name: "Add sampler track" })`, and that is exactly
the accessible name shipped here — so step 2 of that flow will find it with no
change to the spec.

## Walkthrough

<sub>A note on provenance, because this takes a different route to the usual
one: #223 links no core flow, and the one passing flow (CF-001) never scrolls
to the mixer, so its images do not show the change. The `mixer-add-track`
sequence below is captured by the same `walkthrough()` helper, from the **new,
passing** `e2e/mixer.spec.ts` test that proves the affordance — so it is still
a byproduct of a test rather than assembled by hand, and cannot drift from what
shipped. CF-001's sequence is included as the unchanged primary flow. (The
"library data could not be read" panel in both is #226, present on `main` in
any checkout where the sample library has not been built.)</sub>

<sub>**Some images below may render as literal text.** Every URL returns `200`
— they were published by `bun run walkthrough:publish` and verified — but the
API path this body was written through rewrites long image links, and no form I
tried survives it intact. Open the raw URL directly for any that did not
render.</sub>

### CF-001 — A visitor with no account reaches a playing loop

**1. Open the landing page**

![CF-001 step 1](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/CF-001/01-open-the-landing-page.png)

**2. You arrive at the dashboard as a guest, with no projects yet**

![CF-001 step 2](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/CF-001/02-you-arrive-at-the-dashboard-as-a-guest-with-no-projects-yet.png)``

**3. The new project opens on a step editor with a starter pattern**

![CF-001 step 3](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/CF-001/03-the-new-project-opens-on-a-step-editor-with-a-starter-patter.png)``

**4. Turn on a step that was off**

![CF-001 step 4](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/CF-001/04-turn-on-a-step-that-was-off.png)

**5. Start playback — the transport is running**

![CF-001 step 5](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/CF-001/05-start-playback-the-transport-is-running.png)

### mixer-add-track — Add a sampler, a drum machine or a synth track

**1. A new project opens with one track: the starter kick**

![mixer-add-track step 1](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/mixer-add-track/01-a-new-project-opens-with-one-track-the-starter-kick.png)``

**2. Add a sampler track — a strip for it appears in the mixer**

![mixer-add-track step 2](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/mixer-add-track/02-add-a-sampler-track-a-strip-for-it-appears-in-the-mixer.png)``

**3. Add a drum machine track beside it**

![mixer-add-track step 3](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/mixer-add-track/03-add-a-drum-machine-track-beside-it.png)

**4. Each new track arrives with an empty one-bar clip at bar 1**

![mixer-add-track step 4](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/223/mixer-add-track/04-each-new-track-arrives-with-an-empty-one-bar-clip-at-bar-1.png)``

<sub>Captured by `bun run walkthrough:capture`, in Chromium. Flows are defined in [`docs/core-flows.md`](https://github.com/afternoon/solid-groove/blob/main/docs/core-flows.md).</sub>

## Evidence

```
bun run typecheck              tsc --noEmit, clean
bun run check:ci               Checked 487 files. No fixes applied.
bun run test                   Test Files 168 passed (168) / Tests 2267 passed (2267)
bun run test:browser:chromium  19 passed, 2 skipped (CF-002, CF-003 fixme)
bun run verify:core-flows      3 flow(s), each with exactly one spec
```

Re-run in full after #232 merged and this branch was rebased onto `main` (which
also picked up #231's Cloud Storage library change) — the numbers above are
from that run, not the pre-rebase one.

Chromium only for the browser suites: this environment cannot reach
`cdn.playwright.dev`, so Firefox and WebKit were expected to be gated by CI on
this push, per `CLAUDE.md`. **No CI run ever fired for this branch or for
#232's** — `list_workflow_runs` reports zero runs for either, despite the
workflow's `push: [main, "claude/**"]` trigger — so the local Chromium run
above is the only browser evidence this change has. That is not PRD section 10
gating evidence and is not claimed as one. Separately, `browser e2e (firefox)`
is already red on `main` at CF-001's "Stop playback" assertion (the known
Chromium-only playback gap, #43), so that job would have failed here for an
inherited reason.

New coverage, none of which can pass on `main` (the buttons it clicks do not
exist there):

- `src/editor/Mixer.test.tsx` (+5) — each button's instrument and the
  `instrument_type` it reports; the empty one-bar clip and its placement
  arriving in one revision and reverting in one undo; the drum machine's four
  empty pads; per-instrument naming; duplication reporting the duplicated
  track's instrument.
- `e2e/mixer.spec.ts` (+1) — the whole thing in a real browser: the strips
  appear, and the new track's clip is real, asserted through the delete warning
  that counts it rather than through canvas pixels.

The two existing add-track tests changed **only** in which button they click
(`"Add track"` -> `"Add synth track"`); their assertions are untouched. The
other three `e2e/mixer.spec.ts` tests are untouched and still pass.

## Acceptance criteria met

- [x] Creating a track lets the user say what kind it is — sampler, drum
      machine, or synth.
- [x] Both instruments are reachable from the UI for the first time; a new drum
      machine has pads to assign samples to, and a new track has a clip to
      program.
- [x] Track creation still goes through the `track.add` command — a UI
      affordance over an existing command, not a new mutation path.
- [x] `track_added` reports the instrument, so it no longer says only
      `instrument` for every track ever added.
- [ ] "The new track opens on the matching editor" — **not done here**, see
      "out of scope" above. That is #228.
