### PR TITLE
Add asset.add and asset.remove to the command registry

### DIFF
--- a/src/analytics/catalog.ts
+++ b/src/analytics/catalog.ts
@@ -240,6 +240,8 @@ export const COMMAND_IDS = [
 	"instrument.setSample",
 	"pack.add",
 	"pack.remove",
+	"asset.add",
+	"asset.remove",
 	"device.add",
 	"device.remove",
 	"device.reorder",

--- a/src/commands/assets.test.ts
+++ b/src/commands/assets.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createAsset, createPack, type Project } from "../domain";
+import { addAsset, removeAsset, setPadAsset, setSample } from ".";
+import { executeCommand, executeTransaction } from "./execute";
+import { CommandHistory } from "./history";
+import { findTrack } from "./projectEdits";
+import {
+	type CommandTestProject,
+	createCommandTestProject,
+	createTestFactoryContext,
+} from "./testProjects";
+
+/**
+ * `asset.add` / `asset.remove` (LIB-05, invariant 12).
+ *
+ * The behaviour worth pinning is not the array splice: it is that carrying a
+ * sound and pointing at it commit as one transaction, that the derived pack
+ * dependency list follows the assets rather than being maintained alongside
+ * them, and that an asset something still resolves cannot be dropped.
+ */
+
+function apply(
+	project: Project,
+	command: Parameters<typeof executeCommand>[1],
+): Project {
+	const result = executeCommand(project, command);
+	if (!result.ok) {
+		throw new Error(`Expected success: ${result.issues[0].message}`);
+	}
+	return result.project;
+}
+
+/** A sound from a pack the fixture does not carry. */
+function libraryAsset(seed = "asset-test") {
+	const context = createTestFactoryContext(seed);
+	return createAsset(context, {
+		pack: createPack(context, { name: "Test Extras" }),
+		name: "Closed Hat",
+		storageRef: "samples/house/drums/hh/909-hh.wav",
+	});
+}
+
+describe("asset.add", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	it("carries the asset and derives the pack it resolves from", () => {
+		const asset = libraryAsset();
+		const next = apply(fixture.project, addAsset(asset));
+
+		expect(next.song.assets.at(-1)).toEqual(asset);
+		expect(
+			next.metadata.packDependencies.some(
+				(dependency) => dependency.packId === asset.packId,
+			),
+		).toBe(true);
+		// The shelf follows the dependency, so the pack the sound came from is
+		// browsable without a second command (LIB-08).
+		expect(
+			next.metadata.addedPacks.some((entry) => entry.packId === asset.packId),
+		).toBe(true);
+	});
+
+	it("loads a dropped sound onto a sampler as one undoable transaction", () => {
+		const asset = libraryAsset();
+		const history = new CommandHistory(fixture.project);
+
+		const result = history.execute([
+			addAsset(asset),
+			setSample(fixture.trackAId, asset.id),
+		]);
+		expect(result.ok, result.ok ? "" : result.issues[0].message).toBe(true);
+
+		const instrument = findTrack(history.project, fixture.trackAId)?.instrument;
+		expect(instrument?.kind === "sampler" && instrument.assetId).toBe(asset.id);
+		expect(history.project.metadata.revision).toBe(
+			fixture.project.metadata.revision + 1,
+		);
+
+		// One undo takes back both halves: the sampler holds what it held, and the
+		// project no longer carries a sound nothing plays.
+		history.undo();
+		const restored = findTrack(history.project, fixture.trackAId)?.instrument;
+		expect(restored?.kind === "sampler" && restored.assetId).toBe(
+			fixture.assetIds.sampler,
+		);
+		expect(
+			history.project.song.assets.some(
+				(candidate) => candidate.id === asset.id,
+			),
+		).toBe(false);
+	});
+
+	it("inserts at an explicit index rather than appending", () => {
+		const asset = libraryAsset();
+		const next = apply(fixture.project, addAsset(asset, 1));
+		expect(next.song.assets[1]).toEqual(asset);
+		expect(next.song.assets).toHaveLength(
+			fixture.project.song.assets.length + 1,
+		);
+	});
+
+	it("rejects an asset the project already carries", () => {
+		const existing = fixture.project.song.assets[0];
+		const result = executeCommand(fixture.project, addAsset(existing));
+		expect(result.ok).toBe(false);
+		expect(result.ok ? "" : result.issues[0].message).toMatch(/already/);
+	});
+
+	it("rejects an index past the end rather than appending quietly", () => {
+		const result = executeCommand(
+			fixture.project,
+			addAsset(libraryAsset(), 99),
+		);
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("asset.remove", () => {
+	let fixture: CommandTestProject;
+
+	beforeEach(() => {
+		fixture = createCommandTestProject();
+	});
+
+	it("drops an asset nothing loads", () => {
+		const next = apply(fixture.project, removeAsset(fixture.assetIds.unused));
+		expect(
+			next.song.assets.some((asset) => asset.id === fixture.assetIds.unused),
+		).toBe(false);
+	});
+
+	it("refuses an asset a sampler still loads, naming the track", () => {
+		const result = executeCommand(
+			fixture.project,
+			removeAsset(fixture.assetIds.sampler),
+		);
+		expect(result.ok).toBe(false);
+		expect(result.ok ? "" : result.issues[0].message).toContain(
+			fixture.trackAId,
+		);
+		expect(result.project).toBe(fixture.project);
+	});
+
+	it("refuses an asset a drum pad still loads", () => {
+		const result = executeCommand(
+			fixture.project,
+			removeAsset(fixture.assetIds.pad),
+		);
+		expect(result.ok).toBe(false);
+		expect(result.ok ? "" : result.issues[0].message).toContain(
+			fixture.trackBId,
+		);
+	});
+
+	it("drops an asset once the pad that held it lets go, in one transaction", () => {
+		const result = executeTransaction(fixture.project, [
+			setPadAsset(fixture.trackBId, fixture.padIds[0], null),
+			removeAsset(fixture.assetIds.pad),
+		]);
+		expect(result.ok, result.ok ? "" : result.issues[0].message).toBe(true);
+		if (!result.ok) return;
+		expect(
+			result.project.song.assets.some(
+				(asset) => asset.id === fixture.assetIds.pad,
+			),
+		).toBe(false);
+		// The pack that asset resolved from is no longer a dependency, because the
+		// dependency list is derived from `song.assets` rather than maintained.
+		expect(
+			result.project.metadata.packDependencies.some(
+				(dependency) => dependency.packId === fixture.packs[0].id,
+			),
+		).toBe(false);
+	});
+
+	it("rejects an asset the project does not carry", () => {
+		const result = executeCommand(
+			fixture.project,
+			removeAsset(libraryAsset().id),
+		);
+		expect(result.ok).toBe(false);
+	});
+});

--- a/src/commands/definitions/assets.ts
+++ b/src/commands/definitions/assets.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+import { type Asset, assetSchema, type Project } from "../../domain/entities";
+import { type AssetId, assetIdSchema } from "../../domain/ids";
+import { trackAssetIds } from "../../domain/packs";
+import {
+	applied,
+	type CommandInput,
+	defineCommand,
+	eraseCommand,
+	type RegisteredCommand,
+	rejected,
+} from "../types";
+
+/**
+ * Asset lifecycle commands (PRD LIB-05, invariant 12).
+ *
+ * A project stores a *reference* to a library sound, not the library record, so
+ * putting a sound on a track is two things: the project has to carry the asset,
+ * and something has to point at it. These commands own the first half; the
+ * pointer is `instrument.setSample`, `drum.setPadAsset`, or an audio-loop clip.
+ * Both halves go in one transaction, which is what makes "drag a sound onto a
+ * sampler" one undoable step rather than two.
+ *
+ * Three things fall out of the kernel rather than being restated here:
+ *
+ * - **Pack dependencies stay derived.** Neither command touches
+ *   `metadata.packDependencies` or the shelf; `executeTransaction` recomputes
+ *   both from `song.assets` once per transaction (`withDerivedPackDependencies`),
+ *   so adding the first sound from a pack shelves that pack atomically with the
+ *   edit that needed it.
+ * - **Nothing dangles.** `asset.remove` refuses an asset a track's instrument, a
+ *   drum pad, or an audio-loop clip still resolves, naming what holds it, rather
+ *   than letting the transaction fail later as a broken project.
+ * - **Undo restores position.** `song.assets` is serialized in order, so
+ *   removal's inverse puts the asset back at the index it came from instead of
+ *   appending it and calling the project equal.
+ */
+
+export const assetAddPayloadSchema = z.strictObject({
+	/** The asset to carry. Its ID is explicit so a replay lands the same asset. */
+	asset: assetSchema,
+	/** Position in `song.assets`; appended when omitted. */
+	index: z.int().min(0).optional(),
+});
+export type AssetAddPayload = z.infer<typeof assetAddPayloadSchema>;
+
+export const assetRemovePayloadSchema = z.strictObject({
+	assetId: assetIdSchema,
+});
+export type AssetRemovePayload = z.infer<typeof assetRemovePayloadSchema>;
+
+/**
+ * What still resolves this asset — tracks whose instrument loads it (sampler or
+ * drum pad) and audio-loop clips that play it — named so the refusal says what
+ * to clear first rather than only that something did.
+ */
+function holdersOf(project: Project, assetId: AssetId): string[] {
+	const holders = project.song.tracks
+		.filter((track) => trackAssetIds(track).includes(assetId))
+		.map((track) => `track ${track.id}`);
+	holders.push(
+		...project.clips
+			.filter(
+				(clip) =>
+					clip.content.kind === "audioLoop" && clip.content.assetId === assetId,
+			)
+			.map((clip) => `clip ${clip.id}`),
+	);
+	return holders;
+}
+
+export const assetAddCommand = defineCommand<AssetAddPayload>({
+	type: "asset.add",
+	version: 1,
+	schema: assetAddPayloadSchema,
+	summarize: (payload) => `Add ${payload.asset.name} to the project`,
+	apply(project, payload) {
+		const assets = project.song.assets;
+		if (assets.some((candidate) => candidate.id === payload.asset.id)) {
+			return rejected(`Asset ${payload.asset.id} is already in this project`);
+		}
+		const index = payload.index ?? assets.length;
+		if (index > assets.length) {
+			return rejected(
+				`Cannot add an asset at index ${index}; the project carries ${assets.length}`,
+			);
+		}
+		const next = [...assets];
+		next.splice(index, 0, payload.asset);
+		return applied({ ...project, song: { ...project.song, assets: next } });
+	},
+	invert: (payload) => [removeAsset(payload.asset.id)],
+});
+
+export const assetRemoveCommand = defineCommand<AssetRemovePayload>({
+	type: "asset.remove",
+	version: 1,
+	schema: assetRemovePayloadSchema,
+	summarize: (payload, project) =>
+		`Remove ${assetLabel(project.song.assets, payload.assetId)} from the project`,
+	apply(project, payload) {
+		const index = project.song.assets.findIndex(
+			(candidate) => candidate.id === payload.assetId,
+		);
+		if (index < 0) {
+			return rejected(`Asset ${payload.assetId} is not in this project`);
+		}
+		const holders = holdersOf(project, payload.assetId);
+		if (holders.length > 0) {
+			return rejected(
+				`Asset ${payload.assetId} is still loaded by ${holders.join(", ")}`,
+			);
+		}
+		return applied({
+			...project,
+			song: {
+				...project.song,
+				assets: project.song.assets.filter((_, position) => position !== index),
+			},
+		});
+	},
+	invert(payload, before) {
+		const index = before.song.assets.findIndex(
+			(candidate) => candidate.id === payload.assetId,
+		);
+		const asset = before.song.assets[index];
+		return asset ? [addAsset(asset, index)] : [];
+	},
+});
+
+/** The asset's name when the project carries it, else its ID. */
+function assetLabel(assets: readonly Asset[], assetId: AssetId): string {
+	return assets.find((asset) => asset.id === assetId)?.name ?? assetId;
+}
+
+// --- Typed builders -------------------------------------------------------
+
+export function addAsset(
+	asset: Asset,
+	index?: number,
+): CommandInput<AssetAddPayload> {
+	return {
+		type: assetAddCommand.type,
+		payload: index === undefined ? { asset } : { asset, index },
+	};
+}
+
+export function removeAsset(
+	assetId: AssetId,
+): CommandInput<AssetRemovePayload> {
+	return { type: assetRemoveCommand.type, payload: { assetId } };
+}
+
+/** Registered, payload-erased commands from this module. */
+export const assetCommands: readonly RegisteredCommand[] = [
+	eraseCommand(assetAddCommand),
+	eraseCommand(assetRemoveCommand),
+];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,7 @@
  * repository, and the assistant all sit outside it.
  */
 
+export * from "./definitions/assets";
 export * from "./definitions/clips";
 export * from "./definitions/deviceChains";
 export * from "./definitions/devices";

--- a/src/commands/inverse.test.ts
+++ b/src/commands/inverse.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
 	bars,
+	createAsset,
 	createDevice,
 	createDrumPad,
 	createNoteClip,
 	createNoteEvent,
+	createPack,
 	createPlacement,
 	createSeededIdFactory,
 	createSynthInstrument,
@@ -17,6 +19,7 @@ import {
 	toTicks,
 } from "../domain";
 import {
+	addAsset,
 	addClip,
 	addDevice,
 	addNotes,
@@ -30,6 +33,7 @@ import {
 	duplicateNotes,
 	insertChain,
 	quantizeNotes,
+	removeAsset,
 	removeClip,
 	removeDevice,
 	removeNotes,
@@ -317,6 +321,18 @@ const cases: InverseCase[] = [
 		signature: shelfSignature,
 	},
 	{
+		type: "asset.add",
+		// A sound from a pack the fixture does not use, so the round trip also
+		// covers the dependency list the transaction derives from `song.assets`.
+		build: () => addAsset(buildInverseAsset()),
+	},
+	{
+		type: "asset.remove",
+		// The fixture's carried-but-unloaded asset; removing a loaded one is
+		// refused, and this proves the undo puts it back where it was.
+		build: (fixture) => removeAsset(fixture.assetIds.unused),
+	},
+	{
 		type: "device.add",
 		build: (fixture) =>
 			addDevice(
@@ -374,6 +390,16 @@ const cases: InverseCase[] = [
 /** A stable pack ID for the add case, independent of the fixture's IDs. */
 function createPackId(seed: string) {
 	return createSeededIdFactory(seed)("pack");
+}
+
+/** The `asset.add` case's sound, from a pack the fixture does not carry. */
+function buildInverseAsset() {
+	const context = createTestFactoryContext("inverse-asset");
+	return createAsset(context, {
+		pack: createPack(context, { name: "Inverse Extras" }),
+		name: "Rimshot",
+		storageRef: "samples/house/drums/rs/909-rs.wav",
+	});
 }
 
 describe("generated inverses", () => {

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -47,6 +47,8 @@ const EXPECTED_COMMANDS = [
 	"instrument.setSample",
 	"pack.add",
 	"pack.remove",
+	"asset.add",
+	"asset.remove",
 	"device.add",
 	"device.remove",
 	"device.reorder",

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,3 +1,4 @@
+import { assetCommands } from "./definitions/assets";
 import { clipCommands } from "./definitions/clips";
 import { deviceCommands } from "./definitions/devices";
 import { drumCommands } from "./definitions/drum";
@@ -33,6 +34,7 @@ const ALL_DEFINITIONS: readonly RegisteredCommand[] = [
 	...drumCommands,
 	...instrumentCommands,
 	...packCommands,
+	...assetCommands,
 	...deviceCommands,
 ];
 

--- a/src/commands/testProjects.ts
+++ b/src/commands/testProjects.ts
@@ -66,8 +66,12 @@ export interface CommandTestProject {
 	returnId: ReturnId;
 	placementAId: PlacementId;
 	padIds: PadId[];
-	/** The sampler asset on track A, and the clap asset the kick pad uses. */
-	assetIds: { sampler: AssetId; pad: AssetId };
+	/**
+	 * The sampler asset on track A, the clap asset the kick pad uses, and one
+	 * nothing loads — the state an `asset.remove` must be able to act on, since
+	 * removing an asset a track still resolves is refused.
+	 */
+	assetIds: { sampler: AssetId; pad: AssetId; unused: AssetId };
 	/** The two packs the fixture's assets resolve from, in dependency order. */
 	packs: [Pack, Pack];
 	/** A pack on the shelf that no asset uses — a `pack.remove` target (LIB-08). */
@@ -109,6 +113,13 @@ export function createCommandTestProject(
 		pack: drumsPack,
 		name: "909 Clap",
 		storageRef: "samples/house/drums/cp/909-cp.wav",
+	});
+	// From a pack the fixture already depends on, so carrying it changes which
+	// assets the project holds without changing which packs it needs.
+	const unusedAsset = createAsset(context, {
+		pack: bassPack,
+		name: "909 Rimshot",
+		storageRef: "samples/house/drums/rs/909-rs.wav",
 	});
 
 	const device: Device = {
@@ -189,7 +200,7 @@ export function createCommandTestProject(
 
 	const song: Song = {
 		...createEmptySong(120),
-		assets: [asset, padAsset],
+		assets: [asset, padAsset, unusedAsset],
 		tracks: [trackA, trackB],
 		returns: [returnBus],
 		placements: [placementA, placementB],
@@ -237,7 +248,11 @@ export function createCommandTestProject(
 		returnId: returnBus.id,
 		placementAId: placementA.id,
 		padIds: [kick.id, clap.id],
-		assetIds: { sampler: asset.id, pad: padAsset.id },
+		assetIds: {
+			sampler: asset.id,
+			pad: padAsset.id,
+			unused: unusedAsset.id,
+		},
 		packs: [drumsPack, bassPack],
 		shelfOnlyPack,
 		eventIds:


### PR DESCRIPTION
## What & why

1 of 5 for #225 — the central-registration slice, landing first so a sibling
feature cannot collide with it (CLAUDE.md "Landing work" item 3).

A project stores a *reference* to a library sound, not the library record, so
putting a sound on a track is two things: the project has to carry the asset,
and something has to point at it. The registry had the second half only —
`instrument.setSample`, `drum.setPadAsset`, an audio-loop clip — and no way at
all to carry a new asset. That is the command-layer reason the library browser
can audition 200 sounds and load none of them.

`asset.add` carries one, `asset.remove` drops one. Neither touches
`metadata.packDependencies` or the pack shelf: `executeTransaction` already
recomputes both from `song.assets` once per transaction, so the first sound
drawn from a pack shelves that pack atomically with the edit that needed it
(PRD LIB-05, invariant 12).

Two refusals, rather than a transaction that fails later as an invalid project:

- adding an asset the project already carries;
- removing one a track's instrument, a drum pad, or an audio-loop clip still
  resolves — named in the message, so it says what to clear first.

Removal's inverse restores the asset at the index it came from, because
`song.assets` is serialized in order and `inverse.test.ts` compares the
serialized content.

Registration points touched, and nothing else: `src/commands/registry.ts`,
`src/commands/index.ts`, and `COMMAND_IDS` in `src/analytics/catalog.ts`
(`catalog.test.ts` asserts that list equals the registry exactly).

The command test fixture grows one carried-but-unloaded asset, from a pack it
already depends on, because a removal test needs a target nothing holds.

Refs #225

## Core flows

Untouched. This is a mid-stack slice with no user-visible surface. #225 is a bug
with no core flows of its own; CF-002 (#61) depends on it and stays `test.fixme`
until #223 also lands — see #246.

## Walkthrough

No UI change.

## Evidence

```
bun run typecheck   → clean
bun run check       → Checked 502 files. No fixes applied.
bun run test        → Test Files 170 passed (170) · Tests 2278 passed (2278)
```

Diff size: 4 product lines + registrations + tests, well inside the 400-line
ceiling.

`inverse.test.ts` covers both new commands (it fails if a registered command has
no inverse case), and `registry.test.ts`'s pinned command list is updated
deliberately rather than derived.

## Acceptance criteria met

#225 has no acceptance checkboxes. This PR satisfies the command-layer
precondition of its "Expected" outcome: loading a sound is one undoable
transaction. The user-visible half lands in PRs 3–5 of this stack.

## Stack

1. **this PR** — `asset.add` / `asset.remove` (base `main`)
2. #243 — map a browsed library sound onto a project asset
3. #244 — let a library row carry its sound on a drag
4. #245 — load a dropped sound onto a sampler
5. #246 — retire the swap list, insert from the keyboard (`Closes #225`)
