### PR TITLE
Point the editor's derivations at a selected track (1 of 3, #228)

### DIFF
--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -135,10 +135,13 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		model.playheadLabel(audio.positionTicks()),
 	);
 
-	const track = createMemo(() => model.editedTrack(project()));
-	const drumTrack = createMemo(() => model.drumTrack(project()));
+	// The track the editor is pointed at. Selecting one lands with the mixer and
+	// arrangement wiring (#228); until then this is the project's first track,
+	// which is what `model.editedTrack` falls back to.
+	const track = createMemo(() => model.editedTrack(project(), null));
+	const drumTrack = createMemo(() => model.drumTrack(track()));
 	const sampleAssets = createMemo(() => model.sampleAssets(project()));
-	const clip = createMemo(() => model.editedClip(project()));
+	const clip = createMemo(() => model.editedClip(project(), track()));
 
 	// The step editor's live playback-step indicator (CLP-02): which 16th step of
 	// the edited clip the playhead is currently passing, wrapped within the clip's
@@ -161,8 +164,10 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	}
 
 	const loopClips = createMemo(() => model.loopClips(project()));
-	const instrument = createMemo(() => model.editedInstrument(project()));
-	const showPianoRoll = createMemo(() => model.showPianoRoll(project()));
+	const instrument = createMemo(() => model.editedInstrument(track()));
+	const showPianoRoll = createMemo(() =>
+		model.showPianoRoll(project(), track()),
+	);
 
 	// Plain function, not a memo: `hasSelection()` reads the controller's
 	// internal (non-signal) state, so this must be re-evaluated live on every
@@ -186,7 +191,7 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	});
 
 	const instrumentPanelTrackId = createMemo(() =>
-		model.instrumentPanelTrackId(project()),
+		model.instrumentPanelTrackId(track()),
 	);
 	const AUDITION_PITCH = 60; // Middle C
 	const AUDITION_DURATION_TICKS = TICKS_PER_QUARTER;
@@ -207,7 +212,7 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		);
 	}
 
-	const sampleName = createMemo(() => model.sampleName(project()));
+	const sampleName = createMemo(() => model.sampleName(project(), track()));
 	const replacementOptions = createMemo(() =>
 		model.replacementOptions(project()),
 	);

--- a/src/editor/editorViewModel.test.ts
+++ b/src/editor/editorViewModel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Project } from "../domain/entities";
 import {
 	createDenseStepFixtureProject,
 	createDrumMachineFixtureProject,
@@ -6,12 +7,14 @@ import {
 	createSliceFixtureProject,
 } from "../domain/fixtures";
 import { TICKS_PER_BAR, TICKS_PER_QUARTER } from "../domain/time";
+import { emptySelection, selectOnly } from "../selection";
 import {
 	addedPackIds,
 	drumTrack,
 	editedClip,
 	editedInstrument,
 	editedTrack,
+	focusedTrackId,
 	instrumentPanelTrackId,
 	loopClips,
 	packDependencyLabel,
@@ -72,28 +75,66 @@ describe("playheadLabel", () => {
 	});
 });
 
