### PR TITLE
Map a browsed library sound onto a project asset

### DIFF
--- a/src/domain/factories.ts
+++ b/src/domain/factories.ts
@@ -419,8 +419,13 @@ export interface CreateAssetOptions {
 	 * The pack this asset resolves from. Required: an asset with no pack is not
 	 * representable (invariant 12), so a factory that defaulted it would be a way
 	 * to create one by accident.
+	 *
+	 * Only the identity and version are asked for, because that is all an asset
+	 * reference stores — and a caller resolving a sound from a *pack manifest*
+	 * holds exactly that, without the rights position or description a full
+	 * `Pack` record carries. A `Pack` satisfies it structurally.
 	 */
-	pack: Pack;
+	pack: Pick<Pack, "id" | "version">;
 	name: string;
 	storageRef: string;
 	kind?: Asset["kind"];

--- a/src/library/audition.test.ts
+++ b/src/library/audition.test.ts
@@ -28,6 +28,7 @@ function asset(overrides: Partial<LibraryAsset> = {}): LibraryAsset {
 		sampleRate: 48000,
 		channelCount: 1,
 		bpm: null,
+		licence: "solid-groove-owned",
 		...overrides,
 	};
 }

--- a/src/library/insertion.test.ts
+++ b/src/library/insertion.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { executeTransaction } from "../commands";
+import { createFactoryContext } from "../domain/factories";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import { createSeededIdFactory } from "../domain/ids";
+import { fixtureFetcher } from "./__fixtures__/fixtures";
+import {
+	carriedAsset,
+	createLibraryAsset,
+	loadSampleCommands,
+	toLibrarySample,
+} from "./insertion";
+import { LIBRARY_ROOT, packAssets, parsePackManifest } from "./manifest";
+
+/**
+ * Loading a browsed sound onto a track (#225).
+ *
+ * The assets here come from the committed slice of the real delivered library,
+ * so this exercises the wire shape production parses rather than a hand-written
+ * asset that could drift from it.
+ */
+
+async function libraryAssets(slug = "core-electronic-drums") {
+	const raw = await fixtureFetcher()(
+		`samples/starter-library/packs/${slug}/x.json`,
+	);
+	return packAssets(parsePackManifest(raw));
+}
+
+function context(seed = "insertion") {
+	return createFactoryContext({
+		ids: createSeededIdFactory(seed),
+		now: 1_700_000_000_000,
+	});
+}
+
+describe("toLibrarySample", () => {
+	it("keeps the facts a project stores and drops the browsing facets", async () => {
+		const asset = (await libraryAssets())[0];
+		const sample = toLibrarySample(asset);
+
+		expect(sample).not.toBeNull();
+		expect(sample?.name).toBe(asset.name);
+		expect(sample?.packId).toBe(asset.packId);
+		expect(sample?.packVersion).toBe(asset.packVersion);
+		expect(sample?.storageRef).toBe(
+			`${LIBRARY_ROOT}/audio/${asset.storageKey}`,
+		);
+		// The URL is whatever this page load resolves that delivery to — the
+		// manifest's own, not a path this module reassembles. Under same-origin
+		// delivery that is the storage reference with a leading slash; under
+		// bucket delivery it is a Storage download URL, and the reference is
+		// still the stable thing a project keeps.
+		expect(sample?.url).toBe(asset.url);
+		expect(sample).not.toHaveProperty("genres");
+		expect(sample).not.toHaveProperty("role");
+	});
+
+	it("calls a tempo-labelled loop a loop, and a one-shot a sample", async () => {
+		const assets = await libraryAssets("foundation-bass");
+		const loop = assets.find((asset) => asset.type === "loop");
+		const oneShot = assets.find((asset) => asset.type === "one-shot");
+		if (!loop || !oneShot) throw new Error("expected a loop and a one-shot");
+		expect(toLibrarySample(loop)?.kind).toBe("loop");
+		expect(toLibrarySample(oneShot)?.kind).toBe("sample");
+	});
+
+	it("refuses an asset with no master audio, so nothing dangles", async () => {
+		const assets = await libraryAssets();
+		const withoutAudio = { ...assets[0], storageKey: null, url: null };
+		expect(toLibrarySample(withoutAudio)).toBeNull();
+	});
+
+	it("refuses a manifest row whose pack id is not a pack id", async () => {
+		const assets = await libraryAssets();
+		expect(toLibrarySample({ ...assets[0], packId: "nope" })).toBeNull();
+	});
+});
+
+describe("loadSampleCommands", () => {
+	it("carries the sound and points the sampler at it, in one transaction", async () => {
+		const project = createSliceFixtureProject();
+		const track = project.song.tracks[0];
+		const sample = toLibrarySample((await libraryAssets())[1]);
+		if (!sample) throw new Error("expected an insertable sample");
+
+		const result = executeTransaction(
+			project,
+			loadSampleCommands(project, track.id, sample, context()),
+		);
+		expect(result.ok, result.ok ? "" : result.issues[0].message).toBe(true);
+		if (!result.ok) return;
+
+		const asset = carriedAsset(result.project, sample);
+		expect(asset?.name).toBe(sample.name);
+		expect(asset?.provenance.licence).toBe(sample.licence);
+		const instrument = result.project.song.tracks[0].instrument;
+		expect(instrument?.kind === "sampler" && instrument.assetId).toBe(
+			asset?.id,
+		);
+		// One transaction: one revision, so one undo takes the whole drop back.
+		expect(result.project.metadata.revision).toBe(
+			project.metadata.revision + 1,
+		);
+		expect(result.commands).toHaveLength(2);
+	});
+
+	it("reuses a delivery the project already carries rather than duplicating it", async () => {
+		const project = createSliceFixtureProject();
+		const track = project.song.tracks[0];
+		const sample = toLibrarySample((await libraryAssets())[1]);
+		if (!sample) throw new Error("expected an insertable sample");
+
+		const first = executeTransaction(
+			project,
+			loadSampleCommands(project, track.id, sample, context("first")),
+		);
+		if (!first.ok) throw new Error(first.issues[0].message);
+		const commands = loadSampleCommands(
+			first.project,
+			track.id,
+			sample,
+			context("second"),
+		);
+		expect(commands).toHaveLength(1);
+
+		const second = executeTransaction(first.project, commands);
+		if (!second.ok) throw new Error(second.issues[0].message);
+		expect(second.project.song.assets).toHaveLength(
+			first.project.song.assets.length,
+		);
+	});
+
+	it("changes nothing when the track's instrument is not a sampler", async () => {
+		const project = createSliceFixtureProject();
+		const sample = toLibrarySample((await libraryAssets())[0]);
+		if (!sample) throw new Error("expected an insertable sample");
+		// A track with no instrument at all: the asset must not be carried by a
+		// transaction whose sample load is refused.
+		const bare = { ...project.song.tracks[0], instrument: null };
+		const withBare = {
+			...project,
+			song: { ...project.song, tracks: [bare] },
+		};
+
+		const result = executeTransaction(
+			withBare,
+			loadSampleCommands(withBare, bare.id, sample, context()),
+		);
+		expect(result.ok).toBe(false);
+		expect(result.project).toBe(withBare);
+	});
+
+	it("records the pack the sound resolved from as a dependency", async () => {
+		const project = createSliceFixtureProject();
+		const sample = toLibrarySample((await libraryAssets("tonal-elements"))[0]);
+		if (!sample) throw new Error("expected an insertable sample");
+
+		const result = executeTransaction(
+			project,
+			loadSampleCommands(project, project.song.tracks[0].id, sample, context()),
+		);
+		if (!result.ok) throw new Error(result.issues[0].message);
+		expect(
+			result.project.metadata.packDependencies.some(
+				(dependency) =>
+					dependency.packId === sample.packId &&
+					dependency.version === sample.packVersion,
+			),
+		).toBe(true);
+	});
+});
+
+describe("createLibraryAsset", () => {
+	it("mints a project-scoped reference rather than reusing the library id", async () => {
+		const asset = (await libraryAssets())[0];
+		const sample = toLibrarySample(asset);
+		if (!sample) throw new Error("expected an insertable sample");
+		const created = createLibraryAsset(context(), sample);
+
+		expect(created.id).toMatch(/^ast_/);
+		expect(created.id).not.toBe(asset.id);
+		expect(created.provenance.source).toBe("library");
+	});
+});

