### PR TITLE
Let a track's instrument be changed from its panel

### DIFF
--- a/e2e/instrument.spec.ts
+++ b/e2e/instrument.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { walkthrough } from "./support/walkthrough";
+
+// #224: a track's instrument used to be fixed for its whole life — the
+// `instrument.change` command existed but nothing dispatched it. This walks the
+// repair path a producer takes: decide the part wants a different sound source,
+// and change it in place rather than deleting the track and starting over.
+test("changes a track's instrument from its own panel", async ({ page }) => {
+	const step = walkthrough(page, {
+		id: "issue-224",
+		title: "Change a track's instrument",
+	});
+
+	await page.goto("/dashboard");
+	await page.getByRole("button", { name: "New Project" }).click();
+	await expect(page.getByRole("region", { name: "Step editor" })).toBeVisible();
+
+	// The workspace scrolls inside a viewport-height app, so each capture
+	// scrolls that container and then returns the page itself to the top —
+	// otherwise the shot is framed on empty page below the editor.
+	const picker = page.getByRole("region", { name: "Instrument" });
+	const show = async (name: string | RegExp): Promise<void> => {
+		await page.getByRole("region", { name }).scrollIntoViewIfNeeded();
+		await page.evaluate(() => window.scrollTo(0, 0));
+	};
+	// The starter track is a sampler, and the panel now says so out loud.
+	await expect(page.getByRole("region", { name: "Sampler" })).toBeVisible();
+	await show("Instrument");
+	await step("Open a project: the track's instrument is a sampler");
+
+	// Sampler -> synth, in one transaction the command layer can name.
+	await picker.getByText("Synth", { exact: true }).click();
+	await expect(page.getByRole("region", { name: "Synth voice" })).toBeVisible();
+	await expect(page.getByRole("region", { name: "Sampler" })).toHaveCount(0);
+	await show("Synth voice");
+	await expect(
+		page.getByRole("button", { name: /^Undo Change .* to synth/ }),
+	).toBeEnabled();
+	await step("Pick Synth: the synth panel replaces the sampler's");
+
+	// ...and on to the drum machine, which arrives with pads to load.
+	await picker.getByText("Drum machine", { exact: true }).click();
+	await expect(
+		page.getByRole("button", { name: "Audition Kick" }),
+	).toBeVisible();
+	await show(/^Drum machine/);
+	await step("Pick Drum machine: it arrives with pads ready for sounds");
+
+	// The route back off a drum machine — the direction that had no UI at all,
+	// since the drum machine's own panel is mounted elsewhere.
+	await picker.getByText("Sampler", { exact: true }).click();
+	await expect(page.getByRole("region", { name: "Sampler" })).toBeVisible();
+
+	// Each switch is one history entry, so undo walks back a step at a time.
+	await page.getByRole("button", { name: /^Undo/ }).click();
+	await expect(
+		page.getByRole("button", { name: "Audition Kick" }),
+	).toBeVisible();
+	await show(/^Drum machine/);
+	await step("Undo returns the drum machine, one switch at a time");
+});

--- a/src/editor/TrackEditor.tsx
+++ b/src/editor/TrackEditor.tsx
@@ -7,6 +7,7 @@ import type {
 } from "../commands";
 import type { Clip, Instrument, Project } from "../domain/entities";
 import type { EventId, TrackId } from "../domain/ids";
+import InstrumentKindPicker from "../instrument/InstrumentKindPicker";
 import type { SampleChoice } from "../instrument/SamplerPanel";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
 import InstrumentPanel from "./InstrumentPanel";
