### PR TITLE
Select a track by clicking it in the arrangement (3 of 3, #228)

### DIFF
--- a/src/arrangement/ArrangementView.css
+++ b/src/arrangement/ArrangementView.css
@@ -88,11 +88,36 @@
 .arrangement-header-row {
 	display: flex;
 	align-items: center;
-	gap: 8px;
-	padding: 0 8px;
 	font-size: 12px;
 	box-sizing: border-box;
 	border-bottom: 1px solid #1e1e1e;
+}
+
+/* The whole row is the select control (#228): it fills the header cell and
+   carries no chrome of its own, so the column still reads as a list of tracks
+   rather than a column of buttons. The row whose track the editor is showing
+   takes the accent edge the mixer's selected strip does. */
+.arrangement-header-select {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	height: 100%;
+	padding: 0 8px;
+	border-radius: 0;
+	font: inherit;
+	text-align: left;
+	background-color: transparent;
+	color: inherit;
+}
+
+.arrangement-header-select:hover {
+	background-color: #232323;
+}
+
+.arrangement-header-select[aria-pressed="true"] {
+	background-color: #232323;
+	box-shadow: inset 2px 0 0 var(--color-accent, #20c8e8);
 }
 
 .arrangement-header-swatch {

--- a/src/arrangement/ArrangementView.test.tsx
+++ b/src/arrangement/ArrangementView.test.tsx
@@ -1,4 +1,11 @@
-import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	within,
+} from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Analytics } from "../analytics/analytics";
 import { ConsentStore } from "../analytics/consent";
@@ -7,6 +14,7 @@ import {
 	createLargeArrangementProject,
 	createSliceFixtureProject,
 } from "../domain/fixtures";
+import type { TrackId } from "../domain/ids";
 import { TICKS_PER_BAR } from "../domain/time";
 import { EditorSession } from "../editor/EditorSession";
 import { createInMemoryProjectRepository } from "../persistence/inMemoryProjectRepository";
@@ -318,5 +326,87 @@ describe("placement editing wiring (ARR-002)", () => {
 		fireEvent.click(screen.getByText(/Duplicate as an independent copy/));
 		expect(session.project.clips.length).toBe(originalClipCount + 1);
 		expect(session.project.song.placements.length).toBe(3);
+	});
+});
+
+describe("arrangement track selection (#228)", () => {
+	/** The view with a host holding the selected track, as `EditorView` does. */
+	function renderSelectable() {
+		const { analytics, transport } = analyticsAllowing();
+		const project = createLargeArrangementProject(20);
+		const selected: string[] = [];
+		const [selectedTrackId, setSelectedTrackId] = createSignal<TrackId | null>(
+			null,
+		);
+		const result = render(() => (
+			<ArrangementView
+				project={project}
+				analytics={analytics}
+				selectedTrackId={selectedTrackId()}
+				onSelectTrack={(trackId) => {
+					selected.push(trackId);
+					setSelectedTrackId(trackId);
+				}}
+			/>
+		));
+		return { ...result, project, selected, transport };
+	}
+
+	function headerButton(trackName: string): HTMLElement {
+		return within(screen.getByLabelText("Tracks")).getByRole("button", {
+			name: `Edit ${trackName}`,
+		});
+	}
+
+	it("selects a track from its header row, and marks the selected one", () => {
+		const { project, selected } = renderSelectable();
+		const second = project.song.tracks[1];
+
+		expect(headerButton(second.name)).toHaveAttribute("aria-pressed", "false");
+		fireEvent.click(headerButton(second.name));
+
+		expect(selected).toEqual([second.id]);
+		expect(headerButton(second.name)).toHaveAttribute("aria-pressed", "true");
+		expect(headerButton(project.song.tracks[0].name)).toHaveAttribute(
+			"aria-pressed",
+			"false",
+		);
+	});
+
+	it("selects the track of the row a pointer lands on in the timeline", () => {
+		const { container, project, selected } = renderSelectable();
+
+		// Row 1 (the second track), a bar in and clear of the ruler.
+		firePointer(interactionCanvasOf(container), "pointerdown", {
+			clientX: TICKS_PER_BAR * PIXELS_PER_TICK,
+			clientY: RULER_HEIGHT_PX + ROW_HEIGHT_PX + ROW_HEIGHT_PX / 2,
+		});
+
+		expect(selected).toEqual([project.song.tracks[1].id]);
+	});
+
+	it("selects the track from the accessible list too, alongside its bar range", () => {
+		const { project, selected } = renderSelectable();
+		const list = screen.getByLabelText("Arrangement tracks");
+		const buttons = list.querySelectorAll<HTMLButtonElement>(
+			"button[data-track-select]",
+		);
+
+		fireEvent.click(buttons[1]);
+
+		expect(selected).toEqual([project.song.tracks[1].id]);
+		// The bar-range selection it already made is unchanged.
+		expect(
+			screen.getByTestId("arrangement-selection-live").textContent,
+		).toMatch(/bars 1 to/);
+	});
+
+	it("counts selecting a track as arrangement use, with no event of its own", () => {
+		const { project, transport } = renderSelectable();
+
+		fireEvent.click(headerButton(project.song.tracks[1].name));
+
+		expect(featureUses(transport)).toEqual(["arrangement"]);
+		expect(transport.events).toHaveLength(1);
 	});
 });

