### PR TITLE
Decide what a track's instrument switch installs and costs

### DIFF
--- a/src/instrument/instrumentKinds.test.ts
+++ b/src/instrument/instrumentKinds.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { RawCommandInput } from "../commands";
+import { changeInstrument, executeTransaction, removeNotes } from "../commands";
+import type { Project } from "../domain/entities";
+import { createFactoryContext } from "../domain/factories";
+import {
+	createDrumMachineFixtureProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { createSeededIdFactory } from "../domain/ids";
+import { createManualClock } from "../shared/clock";
+import {
+	countPadTriggeredHits,
+	createInstrumentOfKind,
+	DEFAULT_DRUM_PAD_NAMES,
+	INSTRUMENT_KIND_CHOICES,
+	instrumentTypeKey,
+	padTriggeredHits,
+} from "./instrumentKinds";
+
+const context = () =>
+	createFactoryContext({ ids: createSeededIdFactory(224), now: 0 });
+
+describe("instrumentTypeKey", () => {
+	it("maps every offered kind to its OPS-02 analytics key", () => {
+		expect(INSTRUMENT_KIND_CHOICES.map((choice) => choice.kind)).toEqual([
+			"sampler",
+			"synth",
+			"drumMachine",
+		]);
+		expect(instrumentTypeKey("sampler")).toBe("sampler");
+		expect(instrumentTypeKey("synth")).toBe("synth");
+		expect(instrumentTypeKey("drumMachine")).toBe("drum_machine");
+	});
+});
+
+describe("createInstrumentOfKind", () => {
+	it("builds an empty sampler and a default synth", () => {
+		expect(createInstrumentOfKind("sampler", context())).toEqual({
+			kind: "sampler",
+			assetId: null,
+			parameters: {},
+		});
+		expect(createInstrumentOfKind("synth", context())).toEqual({
+			kind: "synth",
+			parameters: {},
+		});
+	});
+
+	it("builds a drum machine with named, sample-less, uniquely identified pads", () => {
+		const instrument = createInstrumentOfKind("drumMachine", context());
+		if (instrument.kind !== "drumMachine")
+			throw new Error("expected a machine");
+		expect(instrument.pads.map((pad) => pad.name)).toEqual([
+			...DEFAULT_DRUM_PAD_NAMES,
+		]);
+		expect(instrument.pads.every((pad) => pad.assetId === null)).toBe(true);
+		expect(new Set(instrument.pads.map((pad) => pad.id)).size).toBe(
+			instrument.pads.length,
+		);
+	});
+});
+
+describe("padTriggeredHits", () => {
+	it("finds the hits a drum-machine track would strand", () => {
+		const project = createDrumMachineFixtureProject();
+		const trackId = project.song.tracks[0].id;
+		const hits = padTriggeredHits(project, trackId);
+
+		expect(hits.length).toBeGreaterThan(0);
+		expect(countPadTriggeredHits(hits)).toBeGreaterThan(0);
+		for (const hit of hits) {
+			const clip = project.clips.find(
+				(candidate) => candidate.id === hit.clipId,
+			);
+			expect(clip?.trackId).toBe(trackId);
+			expect(hit.eventIds.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("ignores pitched notes, other tracks, and no project at all", () => {
+		const pitched = createSliceFixtureProject();
+		expect(padTriggeredHits(pitched, pitched.song.tracks[0].id)).toEqual([]);
+
+		const drums = createDrumMachineFixtureProject();
+		const otherTrackId = drums.song.tracks[1]?.id;
+		if (otherTrackId) {
+			expect(padTriggeredHits(drums, otherTrackId)).toEqual([]);
+		}
+
+		expect(padTriggeredHits(null, drums.song.tracks[0].id)).toEqual([]);
+	});
+});
+
+/**
+ * The reason the picker clears the hits at all: through the real command
+ * kernel, leaving a drum machine with its pad hits in place is rejected whole,
+ * so a switch that only replaced the instrument would silently do nothing.
+ */
+describe("changing a track's instrument through the command kernel", () => {
+	const execute = (project: Project, commands: RawCommandInput[]) =>
+		executeTransaction(project, commands, {
+			actor: "user",
+			clock: createManualClock(),
+		});
+
+	it("accepts any switch that strands no pad hits", () => {
+		const project = createSliceFixtureProject();
+		const trackId = project.song.tracks[0].id;
+		const result = execute(project, [
+			changeInstrument(
+				trackId,
+				createInstrumentOfKind("drumMachine", context()),
+			),
+		]);
+		expect(result.ok).toBe(true);
+	});
+
+	it("rejects leaving a drum machine until its hits go with it", () => {
+		const project = createDrumMachineFixtureProject();
+		const trackId = project.song.tracks[0].id;
+		const synth = () => createInstrumentOfKind("synth", context());
+
+		expect(execute(project, [changeInstrument(trackId, synth())]).ok).toBe(
+			false,
+		);
+
+		const hits = padTriggeredHits(project, trackId);
+		const cleared = execute(project, [
+			...hits.map((hit) => removeNotes(hit.clipId, hit.eventIds)),
+			changeInstrument(trackId, synth()),
+		]);
+		expect(cleared.ok).toBe(true);
+	});
+});

--- a/src/instrument/instrumentKinds.ts
+++ b/src/instrument/instrumentKinds.ts
@@ -1,0 +1,119 @@
+import type { Instrument, Project } from "../domain/entities";
+import {
+	createDrumMachineInstrument,
+	createDrumPad,
+	createSamplerInstrument,
+	createSynthInstrument,
+	type DomainFactoryContext,
+} from "../domain/factories";
+import type { ClipId, EventId, TrackId } from "../domain/ids";
+
+/**
+ * The pure half of changing a track's instrument (#224).
+ *
+ * A track's instrument is replaced by the existing `instrument.change` command,
+ * which takes the whole replacement instrument in its payload — so the choice
+ * of *what* to install, and what a switch costs the track's clips, is decided
+ * here rather than in the command layer. Both answers are plain functions of
+ * the project, so `InstrumentKindPicker` stays a thin dispatch surface.
+ */
+
+export type InstrumentKind = Instrument["kind"];
+
+export interface InstrumentKindChoice {
+	readonly kind: InstrumentKind;
+	readonly label: string;
+}
+
+/** The instrument kinds a track can be switched to, in panel order. */
+export const INSTRUMENT_KIND_CHOICES: readonly InstrumentKindChoice[] = [
+	{ kind: "sampler", label: "Sampler" },
+	{ kind: "synth", label: "Synth" },
+	{ kind: "drumMachine", label: "Drum machine" },
+];
+
+/**
+ * The pads a track gets when it becomes a drum machine. A machine with no pads
+ * has nothing to load a sample into and no lane to program — and no UI adds a
+ * pad yet (`drum.addPad` exists, `DrumMachinePanel` does not expose it) — so a
+ * switch that produced an empty machine would be a dead end. Four named,
+ * sample-less pads give the user somewhere to drop sounds immediately.
+ */
+export const DEFAULT_DRUM_PAD_NAMES: readonly string[] = [
+	"Kick",
+	"Snare",
+	"Hat",
+	"Clap",
+];
+
+/** The OPS-02 `instrument_type` (and `feature_first_use`) key for a kind. */
+export function instrumentTypeKey(
+	kind: InstrumentKind,
+): "sampler" | "synth" | "drum_machine" {
+	switch (kind) {
+		case "sampler":
+			return "sampler";
+		case "synth":
+			return "synth";
+		case "drumMachine":
+			return "drum_machine";
+	}
+}
+
+/**
+ * A fresh instrument of `kind`, at its defaults: an empty sampler, a synth, or
+ * a drum machine with {@link DEFAULT_DRUM_PAD_NAMES}. Every ID it needs is
+ * minted here, so the command payload carries them explicitly and a replay,
+ * redo, or assistant preview reproduces the same project.
+ */
+export function createInstrumentOfKind(
+	kind: InstrumentKind,
+	context: DomainFactoryContext,
+): Instrument {
+	switch (kind) {
+		case "sampler":
+			return createSamplerInstrument(null);
+		case "synth":
+			return createSynthInstrument();
+		case "drumMachine":
+			return createDrumMachineInstrument(
+				DEFAULT_DRUM_PAD_NAMES.map((name) => createDrumPad(context, { name })),
+			);
+	}
+}
+
+/** Notes in one clip that trigger a pad rather than a pitch. */
+export interface PadTriggeredHits {
+	readonly clipId: ClipId;
+	readonly eventIds: readonly EventId[];
+}
+
+/**
+ * Every pad-triggered note in a track's clips.
+ *
+ * A note may only name a pad its own track owns (the domain's pad-trigger
+ * invariant), so leaving a drum machine strands exactly these notes: the
+ * transaction would be rejected whole and the switch would silently do
+ * nothing. They are what the picker warns about and removes in the same
+ * transaction, so undo restores the hits and the machine together.
+ */
+export function padTriggeredHits(
+	project: Project | null,
+	trackId: TrackId,
+): readonly PadTriggeredHits[] {
+	if (!project) return [];
+	return project.clips.flatMap((clip) => {
+		if (clip.trackId !== trackId || clip.content.kind !== "notes") return [];
+		const eventIds = clip.content.events
+			.filter((event) => event.trigger.kind === "pad")
+			.map((event) => event.id);
+		return eventIds.length > 0 ? [{ clipId: clip.id, eventIds }] : [];
+	});
+}
+
+/** How many notes {@link padTriggeredHits} found, across every clip. */
+export function countPadTriggeredHits(
+	hits: readonly PadTriggeredHits[],
+): number {
+	return hits.reduce((total, hit) => total + hit.eventIds.length, 0);
+}


### PR DESCRIPTION
## What & why

1 of 2 for #224. `instrument.change` already replaces a track's instrument, but the command takes the *whole* replacement instrument in its payload — so what to install for a given kind, and what the switch costs the track's clips, is a decision above the command layer. This PR is that decision, as one pure module with no consumers yet; PR 2 is the panel that dispatches it.

- `createInstrumentOfKind(kind, context)` mints a fresh instrument at its defaults, minting every ID it needs so the payload stays replayable (PRD section 9.6, "payloads carry explicit IDs for anything they create"). A new drum machine gets four named, sample-less pads — no surface exposes `drum.addPad` yet, so a switch that produced an empty machine would be a dead end.
- `instrumentTypeKey(kind)` maps a domain kind to its OPS-02 `instrument_type` / `feature_first_use` key, so the panel never writes `"drum_machine"` by hand.
- `padTriggeredHits(project, trackId)` names the notes a switch away from a drum machine would strand. A note may only trigger a pad its own track owns (`src/domain/parse/clip.ts:97`), so leaving the machine with those hits in place is rejected *whole* by the domain — a switch that only replaced the instrument would silently do nothing.

No central registration is touched: `instrument_changed` and the three `instrument_type` values are already in `src/analytics/catalog.ts`, and `instrument.change` is already registered.

Refs #224

## Core flows

None. #224 is a bug report and links no core flow ID, so there is no flow to spec or complete. `bun run verify:core-flows` still passes and reports the three registered flows unchanged (CF-002/CF-003 remain parked at `test.fixme` from #227, untouched by this stack).

## Walkthrough

No UI change — this PR adds a pure module and its tests, with no consumer. The walkthrough is on PR 2, which closes the issue.

## Evidence

The claim that makes this module worth having is proved through the real command kernel rather than asserted:

```
✓ src/instrument/instrumentKinds.test.ts (7 tests) 33ms
    ✓ accepts any switch that strands no pad hits
    ✓ rejects leaving a drum machine until its hits go with it
```

The second case executes `changeInstrument` alone against the drum-machine fixture and asserts `ok === false` (the domain reports `Note evt_… triggers pad pad_…, which its track does not own`), then re-executes it with the `removeNotes` commands ahead of it and asserts `ok === true`.

Green on this commit on its own, with the rest of the stack stashed:

```
$ bun run typecheck
(clean)
$ bun run test -- src/instrument src/editor
Test Files  24 passed (24)
     Tests  291 passed (291)
```

And on the full tree:

```
$ bun run check:ci
Checked 489 files in 623ms. No fixes applied.
$ bun run test
Test Files  169 passed (169)
     Tests  2262 passed (2262)
$ bun run verify:core-flows
check-core-flows — 3 flow(s), each with exactly one spec.
```

One earlier full-suite run reported a single failure that did not reproduce in either of the two subsequent runs and that I could not attribute to a named test; both runs quoted above are clean.

`bun run test:browser:chromium` is reported on PR 2, where the browser spec lives. This environment cannot reach `cdn.playwright.dev`, so Firefox and WebKit are CI's to gate — the Chromium run is a pre-flight, not PRD section 10 evidence.

## Acceptance criteria met

#224 has no acceptance checkboxes. This PR delivers the half of "a track's instrument can be changed" that is a decision rather than a control; the observable behaviour, the `instrument.change` dispatch, and the `instrument_changed` event land in PR 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b1rKVt5jKtzBaehVuKjE7)_