--- a/src/library/insertion.ts
+++ b/src/library/insertion.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import { addAsset, type RawCommandInput, setSample } from "../commands";
+import type { Asset, Project } from "../domain/entities";
+import { assetKindSchema, packVersionSchema } from "../domain/entities";
+import type { DomainFactoryContext } from "../domain/factories";
+import { createAsset } from "../domain/factories";
+import { packIdSchema, type TrackId } from "../domain/ids";
+import { assetStorageRef, type LibraryAsset } from "./manifest";
+
+/**
+ * Putting a library sound into a project (PRD LIB-05, invariant 12).
+ *
+ * The library's read model and the domain's are deliberately different things:
+ * a {@link LibraryAsset} is a row of a pack manifest, complete with the genre
+ * and character tags a browser filters on, while a domain `Asset` is the
+ * *reference* a project stores — a fresh `ast_` ID, the pack and version it
+ * resolved from, and where the audio is delivered. This module is the one
+ * crossing between them, so nothing else in the app has to know both shapes.
+ *
+ * Two things it is careful about:
+ *
+ * - **A dropped sound is described, not trusted.** {@link librarySampleSchema}
+ *   is the payload a drag carries, and it is parsed on the way out of the drop
+ *   rather than cast. A `dataTransfer` can be written by any page the user drags
+ *   from, so the only safe assumption is that its contents are input.
+ * - **The same sound twice is the same asset.** A project that already carries
+ *   this pack's delivery of this sound reuses it, so dropping a hat on four
+ *   tracks leaves one asset behind rather than four identical ones — which is
+ *   also what keeps the buffer cache resolving one entry (`AudioBufferCache`
+ *   keys on asset identity).
+ */
+
+/**
+ * The facts a project needs to carry a library sound — and nothing else. The
+ * browsing facets (genres, characters, role) are the library's, not the
+ * project's, so they deliberately do not travel.
+ */
+export const librarySampleSchema = z.strictObject({
+	name: z.string().min(1),
+	packId: packIdSchema,
+	packVersion: packVersionSchema,
+	kind: assetKindSchema,
+	storageRef: z.string().min(1),
+	url: z.string().min(1),
+	durationSeconds: z.number().min(0).nullable(),
+	sampleRate: z.int().min(1).nullable(),
+	channelCount: z.int().min(1).max(2).nullable(),
+	licence: z.string().min(1),
+});
+export type LibrarySample = z.infer<typeof librarySampleSchema>;
+
+/** Licence recorded when a manifest states none, so provenance is never blank. */
+const UNSTATED_LICENCE = "unstated";
+
+/**
+ * The insertable form of a browsed asset, or `null` when it cannot be loaded
+ * onto an instrument at all.
+ *
+ * A preset carries no master audio (`files.master` is absent), so it has
+ * nothing for a sampler to play. Refusing it here is what stops a preset being
+ * dropped onto a sampler and becoming an asset whose buffer never resolves.
+ */
+export function toLibrarySample(asset: LibraryAsset): LibrarySample | null {
+	if (!asset.storageKey || !asset.url) return null;
+	const parsed = librarySampleSchema.safeParse({
+		name: asset.name,
+		packId: asset.packId,
+		packVersion: asset.packVersion,
+		kind: asset.type === "loop" ? "loop" : "sample",
+		storageRef: assetStorageRef(asset.storageKey),
+		url: asset.url,
+		durationSeconds: asset.durationSeconds,
+		sampleRate: asset.sampleRate,
+		channelCount: asset.channelCount,
+		licence: asset.licence ?? UNSTATED_LICENCE,
+	});
+	return parsed.success ? parsed.data : null;
+}
+
+/** The project's own reference to this delivery of this sound, if it has one. */
+export function carriedAsset(
+	project: Project,
+	sample: LibrarySample,
+): Asset | null {
+	return (
+		project.song.assets.find(
+			(asset) =>
+				asset.packId === sample.packId &&
+				asset.packVersion === sample.packVersion &&
+				asset.storageRef === sample.storageRef,
+		) ?? null
+	);
+}
+
+/** A fresh project-scoped reference to a library sound. */
+export function createLibraryAsset(
+	context: DomainFactoryContext,
+	sample: LibrarySample,
+): Asset {
+	return createAsset(context, {
+		pack: { id: sample.packId, version: sample.packVersion },
+		name: sample.name,
+		kind: sample.kind,
+		storageRef: sample.storageRef,
+		url: sample.url,
+		durationSeconds: sample.durationSeconds,
+		sampleRate: sample.sampleRate,
+		channelCount: sample.channelCount,
+		// The sound came out of a pack manifest, not out of this project, and its
+		// rights position travels with it.
+		source: "library",
+		licence: sample.licence,
+	});
+}
+
+/**
+ * The commands that load a library sound onto a track's sampler, as one
+ * transaction: carry the asset if the project does not already, then point the
+ * sampler at it.
+ *
+ * One transaction is the point — it is one revision, one history entry, and one
+ * undo, so a drop never leaves an orphaned asset behind if the user takes it
+ * back. `instrument.setSample` refuses a track whose instrument is not a
+ * sampler, which makes the whole transaction fail and the project unchanged.
+ */
+export function loadSampleCommands(
+	project: Project,
+	trackId: TrackId,
+	sample: LibrarySample,
+	context: DomainFactoryContext,
+): readonly RawCommandInput[] {
+	const existing = carriedAsset(project, sample);
+	if (existing) {
+		return [setSample(trackId, existing.id)];
+	}
+	const asset = createLibraryAsset(context, sample);
+	return [addAsset(asset), setSample(trackId, asset.id)];
+}