--- a/src/arrangement/ArrangementView.tsx
+++ b/src/arrangement/ArrangementView.tsx
@@ -19,7 +19,7 @@ import type {
 	TransactionResult,
 } from "../commands";
 import type { Project } from "../domain/entities";
-import { createIdFactory } from "../domain/ids";
+import { createIdFactory, type TrackId } from "../domain/ids";
 import { TICKS_PER_BAR } from "../domain/time";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
 import { ArrangementToolbar } from "./ArrangementToolbar";
@@ -106,6 +106,15 @@ export interface ArrangementViewProps {
 	readonly onEditingActionsReady?: (
 		actions: PlacementEditingActions | null,
 	) => void;
+	/**
+	 * The track the editor is showing, marked in the header column (#228).
+	 * Optional, like `onSelectTrack`: without them the arrangement still works,
+	 * it just marks no row and moves nothing when one is clicked.
+	 */
+	readonly selectedTrackId?: TrackId | null;
+	/** Called with the track a clicked row belongs to, so the editor can follow
+	 * it — the arrangement holds no selection state of its own. */
+	readonly onSelectTrack?: (trackId: TrackId) => void;
 }
 
 export default function ArrangementView(props: ArrangementViewProps) {
@@ -203,6 +212,24 @@ export default function ArrangementView(props: ArrangementViewProps) {
 
 	function bumpState(): void {
 		setStateVersion((value) => value + 1);
+	}
+
+	/**
+	 * Point the editor at a track (#228). Clicking a row is how you say "this
+	 * one" here, exactly as clicking a strip is in the mixer; the arrangement
+	 * reports it and the host decides, so this surface keeps no selected-track
+	 * state of its own.
+	 */
+	function selectTrack(trackId: TrackId): void {
+		props.onSelectTrack?.(trackId);
+		noteFirstUse();
+	}
+
+	/** The track under a viewport-local point, or null above/below the rows. */
+	function trackAt(localX: number, localY: number): TrackId | null {
+		if (!shell) return null;
+		const { rowIndex } = shell.pointToArrangement(localX, localY);
+		return projection().tracks[rowIndex]?.id ?? null;
 	}
 
 	onMount(() => {
@@ -370,6 +397,12 @@ export default function ArrangementView(props: ArrangementViewProps) {
 		const { x, y } = localPoint(event);
 		if (y < 0) return;
 
+		// Whatever the click turns out to do — start a placement drag, select a
+		// bar range — it happened on a row, and that row's track is now the one
+		// being worked on (#228).
+		const trackId = trackAt(x, y);
+		if (trackId) selectTrack(trackId);
+
 		// A placement hit starts a drag (move or resize) instead of the shell's
 		// own bar-range selection; anything else falls through to the existing
 		// behavior unchanged.
@@ -441,8 +474,10 @@ export default function ArrangementView(props: ArrangementViewProps) {
 			startTick: 0,
 			endTick: TICKS_PER_BAR,
 		});
+		// The same click a pointer makes on the row: it selects the bar range
+		// *and* points the editor at the track (#228).
+		selectTrack(track.id);
 		bumpState();
-		noteFirstUse();
 	}
 
 	// The visible window of track rows, recomputed from the shell's row range.
@@ -514,7 +549,6 @@ export default function ArrangementView(props: ArrangementViewProps) {
 							{(track) => (
 								<li
 									class="arrangement-header-row"
-									aria-label={`${track.name}${track.muted ? " (muted)" : ""}`}
 									style={{
 										position: "absolute",
 										top: `${track.rowIndex * ROW_METRICS.headerHeightPx}px`,
@@ -522,16 +556,29 @@ export default function ArrangementView(props: ArrangementViewProps) {
 										width: "100%",
 									}}
 								>
-									<span
-										class="arrangement-header-swatch"
-										style={{ background: track.color }}
-									/>
-									{/* The track's name, chosen by the user. The row around it
-									    stays visible, so a replay still shows which track was
-									    clicked (ADR 0002 decision 2). */}
-									<span class={`arrangement-header-name ${MASK_CONTENT}`}>
-										{track.name}
-									</span>
+									{/* The row is the control: clicking a track header points the
+									    editor at that track (#228), and a keyboard reaches the
+									    same thing by tabbing the header column. "Edit", not
+									    "Select": `Select <track>` is the accessible list's name
+									    for selecting that track's first bar range, below. */}
+									<button
+										type="button"
+										class="arrangement-header-select"
+										aria-pressed={props.selectedTrackId === track.id}
+										aria-label={`Edit ${track.name}${track.muted ? " (muted)" : ""}`}
+										onClick={() => selectTrack(track.id)}
+									>
+										<span
+											class="arrangement-header-swatch"
+											style={{ background: track.color }}
+										/>
+										{/* The track's name, chosen by the user. The row around it
+										    stays visible, so a replay still shows which track was
+										    clicked (ADR 0002 decision 2). */}
+										<span class={`arrangement-header-name ${MASK_CONTENT}`}>
+											{track.name}
+										</span>
+									</button>
 								</li>
 							)}
 						</For>

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -76,7 +76,11 @@ function saveStatusGroup(): HTMLElement {
 	return group;
 }
 
-/** The mixer's "edit this track" control for one strip. */
+/**
+ * The mixer's "edit this track" control for one strip. Scoped to the mixer:
+ * the arrangement's header column offers the identically named control for the
+ * same track, which is the point — either surface selects it.
+ */
 function mixerSelect(trackName: string): HTMLElement {
 	return within(screen.getByRole("region", { name: "Mixer" })).getByRole(
 		"button",
@@ -280,6 +284,36 @@ describe("EditorView", () => {
 		expect(
 			screen.getByRole("region", { name: `Drum machine: ${drums.name}` }),
 		).toBeInTheDocument();
+	});
+
+	it("switches the editor to a track selected in the arrangement (#228)", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		const project = createDrumMachineFixtureProject();
+		const [drums, breakTrack] = project.song.tracks;
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+
+		renderEditor(project.metadata.id);
+		await screen.findByRole("region", {
+			name: `Drum machine: ${drums.name}`,
+		});
+
+		// The arrangement's track header column: the same click a pointer makes
+		// on a row, from the DOM side of the hybrid surface.
+		fireEvent.click(
+			within(screen.getByLabelText("Tracks")).getByRole("button", {
+				name: `Edit ${breakTrack.name}`,
+			}),
+		);
+
+		expect(
+			screen.queryByRole("region", { name: `Drum machine: ${drums.name}` }),
+		).not.toBeInTheDocument();
+		// Both surfaces agree on which track is selected: the mixer marks it too.
+		expect(mixerSelect(breakTrack.name)).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
 	});
 
 	it("toggling a step enables undo, and undo reverts it", async () => {

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -332,6 +332,8 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 											dispatch={session.dispatch}
 											beginGesture={session.beginGesture}
 											onEditingActionsReady={setArrangementEditingActions}
+											selectedTrackId={track()?.id ?? null}
+											onSelectTrack={selectTrack}
 										/>
 									</div>
 									<div class="workspace">


### PR DESCRIPTION
## What & why

3 of 3 for #228, builds on #239.

The mixer can now point the editor at a track. The arrangement — the surface you
are actually looking at while you work — could not, which is half of what the
issue asked for.

It takes the same two optional props the mixer took, and holds no
selected-track state of its own: it reports the track and `EditorView`'s
selection decides. That is what keeps the mixer strip and the header row marking
the same track rather than drifting apart.

- **Each windowed track header row is an `Edit <track>` button** with
  `aria-pressed`, so the header column *is* the control rather than a label
  beside one, and a keyboard reaches every visible track by tabbing it. The
  selected row takes the same accent edge as the mixer's selected strip. Named
  "Edit" for the reason given in #239: `Select <track>` already belongs to the
  accessible list's bar-range control below, which `CF-002` clicks by name.
- **A pointer landing anywhere on a row in the timeline selects that row's
  track**, before the click goes on to do whatever it was going to do — start a
  placement drag, or select a bar range. Either way the work is on that track.
- **The accessible track list does both**: it still selects the track's first
  bar range (unchanged, as `ArrangementView.test.tsx` asserts) and now also
  points the editor at it.

Selecting counts as `feature_first_use: arrangement`, like every other
interaction on this surface, and emits no event of its own. No domain, command,
persistence, or audio contract is touched; the ARR-001 shell, the ARR-002
placement controller, and the canvas renderer are untouched.

Closes #228

## Rebased onto #233/#235

The stack was written against `38c81ae` and rebased onto `efdad99` after #231 –
#235 landed; #238 had gone un-mergeable. This slice rebased without conflicts —
the two that needed resolving are in #238 and #239 and are described there. The
walkthrough below was re-captured after the rebase, so it shows the editor as it
actually ships, kind picker and all.

## Core flows

Untouched. `git diff origin/main --stat -- e2e/flows/ e2e-emulator/ docs/` is
empty across the whole stack; this issue links no flow of its own. (The one
non-flow spec the stack edits is `e2e/smoke.spec.ts`, in #239, for the reason
given there.)

## Walkthrough

### CF-001 — A visitor with no account reaches a playing loop

**1. Open the landing page**

![CF-001 step 1](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/228/CF-001/01-open-the-landing-page.png)

**2. You arrive at the dashboard as a guest, with no projects yet**

![CF-001 step 2](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/228/CF-001/02-you-arrive-at-the-dashboard-as-a-guest-with-no-projects-yet.png)``

**3. The new project opens on a step editor with a starter pattern**

![CF-001 step 3](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/228/CF-001/03-the-new-project-opens-on-a-step-editor-with-a-starter-patter.png)``

**4. Turn on a step that was off**

![CF-001 step 4](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/228/CF-001/04-turn-on-a-step-that-was-off.png)

**5. Start playback — the transport is running**

![CF-001 step 5](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/228/CF-001/05-start-playback-the-transport-is-running.png)

<sub>Captured by `bun run walkthrough:capture` from the core-flow specs, in Chromium. Flows are defined in [`docs/core-flows.md`](https://github.com/afternoon/solid-groove/blob/main/docs/core-flows.md).</sub>

Step 3 shows the arrangement's "BD" header row carrying the selected marking —
the accent edge on the track the editor is showing. **It does not show the fix
itself**, and that is worth saying plainly rather than implying otherwise: every
registered flow works a one-track project, so none of them clicks a second
track, and a walkthrough is a byproduct of the flows rather than something
assembled by hand. What proves the switch is `EditorView.test.tsx`'s two
end-to-end cases — mixer strip and arrangement header, each swapping the editor
between the drum fixture's two tracks. A flow that adds a second track and
switches to it would be worth registering; that is the product owner's call, not
something to add to `docs/core-flows.md` from here.

## Evidence

All re-run on the rebased commit (`c9adec0`), not carried over from before it:

- `bun run typecheck` — clean.
- `bun run check` — `Checked 491 files. No fixes applied.`
- `bun run test` — `Test Files 170 passed (170)`, `Tests 2296 passed (2296)`.
- `bun run test:browser:chromium` — `20 passed`, `CF-001` included. Chromium
  only: this environment cannot reach `cdn.playwright.dev` for the
  Firefox/WebKit binaries, so those are CI's to gate. This is **not** the PRD
  section 10 cross-browser evidence.
- `bun run verify:core-flows` — `3 flow(s), each with exactly one spec`, with
  `CF-002`/`CF-003` still parked at `test.fixme` (ARR-003's, untouched here).
- Diff is 232 changed lines.

Per-slice greenness (stacks item (a)): the full unit suite was run on each of
the three rebased commits in turn, not only at the tip — 2285, 2291, 2296 tests,
all green.

**CI's `browser e2e (firefox)` is red, and it is the base branch's failure.**
`CF-001` cannot start playback on a Firefox runner with no audio device; `main`'s
own run at `38c81ae` fails on the same spec, same line, same counts. Diagnosed
with the evidence in [this comment](https://github.com/afternoon/solid-groove/pull/240#issuecomment-5209828743);
it is the gap `docs/testing.md` documents and #43 tracks.

New tests in `ArrangementView.test.tsx` (`arrangement track selection (#228)`):
selecting from a header row reports the track and marks it; a pointer on a
timeline row reports that row's track; the accessible list reports the track
*and* keeps its bar-range selection; and selection logs exactly one
`feature_first_use: arrangement` and nothing else. Plus the end-to-end case in
`EditorView.test.tsx`, which also asserts the mixer marks the track the
arrangement selected.

## Acceptance criteria met

The issue has no checkboxes. Of its two expectations:

- [x] "I should be able to switch between tracks by clicking them in either the
      mixer or the arrangement" — both, by pointer and by keyboard.
- [x] "I should be able to see the instruments/devices for a track" — the
      **instrument**, for whichever track is selected, including a track with no
      clip (#239), and since #235 landed, its kind picker too.
- [ ] **Devices: still not possible, and not fixable here** — now filed as
      **#241**. The editor has no device-chain UI at all: `src/audio/devices`
      holds the DSP, `DeviceChain` reconciles it, seven `device.*` commands are
      registered, and `device_added` is in the analytics catalog — but nothing
      renders an insert chain, so there is no panel to point at the selected
      track, and `device_added` has never had a call site. That is a missing
      feature (PRD FX-01), not a selection bug. When it lands it reads the same
      selected track this stack introduces.

Two neighbours this stack noticed have since landed on `main` and are now part
of what it rebased onto: choosing a new track's instrument (#223 → #233) and
changing it afterwards (#235). Selecting a track is what makes both reachable
for any track but the first.