### PR TITLE
Let a library row carry its sound on a drag

### DIFF
--- a/src/library/AssetRow.tsx
+++ b/src/library/AssetRow.tsx
@@ -1,5 +1,6 @@
 import { HiSolidPlay, HiSolidPlus, HiSolidStop } from "solid-icons/hi";
 import { type JSX, Show } from "solid-js";
+import { writeLibrarySampleDrag } from "./assetDrag";
 import { LOAD_REASON_LABELS } from "./loadReasons";
 import type { LibraryAsset } from "./manifest";
 // `.library-row`, `.library-audition` and `.library-insert` are defined in the
@@ -9,7 +10,14 @@ import type { LibraryAsset } from "./manifest";
 // names, rather than relied on from whichever view happened to mount first.
 import "./LibraryBrowser.css";
 
-/** One auditionable sound. Shared by the panel tree and the pack browser. */
+/**
+ * One auditionable sound. Shared by the panel tree and the pack browser.
+ *
+ * The row is the drag handle: dragging it onto an instrument loads it (#225).
+ * Dragging is a pointer gesture, so it is never the only way in (PRD 9.3) — the
+ * "Insert" button does the same thing from the keyboard, on whichever track the
+ * surface hosting this panel is editing.
+ */
 export default function AssetRow(props: {
 	asset: LibraryAsset;
 	active: boolean;
@@ -26,6 +34,15 @@ export default function AssetRow(props: {
 			classList={{
 				"library-row-active": props.active,
 				"library-row-error": props.error !== null,
+			}}
+			draggable="true"
+			onDragStart={(event) => {
+				// A sound with no master audio (a preset) carries nothing an
+				// instrument can load, so its row starts no drag at all rather than
+				// one that has to be refused when it lands.
+				if (!writeLibrarySampleDrag(event.dataTransfer, props.asset)) {
+					event.preventDefault();
+				}
 			}}
 		>
 			<button

--- a/src/library/LibraryBrowser.test.tsx
+++ b/src/library/LibraryBrowser.test.tsx
@@ -15,6 +15,7 @@ import {
 	FIXTURE_PACK_INDEX_DOC,
 	fixtureFetcher,
 } from "./__fixtures__/fixtures";
+import { readLibrarySampleDrag } from "./assetDrag";
 import LibraryBrowser from "./LibraryBrowser";
 import { FetchClassifiedError, LibraryClient } from "./libraryClient";
 
@@ -217,6 +218,35 @@ describe("audition", () => {
 		fireEvent.click(screen.getAllByRole("button", { name: /^Insert / })[0]);
 		expect(onInsert).toHaveBeenCalledTimes(1);
 		expect(onInsert.mock.calls[0][0]).toHaveProperty("packSlug");
+	});
+
+	it("puts the sound on the drag when a row is dragged (#225)", async () => {
+		renderBrowser();
+		await openFirstGroup();
+		const audition = screen.getAllByRole("button", { name: /^Audition / })[0];
+		const name = (audition.getAttribute("aria-label") ?? "").replace(
+			"Audition ",
+			"",
+		);
+		const row = audition.closest("li");
+		if (!row) throw new Error("expected the sound's row");
+		expect(row.getAttribute("draggable")).toBe("true");
+
+		const data = new Map<string, string>();
+		const dataTransfer = {
+			get types() {
+				return [...data.keys()];
+			},
+			getData: (format: string) => data.get(format) ?? "",
+			setData: (format: string, value: string) => {
+				data.set(format, value);
+			},
+		};
+		fireEvent.dragStart(row, { dataTransfer });
+
+		const sample = readLibrarySampleDrag(dataTransfer);
+		expect(sample?.name).toBe(name);
+		expect(sample?.packId).toMatch(/^pak_/);
 	});
 });
 

--- a/src/library/assetDrag.test.ts
+++ b/src/library/assetDrag.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { fixtureFetcher } from "./__fixtures__/fixtures";
+import {
+	hasLibrarySampleDrag,
+	LIBRARY_SAMPLE_MIME,
+	type LibraryDragTransfer,
+	readLibrarySampleDrag,
+	writeLibrarySampleDrag,
+} from "./assetDrag";
+import { packAssets, parsePackManifest } from "./manifest";
+
+/**
+ * The drag a library sound travels on (#225). jsdom implements no
+ * `DataTransfer`, and neither does a headless worker, so this exercises the
+ * structural slice the app actually uses.
+ */
+
+function fakeTransfer(): LibraryDragTransfer & { data: Map<string, string> } {
+	const data = new Map<string, string>();
+	return {
+		data,
+		get types() {
+			return [...data.keys()];
+		},
+		getData: (format: string) => data.get(format) ?? "",
+		setData: (format: string, value: string) => {
+			data.set(format, value);
+		},
+	};
+}
+
+async function libraryAssets(slug = "core-electronic-drums") {
+	const raw = await fixtureFetcher()(
+		`samples/starter-library/packs/${slug}/x.json`,
+	);
+	return packAssets(parsePackManifest(raw));
+}
+
+describe("carrying a library sound on a drag", () => {
+	it("round-trips a browsed sound through the transfer", async () => {
+		const asset = (await libraryAssets())[0];
+		const transfer = fakeTransfer();
+
+		expect(writeLibrarySampleDrag(transfer, asset)).toBe(true);
+		expect(transfer.effectAllowed).toBe("copy");
+		expect(hasLibrarySampleDrag(transfer)).toBe(true);
+
+		const sample = readLibrarySampleDrag(transfer);
+		expect(sample?.name).toBe(asset.name);
+		expect(sample?.packId).toBe(asset.packId);
+		expect(sample?.url).toBe(asset.url);
+	});
+
+	it("refuses to carry a sound with no master audio", async () => {
+		const asset = {
+			...(await libraryAssets())[0],
+			storageKey: null,
+			url: null,
+		};
+		const transfer = fakeTransfer();
+		expect(writeLibrarySampleDrag(transfer, asset)).toBe(false);
+		expect(hasLibrarySampleDrag(transfer)).toBe(false);
+	});
+
+	it("sees no sound in a drag carrying something else", () => {
+		const transfer = fakeTransfer();
+		transfer.setData("text/plain", "just some text");
+		expect(hasLibrarySampleDrag(transfer)).toBe(false);
+		expect(readLibrarySampleDrag(transfer)).toBeNull();
+	});
+
+	it("ignores a payload another page wrote under our type", () => {
+		// Any page can `setData` an arbitrary MIME type, so what comes back is
+		// input: a shape that is not a library sound reads as no sound at all.
+		const transfer = fakeTransfer();
+		transfer.setData(LIBRARY_SAMPLE_MIME, '{"name":"Nice try","url":"//evil"}');
+		expect(readLibrarySampleDrag(transfer)).toBeNull();
+
+		transfer.setData(LIBRARY_SAMPLE_MIME, "not json at all");
+		expect(readLibrarySampleDrag(transfer)).toBeNull();
+	});
+
+	it("answers for a transfer that is not there at all", () => {
+		expect(hasLibrarySampleDrag(null)).toBe(false);
+		expect(readLibrarySampleDrag(null)).toBeNull();
+	});
+});

--- a/src/library/assetDrag.ts
+++ b/src/library/assetDrag.ts
@@ -1,0 +1,83 @@
+import {
+	type LibrarySample,
+	librarySampleSchema,
+	toLibrarySample,
+} from "./insertion";
+import type { LibraryAsset } from "./manifest";
+
+/**
+ * Carrying a library sound on a drag (#225, PRD LIB-01).
+ *
+ * Dragging is how a producer expects to put a sound on a track, and the web's
+ * drag surface is a `DataTransfer`: a string keyed by MIME type, shared with
+ * every other page and application the user might drag between. Two rules follow
+ * from that, and this module is where both live so no component repeats them:
+ *
+ * - **The payload is described, not referenced.** A module-level "currently
+ *   dragging" variable would be simpler and wrong: it survives a cancelled
+ *   drag, and it cannot cross a window. The sound travels as its own JSON, under
+ *   a type of ours.
+ * - **What comes back is input.** Any page can write this MIME type, so a drop
+ *   parses the payload through `librarySampleSchema` and ignores anything that
+ *   does not fit, rather than casting whatever the transfer held.
+ *
+ * A `dragover` may not read the transfer's *data* at all — browsers expose only
+ * the type list until the drop — which is why {@link hasLibrarySampleDrag} asks
+ * about types and {@link readLibrarySampleDrag} is used only from `drop`.
+ */
+
+/** The drag type a library sound travels under. */
+export const LIBRARY_SAMPLE_MIME = "application/x-solid-groove-library-sample";
+
+/**
+ * The slice of `DataTransfer` these use. Structural rather than the DOM type so
+ * a test can hand in a plain object — jsdom implements no `DataTransfer` at all.
+ */
+export interface LibraryDragTransfer {
+	readonly types: readonly string[];
+	getData(format: string): string;
+	setData(format: string, data: string): void;
+	effectAllowed?: string;
+	dropEffect?: string;
+}
+
+/**
+ * Puts a browsed sound on the drag, and reports whether it could. An asset with
+ * no master audio (a preset) carries nothing a track can load, so its row starts
+ * no drag rather than starting one that must be refused on drop.
+ */
+export function writeLibrarySampleDrag(
+	transfer: LibraryDragTransfer | null | undefined,
+	asset: LibraryAsset,
+): boolean {
+	const sample = toLibrarySample(asset);
+	if (!transfer || !sample) return false;
+	transfer.setData(LIBRARY_SAMPLE_MIME, JSON.stringify(sample));
+	transfer.effectAllowed = "copy";
+	return true;
+}
+
+/** Whether this drag is carrying a library sound, from the type list alone. */
+export function hasLibrarySampleDrag(
+	transfer: LibraryDragTransfer | null | undefined,
+): boolean {
+	return [...(transfer?.types ?? [])].includes(LIBRARY_SAMPLE_MIME);
+}
+
+/** The sound a drop is carrying, or `null` when it is carrying something else. */
+export function readLibrarySampleDrag(
+	transfer: LibraryDragTransfer | null | undefined,
+): LibrarySample | null {
+	if (!hasLibrarySampleDrag(transfer)) return null;
+	const raw = transfer?.getData(LIBRARY_SAMPLE_MIME);
+	if (!raw) return null;
+	try {
+		const parsed = librarySampleSchema.safeParse(JSON.parse(raw));
+		return parsed.success ? parsed.data : null;
+	} catch {
+		// Not JSON at all: a page outside this app wrote our type.
+		return null;
+	}
+}
+
+export type { LibrarySample };


### PR DESCRIPTION
## What & why

3 of 5 for #225, builds on #243.

Dragging a sound onto a track is how a producer expects to load one, and the
web's drag surface is a `DataTransfer`: a string keyed by MIME type, shared with
every other page and application the user might drag between.
`src/library/assetDrag.ts` owns both rules that follow, so no component repeats
them.

- **The sound travels as its own JSON, under a type of ours** — not through a
  module-level "currently dragging" variable, which would survive a cancelled
  drag and could not cross a window.
- **What comes back is input.** Any page can `setData` our MIME type, so a drop
  parses the payload through `librarySampleSchema` and ignores anything that
  does not fit. A `dragover` may not read the transfer's *data* at all, only its
  type list, which is why "is this a sound?" and "give me the sound" are separate
  calls.

`AssetRow` is now the drag handle, in both the panel tree and the pack browser. A
sound with no master audio — a preset — starts no drag at all rather than one
that would have to be refused when it lands.

Nothing takes the drop yet; the sampler does that in #245.

Refs #225

## Core flows

Untouched. CF-002 (#61) names this affordance in its `addSamplerTrack` helper but
stays `test.fixme` until #223 lands too — see #246.

## Walkthrough

No user-visible change on its own: the row becomes draggable, but nothing yet
accepts the drop, so there is nothing to show. #246 carries the walkthrough.

## Evidence

```
bun run typecheck   → clean
bun run check       → Checked 502 files. No fixes applied.
bun run test        → Test Files 170 passed (170) · Tests 2278 passed (2278)
```

Diff: 218 changed lines.

`assetDrag.test.ts` covers the round trip, the preset refusal, a drag carrying
something else, and a payload another page wrote under our type (both malformed
JSON and well-formed JSON of the wrong shape). `LibraryBrowser.test.tsx` adds one
test that a rendered row is `draggable` and puts the right sound on the transfer.

jsdom implements no `DataTransfer` at all, which is why `LibraryDragTransfer` is
a structural slice rather than the DOM type — a test hands in a plain object.
The real-browser behaviour is verified in #246.

## Acceptance criteria met

#225 has no acceptance checkboxes. This slice delivers the drag source half of
its "Expected" outcome.

## Stack

1. #242 — `asset.add` / `asset.remove`
2. #243 — the library → domain asset mapping
3. **this PR** — the drag source
4. #245 — load a dropped sound onto a sampler
5. #246 — retire the swap list, insert from the keyboard (`Closes #225`)