--- a/src/library/manifest.test.ts
+++ b/src/library/manifest.test.ts
@@ -160,6 +160,14 @@ describe("parsing a pack manifest", () => {
 		}
 	});
 
+	it("carries the rights position a project records as provenance", async () => {
+		const raw = await fixtureFetcher()(
+			"samples/starter-library/packs/core-electronic-drums/x.json",
+		);
+		const assets = packAssets(parsePackManifest(raw));
+		expect(assets.every((asset) => asset.licence !== null)).toBe(true);
+	});
+
 	it("carries the tags a filter needs", async () => {
 		const raw = await fixtureFetcher()(
 			"samples/starter-library/packs/core-electronic-drums/x.json",

--- a/src/library/manifest.ts
+++ b/src/library/manifest.ts
@@ -118,10 +118,24 @@ export function packManifestPath(slug: string, version: string): string {
 }
 
 /**
- * The absolute URL for an asset's master audio, from the `storageKey` a
- * manifest records. The delivery layout is `audio/<storageKey>` under the
- * library root, mirroring the bucket exactly.
+ * The library-root-relative path of an asset's master audio, from the
+ * `storageKey` a manifest records. The delivery layout is `audio/<storageKey>`
+ * under the library root, mirroring the bucket exactly.
+ *
+ * This is what a project stores as an asset's `storageRef` (invariant 8: the
+ * reference is delivery, never identity), which is why it is stated once here
+ * rather than at each caller — the generated factory manifest emits the same
+ * shape for the assets the app ships with.
+ *
+ * Deliberately *not* a URL: a `storageRef` is stable across delivery origins,
+ * while {@link assetAudioUrl} resolves against whichever origin this page load
+ * reads the library from. The two coincide only under same-origin delivery.
  */
+export function assetStorageRef(storageKey: string): string {
+	return `${LIBRARY_ROOT}/audio/${storageKey}`;
+}
+
+/** The URL an asset's master audio is fetched from, for this page load. */
 export function assetAudioUrl(storageKey: string): string {
 	return libraryUrl(`audio/${storageKey}`);
 }
@@ -190,6 +204,11 @@ const manifestAssetSchema = z.object({
 				.nullish(),
 		})
 		.nullish(),
+	// The rights position the asset was delivered under. A project that carries
+	// this sound records it as the asset's provenance licence, so what a producer
+	// may do with an exported track is answerable from the project alone rather
+	// than by re-reading the manifest it came from (LIB-05).
+	license: z.object({ id: z.string().min(1) }).nullish(),
 	// A preset carries no audio of its own, so `audio` is `null` for it — accept
 	// null as readily as absent so a preset does not fail the whole manifest.
 	audio: z
@@ -243,6 +262,8 @@ export interface LibraryAsset {
 	/** Absolute audio URL, or `null` when the manifest carried no master file. */
 	readonly url: string | null;
 	readonly storageKey: string | null;
+	/** Delivered rights position, or `null` when the manifest stated none. */
+	readonly licence: string | null;
 	readonly durationSeconds: number | null;
 	readonly sampleRate: number | null;
 	readonly channelCount: number | null;
@@ -344,6 +365,7 @@ export function packAssets(manifest: PackManifest): LibraryAsset[] {
 			packVersion: pack.version,
 			url: storageKey ? assetAudioUrl(storageKey) : null,
 			storageKey,
+			licence: asset.license?.id ?? null,
 			durationSeconds: asset.audio?.durationSeconds ?? null,
 			sampleRate: asset.audio?.sampleRate ?? null,
 			channelCount: asset.audio?.channels ?? null,

--- a/src/library/tree.test.ts
+++ b/src/library/tree.test.ts
@@ -22,6 +22,7 @@ function asset(
 		sampleRate: 48000,
 		channelCount: 1,
 		bpm: null,
+		licence: "solid-groove-owned",
 		...overrides,
 	};
 }


### PR DESCRIPTION
## What & why

2 of 5 for #225, builds on #242.

The library's read model and the domain's are different things on purpose: a
`LibraryAsset` is a row of a pack manifest, complete with the genre and character
tags a browser filters on, while a domain `Asset` is the *reference* a project
stores — a fresh `ast_` ID, the pack and version it resolved from, and where the
audio is delivered. Nothing crossed between them, which is the second half of why
a browsed sound cannot reach a track.

`src/library/insertion.ts` is that crossing, and the only place that knows both
shapes:

- `loadSampleCommands` returns the commands that carry the sound and point a
  sampler at it — one transaction, so a drop is one revision and one undo rather
  than an asset stranded in the project when the load is taken back.
- A delivery the project already carries is **reused** rather than duplicated, so
  the same hat on four tracks is one asset and one `AudioBufferCache` entry.
- `librarySampleSchema` is the payload a drag will carry, and it is parsed rather
  than cast: a `dataTransfer` can be written by any page the user drags from.
- An asset with no master audio — a preset — is refused, so it cannot become a
  reference whose buffer never resolves.

Two supporting changes:

- The manifest read model now carries each asset's delivered rights position
  (`license.id`), so a project records real provenance instead of `createAsset`'s
  `internal` default. Relevant to LIB-05, where the rights position is a product
  fact rather than a detail.
- `createAsset`'s `pack` option now asks only for the two fields an asset
  reference actually stores — the pack's `id` and `version`, as a `Pick` of
  `Pack` — rather than a whole `Pack` record. A caller resolving from a pack
  *manifest* holds exactly those and no more: the manifest's asset rows carry no
  rights block. A full `Pack` still satisfies it structurally, so every existing
  caller is unchanged.

Refs #225

## Core flows

Untouched — no user-visible surface in this slice. See #246.

## Walkthrough

No UI change.

## Evidence

```
bun run typecheck   → clean
bun run check       → Checked 502 files. No fixes applied.
bun run test        → Test Files 170 passed (170) · Tests 2278 passed (2278)
```

`insertion.test.ts` drives every case off the committed slice of the *real*
delivered library (`src/library/__fixtures__`), so it parses the wire shape
production parses rather than a hand-written asset that could drift from it.

Invariant worth checking in one line: no existing caller of `createAsset`
changed — `git diff main...HEAD --stat` shows `src/domain/factories.ts` at 7
lines, all inside the `pack` option's type and its comment.

## Acceptance criteria met

#225 has no acceptance checkboxes. This slice supplies the mapping its
"Expected" outcome needs; the surfaces land in PRs 3–5.

## Stack

1. #242 — `asset.add` / `asset.remove`
2. **this PR** — the library → domain asset mapping
3. #244 — let a library row carry its sound on a drag
4. #245 — load a dropped sound onto a sampler
5. #246 — retire the swap list, insert from the keyboard (`Closes #225`)