-describe("editedTrack", () => {
-	it("is the project's first track", () => {
-		const project = createSliceFixtureProject();
-		expect(editedTrack(project)?.id).toBe(project.song.tracks[0].id);
-		expect(editedTrack(project)?.name).toBe("BD");
+describe("focusedTrackId", () => {
+	it("is the focused track scope's id", () => {
+		const trackId = createSliceFixtureProject().song.tracks[0].id;
+		expect(focusedTrackId(selectOnly({ kind: "track", id: trackId }))).toBe(
+			trackId,
+		);
 	});
 
-	it("is null with no project open", () => {
-		expect(editedTrack(null)).toBeNull();
+	it("is null for an empty selection or a focus that is not a track", () => {
+		expect(focusedTrackId(emptySelection())).toBeNull();
+		const clipId = createSliceFixtureProject().clips[0].id;
+		expect(focusedTrackId(selectOnly({ kind: "clip", id: clipId }))).toBeNull();
+	});
+});
+
+describe("editedTrack", () => {
+	it("is the selected track", () => {
+		const project = createDrumMachineFixtureProject();
+		const second = project.song.tracks[1];
+		expect(editedTrack(project, second.id)?.id).toBe(second.id);
+		expect(editedTrack(project, second.id)?.name).toBe("Break");
+	});
+
+	it("falls back to the first track with nothing selected", () => {
+		const project = createSliceFixtureProject();
+		expect(editedTrack(project, null)?.id).toBe(project.song.tracks[0].id);
+		expect(editedTrack(project, null)?.name).toBe("BD");
+	});
+
+	it("falls back to the first track when the selected one is gone", () => {
+		const project = createSliceFixtureProject();
+		const removed = createDrumMachineFixtureProject().song.tracks[0].id;
+		expect(editedTrack(project, removed)?.id).toBe(project.song.tracks[0].id);
+	});
+
+	it("is null with no project open, and for a project with no tracks", () => {
+		expect(editedTrack(null, null)).toBeNull();
+		const project = createSliceFixtureProject();
+		const empty = { ...project, song: { ...project.song, tracks: [] } };
+		expect(editedTrack(empty, null)).toBeNull();
 	});
 });
 
 describe("drumTrack", () => {
-	it("finds the first drum-machine track", () => {
+	it("is the edited track when it is a drum machine", () => {
 		const project = createDrumMachineFixtureProject();
-		const found = drumTrack(project);
+		const found = drumTrack(editedTrack(project, null));
 		expect(found?.instrument?.kind).toBe("drumMachine");
 		expect(found?.name).toBe("Drums");
 	});
 
-	it("is null for a sampler-only project and with no project open", () => {
-		expect(drumTrack(createSliceFixtureProject())).toBeNull();
+	it("is null when the edited track is not a drum machine", () => {
+		const project = createDrumMachineFixtureProject();
+		// The fixture's second track is an audio track; selecting it must not
+		// leave the first track's pads on screen (#228).
+		const audioTrack = project.song.tracks[1];
+		expect(drumTrack(editedTrack(project, audioTrack.id))).toBeNull();
+		expect(
+			drumTrack(editedTrack(createSliceFixtureProject(), null)),
+		).toBeNull();
 		expect(drumTrack(null)).toBeNull();
 	});
 });
@@ -118,35 +159,38 @@ describe("sampleAssets", () => {
 describe("editedClip", () => {
 	it("is the clip on the edited track", () => {
 		const project = createSliceFixtureProject();
-		const clip = editedClip(project);
+		const clip = editedClip(project, editedTrack(project, null));
 		expect(clip?.id).toBe(project.clips[0].id);
 		expect(clip?.trackId).toBe(project.song.tracks[0].id);
 	});
 
-	it("picks the drum track's clip, not the audio track's loop", () => {
+	it("follows the selection: the audio track's loop, not the drum clip", () => {
 		const project = createDrumMachineFixtureProject();
-		const clip = editedClip(project);
-		expect(clip?.content.kind).toBe("notes");
-		expect(clip?.trackId).toBe(project.song.tracks[0].id);
+		const audioTrack = project.song.tracks[1];
+		const clip = editedClip(project, editedTrack(project, audioTrack.id));
+		expect(clip?.content.kind).toBe("audioLoop");
+		expect(clip?.trackId).toBe(audioTrack.id);
 	});
 
-	it("is null with no project open", () => {
-		expect(editedClip(null)).toBeNull();
+	it("is null with no project open, and for a track with no clip", () => {
+		expect(editedClip(null, null)).toBeNull();
+		const project = createSliceFixtureProject();
+		expect(
+			editedClip({ ...project, clips: [] }, editedTrack(project, null)),
+		).toBeNull();
 	});
 });
 
 describe("editedInstrument", () => {
-	it("is the first track's instrument", () => {
-		expect(editedInstrument(createSliceFixtureProject())?.kind).toBe("sampler");
-		expect(editedInstrument(createDrumMachineFixtureProject())?.kind).toBe(
-			"drumMachine",
-		);
-		expect(editedInstrument(createPianoRollFixtureProject())?.kind).toBe(
-			"synth",
-		);
+	it("is the edited track's instrument", () => {
+		const kindOf = (project: Project) =>
+			editedInstrument(editedTrack(project, null))?.kind;
+		expect(kindOf(createSliceFixtureProject())).toBe("sampler");
+		expect(kindOf(createDrumMachineFixtureProject())).toBe("drumMachine");
+		expect(kindOf(createPianoRollFixtureProject())).toBe("synth");
 	});
 
-	it("is null with no project open", () => {
+	it("is null with no track edited", () => {
 		expect(editedInstrument(null)).toBeNull();
 	});
 });
@@ -178,13 +222,18 @@ describe("loopClips", () => {
 
 describe("sampleName", () => {
 	it("names the sample the edited sampler is loaded with", () => {
-		expect(sampleName(createSliceFixtureProject())).toBe("909 Bass Drum");
+		const project = createSliceFixtureProject();
+		expect(sampleName(project, editedTrack(project, null))).toBe(
+			"909 Bass Drum",
+		);
 	});
 
 	it("is null when the edited instrument is not a sampler", () => {
-		expect(sampleName(createDrumMachineFixtureProject())).toBeNull();
-		expect(sampleName(createPianoRollFixtureProject())).toBeNull();
-		expect(sampleName(null)).toBeNull();
+		const drums = createDrumMachineFixtureProject();
+		expect(sampleName(drums, editedTrack(drums, null))).toBeNull();
+		const synth = createPianoRollFixtureProject();
+		expect(sampleName(synth, editedTrack(synth, null))).toBeNull();
+		expect(sampleName(null, null)).toBeNull();
 	});
 });
 
@@ -233,39 +282,48 @@ describe("packDependencyLabel", () => {
 });
 
 describe("showPianoRoll", () => {
+	const forProject = (project: Project) =>
+		showPianoRoll(project, editedTrack(project, null));
+
 	it("is true for a synth track holding a note clip", () => {
-		expect(showPianoRoll(createPianoRollFixtureProject())).toBe(true);
+		expect(forProject(createPianoRollFixtureProject())).toBe(true);
 	});
 
 	it("is false for a sampler or drum-machine note clip, which get the step grid", () => {
-		expect(showPianoRoll(createSliceFixtureProject())).toBe(false);
-		expect(showPianoRoll(createDrumMachineFixtureProject())).toBe(false);
+		expect(forProject(createSliceFixtureProject())).toBe(false);
+		expect(forProject(createDrumMachineFixtureProject())).toBe(false);
 	});
 
 	it("is false for a synth track with no clip", () => {
 		const project = createPianoRollFixtureProject();
-		expect(showPianoRoll({ ...project, clips: [] })).toBe(false);
+		expect(forProject({ ...project, clips: [] })).toBe(false);
 	});
 
 	it("is false with no project open", () => {
-		expect(showPianoRoll(null)).toBe(false);
+		expect(showPianoRoll(null, null)).toBe(false);
 	});
 });
 
 describe("instrumentPanelTrackId", () => {
-	it("names the track for a sampler or a synth", () => {
+	it("names the edited track, whatever instrument it carries", () => {
 		const sampler = createSliceFixtureProject();
-		expect(instrumentPanelTrackId(sampler)).toBe(sampler.song.tracks[0].id);
+		expect(instrumentPanelTrackId(editedTrack(sampler, null))).toBe(
+			sampler.song.tracks[0].id,
+		);
 		const synth = createPianoRollFixtureProject();
-		expect(instrumentPanelTrackId(synth)).toBe(synth.song.tracks[0].id);
+		expect(instrumentPanelTrackId(editedTrack(synth, null))).toBe(
+			synth.song.tracks[0].id,
+		);
 	});
 
 	it("names a drum-machine track too, so the kind picker can leave it (#224)", () => {
 		const drums = createDrumMachineFixtureProject();
-		expect(instrumentPanelTrackId(drums)).toBe(drums.song.tracks[0].id);
+		expect(instrumentPanelTrackId(editedTrack(drums, null))).toBe(
+			drums.song.tracks[0].id,
+		);
 	});
 
-	it("is null with no project open", () => {
+	it("is null with no track edited", () => {
 		expect(instrumentPanelTrackId(null)).toBeNull();
 	});
 });

--- a/src/editor/editorViewModel.ts
+++ b/src/editor/editorViewModel.ts
@@ -8,6 +8,7 @@ import type {
 import type { TrackId } from "../domain/ids";
 import { formatBarsBeatsSixteenths } from "../domain/time";
 import type { SampleChoice } from "../instrument/SamplerPanel";
+import type { SelectionState } from "../selection";
 
 /**
  * Pure, framework-free derivations behind `EditorView`.
@@ -62,22 +63,49 @@ export function playheadLabel(positionTicks: number): string {
 	return `${Number(bars) + 1}.${Number(beats) + 1}`;
 }
 
-/** The track this slice edits: the project's first. */
-export function editedTrack(project: Project | null): Track | null {
-	return project?.song.tracks[0] ?? null;
+/**
+ * The focused track in the editor's `SelectionState`, or null when focus is
+ * something other than a track (or nothing at all).
+ *
+ * Track selection is UI-only state held in the shared PRD 9.2 selection model,
+ * never in the project: `reconcileSelection` drops a track the project no
+ * longer has, and {@link editedTrack} falls back to the first track from there.
+ */
+export function focusedTrackId(selection: SelectionState): TrackId | null {
+	return selection.focus?.kind === "track" ? selection.focus.id : null;
 }
 
 /**
- * The first drum-machine track, if any, gets its instrument panel. The
- * `FND-009` starter is sampler-only; this surfaces the `LOOP-005` drum
- * machine wherever a project has one (e.g. the drum-machine fixture).
+ * The track the editor is pointed at: the one selected in the mixer or the
+ * arrangement, falling back to the project's first track when nothing is
+ * selected yet — or when the selection names a track the project no longer has
+ * (#228).
+ *
+ * The fallback is what makes every derivation below total: the editor always
+ * edits *some* track while the project has one, so opening a project needs no
+ * selection gesture first.
  */
-export function drumTrack(project: Project | null): Track | null {
+export function editedTrack(
+	project: Project | null,
+	selectedTrackId: TrackId | null,
+): Track | null {
+	const tracks = project?.song.tracks ?? [];
 	return (
-		project?.song.tracks.find(
-			(candidate) => candidate.instrument?.kind === "drumMachine",
-		) ?? null
+		tracks.find((candidate) => candidate.id === selectedTrackId) ??
+		tracks[0] ??
+		null
 	);
+}
+
+/**
+ * The edited track when it is a drum machine, which gets the `LOOP-005` pad
+ * panel instead of the sampler/synth panel. Following the selection rather
+ * than searching the project for the first drum-machine track is the point of
+ * #228: a project can hold several, and the one on screen is the one you
+ * clicked.
+ */
+export function drumTrack(track: Track | null): Track | null {
+	return track?.instrument?.kind === "drumMachine" ? track : null;
 }
 
 /** Every `sample`-kind asset the project carries. */
@@ -88,15 +116,17 @@ export function sampleAssets(project: Project | null): readonly Asset[] {
 }
 
 /** The clip on the edited track, if it has one. */
-export function editedClip(project: Project | null): Clip | null {
-	const track = editedTrack(project);
+export function editedClip(
+	project: Project | null,
+	track: Track | null,
+): Clip | null {
 	if (!project || !track) return null;
 	return project.clips.find((c) => c.trackId === track.id) ?? null;
 }
 
-/** The instrument of the slice's first track, and the audition note it plays. */
-export function editedInstrument(project: Project | null): Instrument | null {
-	return editedTrack(project)?.instrument ?? null;
+/** The edited track's instrument, and the audition note it plays. */
+export function editedInstrument(track: Track | null): Instrument | null {
+	return track?.instrument ?? null;
 }
 
 /**
@@ -116,8 +146,11 @@ export function loopClips(project: Project | null): readonly LoopClipEntry[] {
 }
 
 /** The name of the sample the edited track's sampler is loaded with. */
-export function sampleName(project: Project | null): string | null {
-	const current = editedInstrument(project);
+export function sampleName(
+	project: Project | null,
+	track: Track | null,
+): string | null {
+	const current = editedInstrument(track);
 	if (current?.kind !== "sampler" || !current.assetId) return null;
 	return (
 		project?.song.assets.find((asset) => asset.id === current.assetId)?.name ??
@@ -150,11 +183,13 @@ export function packDependencyLabel(project: Project | null): string | null {
  * FND-009 step grid: pitched notes want two dimensions (pitch x time), which
  * the 16-step grid cannot show.
  */
-export function showPianoRoll(project: Project | null): boolean {
-	const clip = editedClip(project);
+export function showPianoRoll(
+	project: Project | null,
+	track: Track | null,
+): boolean {
+	const clip = editedClip(project, track);
 	return (
-		editedInstrument(project)?.kind === "synth" &&
-		clip?.content.kind === "notes"
+		editedInstrument(track)?.kind === "synth" && clip?.content.kind === "notes"
 	);
 }
 
@@ -164,8 +199,6 @@ export function showPianoRoll(project: Project | null): boolean {
  * the kinds that have a sub-panel would leave a drum-machine track (whose own
  * panel `EditorView` mounts separately) with no way back off the drum machine.
  */
-export function instrumentPanelTrackId(
-	project: Project | null,
-): TrackId | null {
-	return editedTrack(project)?.id ?? null;
+export function instrumentPanelTrackId(track: Track | null): TrackId | null {
+	return track?.id ?? null;
 }


### PR DESCRIPTION
## What & why

1 of 3 for #228. Preparation only — **no behavior change**.

`editorViewModel` hard-coded the project's first track. `editedTrack` was
`song.tracks[0]`, and `editedClip`, `editedInstrument`, `sampleName`,
`showPianoRoll`, and `instrumentPanelTrackId` each re-derived it, so there was
nowhere to say "point the editor at *that* track" — the root of #228's "I can't
switch between tracks".

- `editedTrack(project, selectedTrackId)` resolves the selection, falling back
  to the project's first track when nothing is selected, or when the selected id
  names a track the project no longer has. That fallback is what keeps every
  derivation below it total, and keeps opening a project free of any selection
  gesture.
- The rest now take the resolved `Track` instead of re-deriving one.
- `drumTrack` follows the edited track rather than searching the project for the
  first drum-machine track: a project can hold several, and the one on screen
  should be the one you clicked.
- `focusedTrackId(selection)` reads the focused track out of the shared PRD 9.2
  `SelectionState` — where PR 2 holds the editor's selection. Selection stays
  UI-only state; nothing here touches a `Project`.

`EditorView` passes `null`, so it still edits the first track, exactly as
before. No domain, command, persistence, or audio contract is touched.

Refs #228

## Rebased onto #233/#235

This stack was written against `38c81ae` and rebased onto `efdad99` after #231,
#232, #233, #234 and #235 landed. One conflict here, resolved in `main`'s
favour: #235 had already widened `instrumentPanelTrackId` to name the edited
track whatever instrument it carries, so the kind picker can leave a drum
machine. That semantic is kept exactly; only the signature changes, from
`(project)` to the resolved `(track)`. Its test keeps `main`'s
drum-machine case and drops the "is null for a drum machine" case this branch
had written against the older behaviour — that assertion contradicted #235, and
belonged to it, not to this PR.

## Core flows

Untouched. This issue is a bug report and links no flow. `git diff origin/main
--stat -- e2e/ e2e-emulator/ docs/` is empty across this PR.

## Walkthrough

No UI change. Every rendered output is identical: the parameter added here is
passed `null` by the only caller. The walkthrough for the change users can see
is on the PR that closes the issue (3 of 3).

## Evidence

All re-run on the rebased commit (`9d96b92`), not carried over from before it:

- `bun run typecheck` — clean.
- `bun run check` — `Checked 491 files. No fixes applied.`
- `bun run test` — `Test Files 170 passed (170)`, `Tests 2285 passed (2285)`,
  green on this commit on its own.
- `src/editor/editorViewModel.test.ts` grew by ten cases: the existing ones now
  pass the resolved track explicitly, plus new ones for the selected track, the
  two fallbacks (nothing selected, selected track gone), a project with no
  tracks, `focusedTrackId`, and `drumTrack` no longer answering for a track that
  is not the edited one.

## Acceptance criteria met

The issue has no checkboxes and this PR satisfies neither of its two symptoms on
its own — it is the seam the next two build on. Both are met by the end of the
stack: PR 2 (#239) makes the mixer select, PR 3 (#240) the arrangement.