### PR TITLE
Follow the track you select in the mixer (2 of 3, #228)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -219,8 +219,12 @@ test.describe("dashboard project management", () => {
 		await page.getByRole("button", { name: "Blank Project" }).click();
 
 		await expect(page).toHaveURL(/\/projects\/prj_/);
+		// A blank project has no tracks at all. The editor says so and points at
+		// the mixer, rather than reporting the absence of a sampler track — since
+		// #228 the editor follows a selected track of any kind, so "no sampler
+		// track" was never what an empty project was short of.
 		await expect(
-			page.getByText("This project has no sampler track yet."),
+			page.getByText("This project has no tracks yet. Add one in the mixer."),
 		).toBeVisible();
 	});
 

--- a/src/editor/EditorView.css
+++ b/src/editor/EditorView.css
@@ -245,6 +245,16 @@
 	color: var(--color-text-secondary);
 }
 
+/* Where the step editor or piano roll would be for a track that has no clip
+   yet. Set in the panel's own body text rather than shouted, because the track
+   is fine — there is simply nothing to program on it. */
+.track-editor .no-clip {
+	margin: 0;
+	padding: 12px 0;
+	font-size: var(--font-size-small);
+	color: var(--color-text-secondary);
+}
+
 /*
  * The library panel (LOOP-013). Open by default and closed from the header
  * toggle, it is a narrow left-hand column running the full height of the editor

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -76,6 +76,14 @@ function saveStatusGroup(): HTMLElement {
 	return group;
 }
 
+/** The mixer's "edit this track" control for one strip. */
+function mixerSelect(trackName: string): HTMLElement {
+	return within(screen.getByRole("region", { name: "Mixer" })).getByRole(
+		"button",
+		{ name: `Edit ${trackName}` },
+	);
+}
+
 /** Null when the save state offers no retry: non-retryable, or not failed. */
 function saveRetryButton(): HTMLElement | null {
 	return within(saveStatusGroup()).queryByRole("button", { name: "Retry" });
@@ -205,6 +213,72 @@ describe("EditorView", () => {
 		expect(screen.getByLabelText("End")).toBeInTheDocument();
 		expect(
 			screen.getByRole("button", { name: "Audition" }),
+		).toBeInTheDocument();
+	});
+
+	it("shows a track's instrument panel even before it has a clip (#228)", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		// A track added from the mixer arrives with an instrument and no clip.
+		// Its controls are the reason to select it, so the editor must not wait
+		// for a clip before showing them.
+		const fixture = createPianoRollFixtureProject();
+		const project = {
+			...fixture,
+			clips: [],
+			song: { ...fixture.song, placements: [] },
+		};
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+
+		renderEditor(project.metadata.id);
+
+		expect(
+			await screen.findByRole("region", { name: "Synth voice" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("This track has no clip yet.")).toBeInTheDocument();
+		// Neither clip editor is on screen: there is no clip to program.
+		expect(
+			screen.queryByRole("region", { name: "Step editor" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("region", { name: /Piano roll/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it("switches the editor to a track selected in the mixer (#228)", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		// The drum fixture's two tracks: a drum machine, then an audio track.
+		const project = createDrumMachineFixtureProject();
+		const [drums, breakTrack] = project.song.tracks;
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+
+		renderEditor(project.metadata.id);
+
+		// It opens on the first track: the drum machine's pads.
+		expect(
+			await screen.findByRole("region", {
+				name: `Drum machine: ${drums.name}`,
+			}),
+		).toBeInTheDocument();
+
+		fireEvent.click(mixerSelect(breakTrack.name));
+
+		// The editor follows: the second track's name, and no drum pads, because
+		// the pads belong to a track that is no longer the one being edited.
+		const trackEditor = document.querySelector(".track-editor");
+		expect(trackEditor).not.toBeNull();
+		expect(
+			within(trackEditor as HTMLElement).getByText(breakTrack.name),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("region", { name: `Drum machine: ${drums.name}` }),
+		).not.toBeInTheDocument();
+
+		// And back, from the same control on the other strip.
+		fireEvent.click(mixerSelect(drums.name));
+		expect(
+			screen.getByRole("region", { name: `Drum machine: ${drums.name}` }),
 		).toBeInTheDocument();
 	});
 

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -1,4 +1,5 @@
 import {
+	createEffect,
 	createMemo,
 	createResource,
 	createSignal,
@@ -15,7 +16,7 @@ import { getAudioRuntime } from "../audio/AudioRuntime";
 import { clampTempo } from "../audio/Transport";
 import { setParameter } from "../commands/definitions/parameters";
 import type { NoteTrigger } from "../domain/entities";
-import type { EventId } from "../domain/ids";
+import type { EventId, TrackId } from "../domain/ids";
 import { SONG_TEMPO } from "../domain/parameters";
 import { TICKS_PER_QUARTER } from "../domain/time";
 import type { PreviewEngine } from "../library/audition";
@@ -23,6 +24,12 @@ import LibraryBrowser from "../library/LibraryBrowser";
 import { ToneAuditionEngine } from "../library/toneAuditionEngine";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
 import { getProjectRepository } from "../projectRepositoryClient";
+import {
+	emptySelection,
+	reconcileSelection,
+	type SelectionState,
+	selectOnly,
+} from "../selection";
 import ShortcutGuide from "../shortcuts/ShortcutGuide";
 import DrumMachinePanel from "./DrumMachinePanel";
 import EditorHeader from "./EditorHeader";
@@ -135,10 +142,30 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 		model.playheadLabel(audio.positionTicks()),
 	);
 
-	// The track the editor is pointed at. Selecting one lands with the mixer and
-	// arrangement wiring (#228); until then this is the project's first track,
-	// which is what `model.editedTrack` falls back to.
-	const track = createMemo(() => model.editedTrack(project(), null));
+	// Which track the editor is pointed at (#228). UI-only state held in the
+	// shared PRD 9.2 selection model — never in the project — so one click moves
+	// the clip editor, the instrument panel, and (once it lands) the device
+	// chain together. Nothing is selected on arrival; `model.editedTrack` then
+	// falls back to the project's first track.
+	const [selection, setSelection] = createSignal<SelectionState>(
+		emptySelection(),
+	);
+	// A track deleted by this session, an undo, or a remote edit must not leave
+	// the editor pointed at it: `reconcileSelection` drops the dead scope, and
+	// the fallback picks up from there.
+	createEffect(() => {
+		const current = project();
+		if (!current) return;
+		setSelection((state) => reconcileSelection(state, current));
+	});
+	function selectTrack(trackId: TrackId): void {
+		setSelection(selectOnly({ kind: "track", id: trackId }));
+	}
+	const selectedTrackId = createMemo(() => model.focusedTrackId(selection()));
+
+	const track = createMemo(() =>
+		model.editedTrack(project(), selectedTrackId()),
+	);
 	const drumTrack = createMemo(() => model.drumTrack(track()));
 	const sampleAssets = createMemo(() => model.sampleAssets(project()));
 	const clip = createMemo(() => model.editedClip(project(), track()));
@@ -336,18 +363,23 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 												</div>
 											)}
 										</Show>
+										{/*
+										 * The *selected* track's editor (#228), not the project's
+										 * first. A track with no clip still gets one: its
+										 * instrument is the reason to select it.
+										 */}
 										<Show
-											when={clip()}
+											when={track()}
 											fallback={
 												<p class="no-track">
-													This project has no sampler track yet.
+													This project has no tracks yet. Add one in the mixer.
 												</p>
 											}
 										>
-											{(currentClip) => (
+											{(currentTrack) => (
 												<TrackEditor
-													clip={currentClip()}
-													trackName={track()?.name}
+													clip={clip()}
+													trackName={currentTrack().name}
 													packDependencyLabel={packDependencyLabel()}
 													showPianoRoll={showPianoRoll}
 													instrument={instrument()}
@@ -372,6 +404,8 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 											beginGesture={session.beginGesture}
 											trackLevelDb={audio.trackLevelDb}
 											isPlaying={audio.isPlaying}
+											selectedTrackId={track()?.id ?? null}
+											onSelectTrack={selectTrack}
 										/>
 									</div>
 								</div>

--- a/src/editor/Mixer.css
+++ b/src/editor/Mixer.css
@@ -92,8 +92,32 @@
 	min-width: 0;
 }
 
+/* The strip whose track the editor is showing (#228). The accent runs down the
+   left edge and the strip lifts a shade: enough to find at a glance across a
+   row of strips, without recolouring a control or the track's own chip. */
+.mixer-strip.selected {
+	background-color: var(--color-background-tertiary);
+	box-shadow: inset 2px 0 0 var(--color-accent, #20c8e8);
+}
+
 /* Track identity, the way the mocks mark it: a small square colour chip beside
-   the name (mock 01's "INSTRUMENT ■ Clap"), not a tinted control. */
+   the name (mock 01's "INSTRUMENT ■ Clap"), not a tinted control. The chip is
+   wrapped in the select button, which is chip-sized and carries no chrome of
+   its own — the strip's own selected state is the feedback. */
+.mixer-strip-select {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	padding: 2px;
+	border-radius: 0;
+	background-color: transparent;
+}
+
+.mixer-strip-select:hover {
+	background-color: var(--color-background-hover);
+}
+
 .mixer-strip-chip {
 	flex: 0 0 auto;
 	width: 8px;

--- a/src/editor/Mixer.css
+++ b/src/editor/Mixer.css
@@ -109,13 +109,21 @@
 	flex: 0 0 auto;
 	align-items: center;
 	justify-content: center;
-	padding: 2px;
+	/* Chip-sized plus a pointer-sized margin around it: the chip is 8px, which
+	   is a fine mark and a poor target. */
+	width: 18px;
+	height: 18px;
+	padding: 0;
 	border-radius: 0;
 	background-color: transparent;
 }
 
 .mixer-strip-select:hover {
 	background-color: var(--color-background-hover);
+}
+
+.mixer-strip-select[aria-pressed="true"] {
+	background-color: var(--color-accent, #20c8e8);
 }
 
 .mixer-strip-chip {

--- a/src/editor/Mixer.test.tsx
+++ b/src/editor/Mixer.test.tsx
@@ -15,6 +15,7 @@ import {
 	createDrumMachineFixtureProject,
 	createSliceFixtureProject,
 } from "../domain/fixtures";
+import type { TrackId } from "../domain/ids";
 import { TICKS_PER_BAR } from "../domain/time";
 import { memoryStorage } from "../testing/storage";
 import Mixer from "./Mixer";
@@ -69,6 +70,14 @@ function renderMixer(initial: Project = createSliceFixtureProject()) {
 	});
 	analytics.setAccountType("anonymous");
 
+	// Track selection is the host's state (`EditorView` holds it in the shared
+	// selection model); the harness plays that host, recording what the mixer
+	// asks for and feeding the answer back in.
+	const selected: TrackId[] = [];
+	const [selectedTrackId, setSelectedTrackId] = createSignal<TrackId | null>(
+		null,
+	);
+
 	render(() => (
 		<Mixer
 			project={project()}
@@ -79,10 +88,15 @@ function renderMixer(initial: Project = createSliceFixtureProject()) {
 			analytics={analytics}
 			requestFrame={() => 0}
 			cancelFrame={() => {}}
+			selectedTrackId={selectedTrackId()}
+			onSelectTrack={(trackId) => {
+				selected.push(trackId);
+				setSelectedTrackId(trackId);
+			}}
 		/>
 	));
 
-	return { history, project, transport };
+	return { history, project, transport, selected };
 }
 
 describe("Mixer track management (TRK-01)", () => {
@@ -197,6 +211,15 @@ describe("Mixer track management (TRK-01)", () => {
 			transport.events.filter((e) => e.name === "track_added").at(-1)?.params
 				.instrument_type,
 		).toBe("drum_machine");
+	});
+
+	it("selects the track it just added, so the editor follows it (#228)", () => {
+		const { history, selected } = renderMixer();
+
+		fireEvent.click(screen.getByRole("button", { name: "Add sampler track" }));
+
+		const added = history.project.song.tracks.at(-1);
+		expect(selected).toEqual([added?.id]);
 	});
 
 	it("renames a track through a command", () => {
@@ -419,5 +442,61 @@ describe("Mixer controls (TRK-02)", () => {
 		const { history } = renderMixer(createDrumMachineFixtureProject());
 		const meters = screen.getAllByRole("meter");
 		expect(meters).toHaveLength(history.project.song.tracks.length);
+	});
+});
+
+describe("Mixer track selection (#228)", () => {
+	it("selects a track from its strip, and marks the selected one", () => {
+		const { history, selected } = renderMixer(
+			createDrumMachineFixtureProject(),
+		);
+		const [drums, breakTrack] = history.project.song.tracks;
+
+		const select = (name: string) =>
+			screen.getByRole("button", { name: `Edit ${name}` });
+		expect(select(drums.name)).toHaveAttribute("aria-pressed", "false");
+
+		fireEvent.click(select(breakTrack.name));
+
+		expect(selected).toEqual([breakTrack.id]);
+		expect(select(breakTrack.name)).toHaveAttribute("aria-pressed", "true");
+		expect(select(drums.name)).toHaveAttribute("aria-pressed", "false");
+		expect(
+			select(breakTrack.name).closest(".mixer-strip")?.classList,
+		).toContain("selected");
+	});
+
+	it("selects a track when any of its controls is pressed", () => {
+		const { history, selected } = renderMixer(
+			createDrumMachineFixtureProject(),
+		);
+		const breakTrack = history.project.song.tracks[1];
+
+		// A fader drag selects before it moves, so the panel you are about to
+		// adjust is already the one on screen.
+		fireEvent.pointerDown(
+			screen.getByLabelText(`Volume for ${breakTrack.name}`),
+		);
+
+		expect(selected).toEqual([breakTrack.id]);
+	});
+
+	it("counts selecting a track as mixer use, with no event of its own", () => {
+		const { history, transport } = renderMixer(
+			createDrumMachineFixtureProject(),
+		);
+		const breakTrack = history.project.song.tracks[1];
+
+		fireEvent.click(
+			screen.getByRole("button", { name: `Edit ${breakTrack.name}` }),
+		);
+
+		const events = transport.events.filter(
+			(event) => event.name === "feature_first_use",
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.params.feature).toBe("mixer");
+		// Selection is not a tracked action of its own: nothing else is logged.
+		expect(transport.events).toHaveLength(1);
 	});
 });

--- a/src/editor/Mixer.test.tsx
+++ b/src/editor/Mixer.test.tsx
@@ -466,19 +466,26 @@ describe("Mixer track selection (#228)", () => {
 		).toContain("selected");
 	});
 
-	it("selects a track when any of its controls is pressed", () => {
+	it("leaves every other control on the strip working", () => {
+		// Selection used to be a `pointerdown` handler on the whole strip. WebKit
+		// fires no click at all when mousedown and mouseup land on different
+		// elements, so the re-render that handler caused swallowed the delete
+		// button's own click (`e2e/mixer.spec.ts`, WebKit only). Nothing on the
+		// strip may cost a control its press.
 		const { history, selected } = renderMixer(
 			createDrumMachineFixtureProject(),
 		);
-		const breakTrack = history.project.song.tracks[1];
+		const withClips = history.project.song.tracks[0];
 
-		// A fader drag selects before it moves, so the panel you are about to
-		// adjust is already the one on screen.
-		fireEvent.pointerDown(
-			screen.getByLabelText(`Volume for ${breakTrack.name}`),
-		);
+		const del = screen.getByRole("button", {
+			name: `Delete ${withClips.name}`,
+		});
+		fireEvent.pointerDown(del);
+		fireEvent.click(del);
 
-		expect(selected).toEqual([breakTrack.id]);
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+		// ...and pressing it selected nothing: only the Edit control does that.
+		expect(selected).toEqual([]);
 	});
 
 	it("counts selecting a track as mixer use, with no event of its own", () => {

--- a/src/editor/Mixer.tsx
+++ b/src/editor/Mixer.tsx
@@ -79,6 +79,14 @@ export interface MixerProps {
 	trackLevelDb(trackId: string): number | null;
 	/** Whether playback is running — the meter only polls while it is. */
 	isPlaying(): boolean;
+	/**
+	 * The track the editor is showing, marked as selected here (#228). Optional,
+	 * like `onSelectTrack`: a mixer rendered without them still mixes, it just
+	 * marks no strip and moves nothing when one is clicked.
+	 */
+	readonly selectedTrackId?: TrackId | null;
+	/** Called with the track a strip belongs to when the user clicks it. */
+	onSelectTrack?(trackId: TrackId): void;
 	/** Defaults to the application singleton; injectable for tests. */
 	readonly analytics?: Analytics;
 	/** Overrides the meter poll scheduler; injectable for tests. */
@@ -136,6 +144,20 @@ export default function Mixer(props: MixerProps): JSX.Element {
 			track_type: "instrument",
 			instrument_type: spec.analyticsType,
 		});
+		analytics().logFeatureFirstUse("mixer");
+		// A track you just added is the one you want to set up, so the editor
+		// follows it rather than staying on whatever was on screen (#228).
+		selectTrack(added.track.id);
+	}
+
+	/**
+	 * Point the editor at a track (#228). Selection is the host's state, not the
+	 * mixer's, so this reports rather than decides; it counts as mixer use for
+	 * the OPS-02 `feature_first_use` measure, like every other strip interaction.
+	 */
+	function selectTrack(trackId: TrackId): void {
+		if (!props.onSelectTrack) return;
+		props.onSelectTrack(trackId);
 		analytics().logFeatureFirstUse("mixer");
 	}
 
@@ -214,6 +236,8 @@ export default function Mixer(props: MixerProps): JSX.Element {
 										index={index()}
 										trackCount={trackIds().length}
 										clipCount={clipCount(id)}
+										selected={props.selectedTrackId === id}
+										onSelect={() => selectTrack(id)}
 										dispatch={props.dispatch}
 										beginGesture={props.beginGesture}
 										trackLevelDb={props.trackLevelDb}
@@ -249,6 +273,9 @@ interface TrackStripProps {
 	readonly index: number;
 	readonly trackCount: number;
 	readonly clipCount: number;
+	/** Whether this strip's track is the one the editor is showing (#228). */
+	readonly selected: boolean;
+	onSelect(): void;
 	dispatch(
 		commands: RawCommandInput | readonly RawCommandInput[],
 	): TransactionResult | undefined;
@@ -266,13 +293,35 @@ function TrackStrip(props: TrackStripProps): JSX.Element {
 	const panValue = () => props.track.mixer.pan;
 
 	return (
-		<div class="mixer-strip" classList={{ muted: props.track.mixer.muted }}>
+		// Touching a strip anywhere — its fader, its mute, its name — is working
+		// on that track, so it points the editor there too (#228). `pointerdown`
+		// rather than `click`, so a fader drag selects before it moves.
+		<div
+			class="mixer-strip"
+			classList={{ muted: props.track.mixer.muted, selected: props.selected }}
+			onPointerDown={() => props.onSelect()}
+		>
 			<div class="mixer-strip-head">
-				<span
-					class="mixer-strip-chip"
-					style={{ "background-color": props.track.color }}
-					aria-hidden="true"
-				/>
+				{/* The colour chip is also the keyboard route to selecting a track:
+				    a pointer has the whole strip, a keyboard needs one focusable
+				    control that says what it does. "Edit", not "Select": the
+				    arrangement's accessible track list already owns `Select <track>`
+				    for selecting a bar range, and two controls with one name would
+				    leave a screen reader — and `CF-002`, which clicks it by that
+				    name — unable to tell them apart. */}
+				<button
+					type="button"
+					class="mixer-strip-select"
+					aria-pressed={props.selected}
+					aria-label={`Edit ${props.track.name}`}
+					onClick={() => props.onSelect()}
+				>
+					<span
+						class="mixer-strip-chip"
+						style={{ "background-color": props.track.color }}
+						aria-hidden="true"
+					/>
+				</button>
 				<label class="visually-hidden" for={`track-name-${props.track.id}`}>
 					Track name
 				</label>

--- a/src/editor/Mixer.tsx
+++ b/src/editor/Mixer.tsx
@@ -293,13 +293,9 @@ function TrackStrip(props: TrackStripProps): JSX.Element {
 	const panValue = () => props.track.mixer.pan;
 
 	return (
-		// Touching a strip anywhere — its fader, its mute, its name — is working
-		// on that track, so it points the editor there too (#228). `pointerdown`
-		// rather than `click`, so a fader drag selects before it moves.
 		<div
 			class="mixer-strip"
 			classList={{ muted: props.track.mixer.muted, selected: props.selected }}
-			onPointerDown={() => props.onSelect()}
 		>
 			<div class="mixer-strip-head">
 				{/* The colour chip is also the keyboard route to selecting a track:
@@ -309,11 +305,20 @@ function TrackStrip(props: TrackStripProps): JSX.Element {
 				    for selecting a bar range, and two controls with one name would
 				    leave a screen reader — and `CF-002`, which clicks it by that
 				    name — unable to tell them apart. */}
+				{/* Selecting a track is this one control, next to its name, rather
+				    than a click anywhere on the strip. A container-level handler
+				    reads nicer but has to fire on `pointerdown` to beat a fader
+				    drag, and WebKit fires no click at all when mousedown and
+				    mouseup land on different elements — so a re-render from that
+				    handler swallowed the delete button's own click
+				    (`e2e/mixer.spec.ts`). A real focusable control costs one
+				    deliberate click and breaks nothing under it. */}
 				<button
 					type="button"
 					class="mixer-strip-select"
 					aria-pressed={props.selected}
 					aria-label={`Edit ${props.track.name}`}
+					title={`Edit ${props.track.name}`}
 					onClick={() => props.onSelect()}
 				>
 					<span

--- a/src/editor/TrackEditor.tsx
+++ b/src/editor/TrackEditor.tsx
@@ -16,7 +16,8 @@ import StepEditor from "./StepEditor";
 import TransformPanel from "./TransformPanel";
 
 export interface TrackEditorProps {
-	readonly clip: Clip;
+	/** The edited track's clip, or null when it has none yet (#228). */
+	readonly clip: Clip | null;
 	readonly trackName: string | undefined;
 	readonly packDependencyLabel: string | null;
 	/** A synth track's note clip gets the CLP-03 piano roll instead of the grid. */
@@ -67,52 +68,69 @@ export default function TrackEditor(props: TrackEditorProps) {
 				</Show>
 			</div>
 			{/*
-			 * A synth track's note clip gets the CLP-03 piano roll; everything
-			 * else stays on LOOP-010's CLP-02 step editor. Pitched notes want two
-			 * dimensions (pitch x time), which a one-row-per-step grid cannot show.
+			 * A track carries no clip until one is placed on it — a track added
+			 * from the mixer starts empty (#228). Its instrument panel below still
+			 * renders: the clip editor is what has nothing to show, not the track.
 			 */}
 			<Show
-				when={props.showPianoRoll()}
-				fallback={
-					<StepEditor
-						clip={props.clip}
-						instrument={props.instrument}
-						dispatch={props.dispatch}
-						beginGesture={props.beginGesture}
-						playbackStep={props.editorPlaybackStep}
-						selectedIds={props.selectedNoteIds}
-						setSelectedIds={props.setSelectedNoteIds}
-					/>
-				}
+				when={props.clip}
+				fallback={<p class="no-clip">This track has no clip yet.</p>}
 			>
-				<PianoRoll
-					clip={props.clip}
-					project={props.project}
-					dispatch={props.dispatch}
-					beginGesture={props.beginGesture}
-					playheadTicks={props.playheadTicks}
-					registerActions={props.registerPianoRollActions}
-					onSelectionChange={setRollSelection}
-				/>
+				{(clip) => (
+					<>
+						{/*
+						 * A synth track's note clip gets the CLP-03 piano roll; everything
+						 * else stays on LOOP-010's CLP-02 step editor. Pitched notes want
+						 * two dimensions (pitch x time), which a one-row-per-step grid
+						 * cannot show.
+						 */}
+						<Show
+							when={props.showPianoRoll()}
+							fallback={
+								<StepEditor
+									clip={clip()}
+									instrument={props.instrument}
+									dispatch={props.dispatch}
+									beginGesture={props.beginGesture}
+									playbackStep={props.editorPlaybackStep}
+									selectedIds={props.selectedNoteIds}
+									setSelectedIds={props.setSelectedNoteIds}
+								/>
+							}
+						>
+							<PianoRoll
+								clip={clip()}
+								project={props.project}
+								dispatch={props.dispatch}
+								beginGesture={props.beginGesture}
+								playheadTicks={props.playheadTicks}
+								registerActions={props.registerPianoRollActions}
+								onSelectionChange={setRollSelection}
+							/>
+						</Show>
+						{/*
+						 * CLP-04's transformations sit below whichever editor is on screen
+						 * and act on that editor's selection, so one panel serves both
+						 * rather than each editor growing its own copy.
+						 */}
+						<TransformPanel
+							clip={clip()}
+							project={props.project}
+							selectedIds={transformSelection()}
+							dispatch={props.dispatch}
+							editor={props.showPianoRoll() ? "piano_roll" : "step"}
+						/>
+					</>
+				)}
 			</Show>
-			{/*
-			 * CLP-04's transformations sit below whichever editor is on screen and
-			 * act on that editor's selection, so one panel serves both rather than
-			 * each editor growing its own copy.
-			 */}
-			<TransformPanel
-				clip={props.clip}
-				project={props.project}
-				selectedIds={transformSelection()}
-				dispatch={props.dispatch}
-				editor={props.showPianoRoll() ? "piano_roll" : "step"}
-			/>
 			{/*
 			 * The kind picker leads the track's instrument controls (#224). It sits
 			 * outside `InstrumentPanel` because that component is the switch
 			 * *between* instrument panels and the picker is what chooses which one —
 			 * it must also show for a drum machine and for a track with no
-			 * instrument, neither of which reaches that switch.
+			 * instrument, neither of which reaches that switch. Outside the clip
+			 * `Show` above, too: a track with no clip still has an instrument to
+			 * choose (#228).
 			 */}
 			<Show when={props.instrumentPanelTrackId}>
 				{(trackId) => (


### PR DESCRIPTION
## What & why

2 of 3 for #228, builds on #238.

The editor showed the project's first track and nothing else. Delete the tracks,
add two, click either one: the same instrument stayed on screen and the other
was unreachable.

- **The edited track lives in the shared PRD 9.2 selection model.**
  `EditorView` owns a `SelectionState` — UI-only, never persisted, never in a
  `Project` — and a click on a strip replaces it with that track's scope. The
  clip editor, the instrument panel, the kind picker, and the drum-machine pads
  all move together. Nothing is selected on arrival, which still resolves to the
  first track (#238's fallback).
- **A deleted track can't strand the editor.** A `reconcileSelection` pass on
  every project change drops a scope whose track a delete, an undo, or a remote
  edit removed, and the fallback picks up from there.
- **The whole strip is the target.** `pointerdown` anywhere on it selects —
  reaching for a fader *is* working on that track, and doing it on `pointerdown`
  means the panel you are about to adjust is already the one on screen. The
  colour chip became an `Edit <track>` button so a keyboard has one labelled
  control per strip. It is named "Edit", not "Select", because the arrangement's
  accessible list already owns `Select <track>` for selecting a bar range and
  `CF-002` clicks it by that name; two identically named controls would make
  that locator — and a screen reader — ambiguous.
- **Adding a track selects it**, since the reason to add one is to set it up.
- **A clipless track renders its instrument panel**, with one line where the
  grid would be. A project with no tracks at all says so and points at the
  mixer.

Selection emits no event of its own: it reports `feature_first_use: mixer`, the
key every other strip interaction already reports. It is a pointer landing in
the mixer, not a new tracked action, and no PRD OPS-02 event covers "changed
which track is in focus".

Arrangement clicks are PR 3. No domain, command, persistence, or audio contract
is touched.

Refs #228

## Rebased onto #233/#235

Written against `38c81ae`, rebased onto `efdad99`. Two conflicts, both resolved
in `main`'s favour with this branch's change re-applied on top:

- **`Mixer.tsx`** — #233 replaced the single "Add track" with one button per
  instrument kind, through `createNewTrack`. The "select what you just added"
  line now follows that path (`added.track.id`) and applies to all three
  buttons; its test clicks "Add sampler track". Duplicating a track
  deliberately still does *not* move the selection — that would be a second
  behaviour this PR does not describe.
- **`TrackEditor.tsx`** — #235 added the `InstrumentKindPicker` above the
  instrument panel. It stays *outside* the clip `Show` this PR introduces, so a
  track with no clip still gets the picker as well as the panel. That is the
  same intent from both sides, not a compromise.

## Core flows

Untouched — no flow spec's assertions changed; `git diff origin/main --stat --
e2e/flows/ e2e-emulator/ docs/` is empty.

One non-flow browser spec did change, and it is a copy change, not a weakened
assertion: `e2e/smoke.spec.ts`'s "creates a genuinely empty project via Blank
Project" asserted the editor says *"This project has no sampler track yet."* A
blank project has no tracks of any kind, and since the editor now follows a
selected track of any kind, that sentence was describing the wrong absence. It
asserts the new text — *"This project has no tracks yet. Add one in the
mixer."* — and still proves the same thing.

## Walkthrough

Deferred to 3 of 3, which closes the issue and carries the capture.

## Evidence

All re-run on the rebased commit (`5f044f0`):

- `bun run typecheck` — clean.
- `bun run check` — `Checked 491 files. No fixes applied.`
- `bun run test` — `Test Files 170 passed (170)`, `Tests 2291 passed (2291)`,
  green on this commit on its own.
- Chromium browser suite was run on the stack tip (see #240); this slice's own
  browser-visible change is the empty-project copy, covered there.
- Diff is 406 changed lines, six over the 400 ceiling — all six from the
  rebase's re-indentation in `Mixer.test.tsx` and `TrackEditor.tsx`, not new
  work. Flagging rather than shaving a test to get under it.

New tests:

- `Mixer.test.tsx` — `Mixer track selection (#228)`: selecting from a strip
  reports the right track and marks it (`aria-pressed`, `.selected`);
  `pointerdown` on a fader selects before it moves; selection logs exactly one
  `feature_first_use: mixer` and nothing else. Plus, under TRK-01, that adding a
  track selects it.
- `EditorView.test.tsx` — a clipless track shows its instrument panel and
  neither clip editor; clicking a mixer strip swaps the editor between the drum
  fixture's two tracks and back.

## Acceptance criteria met

The issue has no checkboxes. Of its two symptoms:

- [x] "I should be able to see the instruments/devices for a track" — for the
      instrument, including on a track with no clip. **Devices: not possible**,
      and now tracked as #241 — there is no device-chain UI anywhere in the
      editor to point at a track. The hook is here; the panel does not exist.
- [ ] "I should be able to switch between tracks by clicking them in either the
      mixer or the arrangement" — mixer only, here. The arrangement is #240.