@@ -31,7 +32,7 @@ export interface TrackEditorProps {
 	readonly project: Project;
 	readonly playheadTicks: number;
 	readonly registerPianoRollActions: (actions: PianoRollActions) => void;
-	/** Present only when the instrument gets a panel (sampler or synth). */
+	/** The edited track, when there is one; null while no project is open. */
 	readonly instrumentPanelTrackId: TrackId | null;
 	readonly sampleName: string | null;
 	readonly replacementOptions: readonly SampleChoice[];
@@ -106,6 +107,23 @@ export default function TrackEditor(props: TrackEditorProps) {
 				dispatch={props.dispatch}
 				editor={props.showPianoRoll() ? "piano_roll" : "step"}
 			/>
+			{/*
+			 * The kind picker leads the track's instrument controls (#224). It sits
+			 * outside `InstrumentPanel` because that component is the switch
+			 * *between* instrument panels and the picker is what chooses which one —
+			 * it must also show for a drum machine and for a track with no
+			 * instrument, neither of which reaches that switch.
+			 */}
+			<Show when={props.instrumentPanelTrackId}>
+				{(trackId) => (
+					<InstrumentKindPicker
+						trackId={trackId()}
+						project={props.project}
+						instrument={props.instrument}
+						dispatch={props.dispatch}
+					/>
+				)}
+			</Show>
 			<Show when={props.instrumentPanelTrackId}>
 				{(trackId) => (
 					<InstrumentPanel

--- a/src/editor/editorViewModel.test.ts
+++ b/src/editor/editorViewModel.test.ts
@@ -260,10 +260,9 @@ describe("instrumentPanelTrackId", () => {
 		expect(instrumentPanelTrackId(synth)).toBe(synth.song.tracks[0].id);
 	});
 
-	it("is null for a drum machine, whose panel is DrumMachinePanel", () => {
-		expect(
-			instrumentPanelTrackId(createDrumMachineFixtureProject()),
-		).toBeNull();
+	it("names a drum-machine track too, so the kind picker can leave it (#224)", () => {
+		const drums = createDrumMachineFixtureProject();
+		expect(instrumentPanelTrackId(drums)).toBe(drums.song.tracks[0].id);
 	});
 
 	it("is null with no project open", () => {

--- a/src/editor/editorViewModel.ts
+++ b/src/editor/editorViewModel.ts
@@ -159,14 +159,13 @@ export function showPianoRoll(project: Project | null): boolean {
 }
 
 /**
- * The track id, only when it carries an instrument this slice renders a panel
- * for (sampler or synth). The drum machine's panel lands with LOOP-005.
+ * The track the instrument panel edits — whatever instrument it carries, or
+ * none at all. The panel leads with the kind picker (#224), so gating this on
+ * the kinds that have a sub-panel would leave a drum-machine track (whose own
+ * panel `EditorView` mounts separately) with no way back off the drum machine.
  */
 export function instrumentPanelTrackId(
 	project: Project | null,
 ): TrackId | null {
-	const kind = editedInstrument(project)?.kind;
-	return kind === "sampler" || kind === "synth"
-		? (editedTrack(project)?.id ?? null)
-		: null;
+	return editedTrack(project)?.id ?? null;
 }

--- a/src/instrument/InstrumentKindPicker.test.tsx
+++ b/src/instrument/InstrumentKindPicker.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import type { Project } from "../domain/entities";
+import { createFactoryContext } from "../domain/factories";
+import {
+	createDrumMachineFixtureProject,
+	createSliceFixtureProject,
+} from "../domain/fixtures";
+import { createSeededIdFactory } from "../domain/ids";
+import { memoryStorage } from "../testing/storage";
+import InstrumentKindPicker from "./InstrumentKindPicker";
+
+afterEach(() => cleanup());
+
+type Dispatch = (
+	commands: RawCommandInput | readonly RawCommandInput[],
+) => TransactionResult | undefined;
+
+function renderPicker(project: Project, ok = true) {
+	const dispatch = vi.fn<Dispatch>(
+		() => ({ ok, issues: [] }) as unknown as TransactionResult,
+	);
+	const transport = createRecordingTransport();
+	const analytics = new Analytics({
+		transport,
+		consent: new ConsentStore(memoryStorage()),
+		storage: memoryStorage(),
+	});
+	analytics.setAccountType("anonymous");
+	const track = project.song.tracks[0];
+	render(() => (
+		<InstrumentKindPicker
+			trackId={track.id}
+			project={project}
+			instrument={track.instrument}
+			dispatch={dispatch}
+			analytics={analytics}
+			factoryContext={createFactoryContext({
+				ids: createSeededIdFactory(224),
+				now: 0,
+			})}
+		/>
+	));
+	return { dispatch, transport, track };
+}
+
+/** The commands of the single transaction the picker dispatched. */
+function transaction(dispatch: ReturnType<typeof vi.fn>): RawCommandInput[] {
+	expect(dispatch).toHaveBeenCalledTimes(1);
+	const commands = dispatch.mock.calls[0][0];
+	return Array.isArray(commands) ? commands : [commands];
+}
+
+describe("InstrumentKindPicker", () => {
+	it("offers every instrument kind and marks the track's current one", () => {
+		renderPicker(createSliceFixtureProject());
+		expect(
+			(screen.getByRole("radio", { name: "Sampler" }) as HTMLInputElement)
+				.checked,
+		).toBe(true);
+		expect(
+			(screen.getByRole("radio", { name: "Synth" }) as HTMLInputElement)
+				.checked,
+		).toBe(false);
+		expect(screen.getByRole("radio", { name: "Drum machine" })).toBeVisible();
+	});
+
+	it("changes the instrument in one transaction and reports the new type", () => {
+		const { dispatch, transport, track } = renderPicker(
+			createSliceFixtureProject(),
+		);
+		fireEvent.click(screen.getByRole("radio", { name: "Synth" }));
+
+		const commands = transaction(dispatch);
+		expect(commands).toHaveLength(1);
+		expect(commands[0]).toMatchObject({
+			type: "instrument.change",
+			payload: { trackId: track.id, instrument: { kind: "synth" } },
+		});
+
+		const changed = transport.named("instrument_changed");
+		expect(changed).toHaveLength(1);
+		expect(changed[0].params.instrument_type).toBe("synth");
+		expect(
+			transport
+				.named("feature_first_use")
+				.filter((event) => event.params.feature === "synth"),
+		).toHaveLength(1);
+	});
+
+	it("gives a new drum machine pads to load sounds into", () => {
+		const { dispatch } = renderPicker(createSliceFixtureProject());
+		fireEvent.click(screen.getByRole("radio", { name: "Drum machine" }));
+
+		const command = transaction(dispatch)[0] as {
+			payload: { instrument: { kind: string; pads: readonly unknown[] } };
+		};
+		expect(command.payload.instrument.kind).toBe("drumMachine");
+		expect(command.payload.instrument.pads.length).toBeGreaterThan(0);
+	});
+
+	it("does nothing when the track's current kind is picked again", () => {
+		const { dispatch, transport } = renderPicker(createSliceFixtureProject());
+		fireEvent.click(screen.getByRole("radio", { name: "Sampler" }));
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(transport.events).toHaveLength(0);
+	});
+
+	it("confirms before leaving a drum machine whose clips hold pad hits", () => {
+		const { dispatch, transport } = renderPicker(
+			createDrumMachineFixtureProject(),
+		);
+		fireEvent.click(screen.getByRole("radio", { name: "Synth" }));
+
+		expect(screen.getByRole("alertdialog")).toBeVisible();
+		expect(dispatch).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(screen.queryByRole("alertdialog")).toBeNull();
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(transport.events).toHaveLength(0);
+	});
+
+	it("deletes the stranded hits in the same transaction once confirmed", () => {
+		const project = createDrumMachineFixtureProject();
+		const { dispatch, transport } = renderPicker(project);
+		fireEvent.click(screen.getByRole("radio", { name: "Synth" }));
+		fireEvent.click(screen.getByRole("button", { name: "Change instrument" }));
+
+		const commands = transaction(dispatch);
+		expect(commands.length).toBeGreaterThan(1);
+		expect(commands.slice(0, -1).map((command) => command.type)).toEqual(
+			commands.slice(0, -1).map(() => "note.remove"),
+		);
+		expect(commands.at(-1)).toMatchObject({
+			type: "instrument.change",
+			payload: { instrument: { kind: "synth" } },
+		});
+		expect(transport.named("instrument_changed")).toHaveLength(1);
+	});
+
+	it("reports nothing when the transaction is rejected", () => {
+		const { transport } = renderPicker(createSliceFixtureProject(), false);
+		fireEvent.click(screen.getByRole("radio", { name: "Synth" }));
+		expect(transport.events).toHaveLength(0);
+	});
+});

--- a/src/instrument/InstrumentKindPicker.tsx
+++ b/src/instrument/InstrumentKindPicker.tsx
@@ -1,0 +1,142 @@
+import { createSignal, type JSX, Show } from "solid-js";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
+import type { RawCommandInput, TransactionResult } from "../commands";
+import { changeInstrument, removeNotes } from "../commands";
+import ConfirmDialog from "../components/ConfirmDialog";
+import type { Instrument, Project } from "../domain/entities";
+import {
+	createFactoryContext,
+	type DomainFactoryContext,
+} from "../domain/factories";
+import type { TrackId } from "../domain/ids";
+import "./InstrumentPanel.css";
+import {
+	countPadTriggeredHits,
+	createInstrumentOfKind,
+	INSTRUMENT_KIND_CHOICES,
+	type InstrumentKind,
+	instrumentTypeKey,
+	type PadTriggeredHits,
+	padTriggeredHits,
+} from "./instrumentKinds";
+import OptionGroup from "./OptionGroup";
+
+/** Mints pad IDs for drum machines this picker creates. A module singleton. */
+const defaultFactoryContext = createFactoryContext();
+
+export interface InstrumentKindPickerProps {
+	readonly trackId: TrackId;
+	readonly project: Project;
+	/** The track's current instrument, or null when it has none. */
+	readonly instrument: Instrument | null;
+	dispatch(
+		commands: RawCommandInput | readonly RawCommandInput[],
+	): TransactionResult | undefined;
+	/** Defaults to the application singleton; injectable for tests. */
+	readonly analytics?: Analytics;
+	/** Overrides the pad-ID factory so tests are deterministic. */
+	readonly factoryContext?: DomainFactoryContext;
+}
+
+/**
+ * The instrument-kind switch at the head of a track's instrument panel (#224).
+ *
+ * Before this, a track kept whichever instrument it was born with: the command
+ * layer could replace one (`instrument.change`) but nothing dispatched it, so
+ * wanting a sampler on a synth track meant deleting the track. Switching keeps
+ * the track's name, mixer settings, devices, sends, and clips, in one undoable
+ * transaction that emits `instrument_changed` with the new type.
+ *
+ * Leaving a drum machine is the one lossy direction: a pad-triggered note may
+ * only name a pad its own track owns, so those hits cannot survive the switch.
+ * Rather than let the transaction be rejected whole — which would look like a
+ * dead control — the picker confirms first, then deletes the hits in the *same*
+ * transaction as the instrument change, so one undo brings both back. Following
+ * the mixer's precedent, a track with nothing to lose switches with no ceremony.
+ */
+export default function InstrumentKindPicker(
+	props: InstrumentKindPickerProps,
+): JSX.Element {
+	const analytics = () => props.analytics ?? defaultAnalytics;
+	const factoryContext = () => props.factoryContext ?? defaultFactoryContext;
+	const [pendingKind, setPendingKind] = createSignal<InstrumentKind | null>(
+		null,
+	);
+
+	/** The hits a switch away from the drum machine would strand. */
+	const strandedHits = (kind: InstrumentKind): readonly PadTriggeredHits[] =>
+		kind === "drumMachine"
+			? []
+			: padTriggeredHits(props.project, props.trackId);
+
+	function select(kind: InstrumentKind): void {
+		if (kind === props.instrument?.kind) return;
+		const hits = strandedHits(kind);
+		if (hits.length > 0) {
+			setPendingKind(kind);
+			return;
+		}
+		change(kind, hits);
+	}
+
+	function change(
+		kind: InstrumentKind,
+		hits: readonly PadTriggeredHits[],
+	): void {
+		const result = props.dispatch([
+			...hits.map((hit) => removeNotes(hit.clipId, hit.eventIds)),
+			changeInstrument(
+				props.trackId,
+				createInstrumentOfKind(kind, factoryContext()),
+			),
+		]);
+		if (!result?.ok) return;
+		const type = instrumentTypeKey(kind);
+		analytics().log("instrument_changed", { instrument_type: type });
+		analytics().logFeatureFirstUse(type);
+	}
+
+	function confirmPending(): void {
+		const kind = pendingKind();
+		if (!kind) return;
+		setPendingKind(null);
+		change(kind, strandedHits(kind));
+	}
+
+	const pendingLabel = () =>
+		INSTRUMENT_KIND_CHOICES.find((choice) => choice.kind === pendingKind())
+			?.label ?? "";
+	const pendingHitCount = () => {
+		const kind = pendingKind();
+		return kind ? countPadTriggeredHits(strandedHits(kind)) : 0;
+	};
+
+	return (
+		<section class="instrument-panel instrument-kind" aria-label="Instrument">
+			<div class="instrument-panel-group">
+				<h3 class="instrument-panel-heading">Instrument</h3>
+				<OptionGroup
+					legend="Instrument type"
+					value={props.instrument?.kind ?? null}
+					options={INSTRUMENT_KIND_CHOICES.map((choice) => ({
+						value: choice.kind,
+						label: choice.label,
+					}))}
+					onSelect={select}
+				/>
+			</div>
+			<Show when={pendingKind()}>
+				<ConfirmDialog
+					title={`Change this track to a ${pendingLabel().toLowerCase()}?`}
+					message={`${pendingHitCount()} drum ${pendingHitCount() === 1 ? "hit" : "hits"} in this track's clips can only play on a drum machine and will be deleted. Undo restores them.`}
+					confirmLabel="Change instrument"
+					onConfirm={confirmPending}
+					onCancel={() => setPendingKind(null)}
+				/>
+			</Show>
+		</section>
+	);
+}

--- a/src/instrument/OptionGroup.tsx
+++ b/src/instrument/OptionGroup.tsx
@@ -12,7 +12,8 @@ export interface OptionGroupProps<V extends string | number> {
 	/** Accessible group name, e.g. "Waveform". */
 	readonly legend: string;
 	readonly options: readonly OptionGroupOption<V>[];
-	readonly value: V;
+	/** The selected value, or null when the group has no selection yet. */
+	readonly value: V | null;
 	onSelect(value: V): void;
 }
 


### PR DESCRIPTION
## What & why

2 of 2 for #224, builds on #234 (base is `claude/issue-224-lt6rp7`; retarget to `main` once that merges).

The command layer could replace a track's instrument, but **no component ever dispatched `instrument.change`** — so a track kept whatever it was born with, and a producer who wanted a sampler on a synth track had to delete the track and start over. `InstrumentKindPicker` leads the track's instrument controls with a sampler / synth / drum-machine choice and dispatches that command, keeping the track's name, mixer settings, devices, sends, and clips.

**The clip question the issue flags.** Leaving a drum machine is the one lossy direction: a note may only trigger a pad its own track owns, so those hits cannot survive the switch, and the domain rejects the whole transaction rather than orphaning them. Letting that happen would read as a dead control, so the picker follows the mixer's delete precedent — a track with nothing to lose switches with no ceremony; a track with pad hits confirms first, and the hits are then cleared in the **same transaction** as the instrument change. That means one revision, one history entry, and one undo that brings the machine *and* its hits back. Switching *to* a drum machine, or between the pitched instruments, loses nothing and never prompts.

**Where the picker sits.** Beside `InstrumentPanel`, not inside it: that component is the switch *between* instrument panels, while this chooses which one, and it must show for a drum machine (whose own panel `EditorView` mounts separately) and for a track with no instrument at all — neither of which reaches that switch. For the same reason `instrumentPanelTrackId` no longer filters by kind; gating it there is exactly what left a drum-machine track with no way back off the drum machine.

`OptionGroup`'s `value` becomes nullable so a track with no instrument shows the group with nothing selected rather than a false first choice. `SynthPanel`'s use is unchanged.

Analytics ships with it: `instrument_changed` with the new `instrument_type`, plus the kind's `feature_first_use` key, emitted once per accepted switch and never on a rejected one. No new catalog keys were needed and no event carries a name or user string.

Closes #224

## Core flows

None. #224 is a bug report and links no core flow ID. `bun run verify:core-flows` passes and reports the three registered flows unchanged; CF-002/CF-003 stay parked at `test.fixme` from #227, and no flow spec's assertions were touched by this stack (`git diff main...HEAD -- docs/core-flows.md docs/prd.md e2e/flows e2e-emulator/flows` is empty).

Because there is no flow to capture from, the walkthrough below comes from `e2e/instrument.spec.ts` — a new browser spec that walks the same path a flow would, added in this PR and calling the same `walkthrough()` helper. It sits at the `e2e/` root beside `smoke.spec.ts` and `mixer.spec.ts`, not in `e2e/flows/`, so the 1:1 flow-to-spec check is unaffected.

## Walkthrough

### issue-224 — Change a track's instrument

**1. Open a project: the track's instrument is a sampler**

<img width="900" alt="Open a project: the track's instrument is a sampler" src="``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/224/issue-224/01-open-a-project-the-track-s-instrument-is-a-sampler.png"&gt;``

**2. Pick Synth: the synth panel replaces the sampler's**

<img width="900" alt="Pick Synth: the synth panel replaces the sampler's" src="``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/224/issue-224/02-pick-synth-the-synth-panel-replaces-the-sampler-s.png"&gt;``

**3. Pick Drum machine: it arrives with pads ready for sounds**

<img width="900" alt="Pick Drum machine: it arrives with pads ready for sounds" src="``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/224/issue-224/03-pick-drum-machine-it-arrives-with-pads-ready-for-sounds.png"&gt;``

**4. Undo returns the drum machine, one switch at a time**

<img width="900" alt="Undo returns the drum machine, one switch at a time" src="``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/224/issue-224/04-undo-returns-the-drum-machine-one-switch-at-a-time.png"&gt;``

<sub>Captured by `bun run walkthrough:capture` from the passing spec, in Chromium, and published to the `claude/walkthroughs` branch by `bun run walkthrough:publish`. All four URLs verified to return 200.</sub>

## Evidence

```
$ bun run check:ci
Checked 489 files in 623ms. No fixes applied.

$ bun run test
Test Files  169 passed (169)
     Tests  2262 passed (2262)

$ bun run test:browser:chromium
19 passed, 2 skipped (37.8s)
  ✓ e2e/instrument.spec.ts:8:1 › changes a track's instrument from its own panel (11.9s)

$ bun run verify:core-flows
check-core-flows — 3 flow(s), each with exactly one spec.
```

New component coverage (`src/instrument/InstrumentKindPicker.test.tsx`, 7 cases): the group offers all three kinds and marks the current one; a switch dispatches exactly one transaction whose last command is `instrument.change` and emits `instrument_changed` once; a new drum machine arrives with pads; re-picking the current kind dispatches nothing; a drum-machine track with pad hits opens the confirmation and dispatches nothing until confirmed, and cancelling emits nothing; confirming dispatches the `note.remove` commands and the `instrument.change` in one array; a rejected transaction emits nothing.

Each test fails before the implementation (the component did not exist). The transaction-level claim behind the confirmation — that the naive switch is rejected and the cleared one is accepted — is proved through the real command kernel in PR 1's `instrumentKinds.test.ts` rather than against the mocked dispatch here.

Firefox and WebKit are CI's to gate: this environment cannot reach `cdn.playwright.dev`, so only Chromium is installable and the run above is a pre-flight, not PRD section 10 evidence.

**Stack invariants.** `SynthPanel.tsx` and `SynthPanel.test.tsx` are untouched across both PRs (`git diff main...HEAD --stat -- src/instrument/SynthPanel*` is empty) — `OptionGroup`'s `value` only widened to accept `null`, so its existing caller keeps passing a non-null value and its 6 tests pass unchanged. `docs/prd.md` and `docs/core-flows.md` are untouched. PR 1 is green on its own commit (typecheck clean, 291 tests) with this PR's changes stashed, so it can merge and be walked away from.

## Acceptance criteria met

#224 has no acceptance checkboxes; against its "Expected":

- ✅ A track's instrument can be changed from the track's own panel.
- ✅ It dispatches the existing `instrument.change` command (the issue calls it `instrument.set`; `src/commands/definitions/instruments.ts:69` registers it as `instrument.change`), as one undoable transaction.
- ✅ `instrument_changed` is emitted with the new `instrument_type`.
- ✅ The issue's open "Notes" question — what happens to clips that no longer fit — is answered above, in the least destructive way the domain allows: confirm, then delete in the same transaction so undo restores.

Not in scope: #223 (Add track always creates a synth) is a separate issue; this PR changes what an *existing* track can become, not what a new one starts as. The picker also only reaches the edited track — a project with no clip still shows "This project has no sampler track yet." and no panel, which is pre-existing `EditorView` behaviour.