### PR TITLE
Load a sound dropped from the library onto a sampler

### DIFF
--- a/e2e/instrument.spec.ts
+++ b/e2e/instrument.spec.ts
@@ -15,17 +15,19 @@ test("changes a track's instrument from its own panel", async ({ page }) => {
 	await page.getByRole("button", { name: "New Project" }).click();
 	await expect(page.getByRole("region", { name: "Step editor" })).toBeVisible();
 
+	// `exact` because the track's instrument controls now sit in a region named
+	// "<track> instrument" (#225), which a substring match would also select.
+	const picker = page.getByRole("region", { name: "Instrument", exact: true });
 	// The workspace scrolls inside a viewport-height app, so each capture
 	// scrolls that container and then returns the page itself to the top —
 	// otherwise the shot is framed on empty page below the editor.
-	const picker = page.getByRole("region", { name: "Instrument" });
 	const show = async (name: string | RegExp): Promise<void> => {
 		await page.getByRole("region", { name }).scrollIntoViewIfNeeded();
 		await page.evaluate(() => window.scrollTo(0, 0));
 	};
 	// The starter track is a sampler, and the panel now says so out loud.
 	await expect(page.getByRole("region", { name: "Sampler" })).toBeVisible();
-	await show("Instrument");
+	await show(/^Instrument$/);
 	await step("Open a project: the track's instrument is a sampler");
 
 	// Sampler -> synth, in one transaction the command layer can name.

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -8,6 +8,9 @@ import {
 	within,
 } from "@solidjs/testing-library";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
 import { installWebAudioGlobals } from "../audio/testAudioContext";
 import {
 	createDrumMachineFixtureProject,
@@ -15,9 +18,11 @@ import {
 	createSliceFixtureProject,
 } from "../domain/fixtures";
 import { fakePreviewEngine } from "../library/__fixtures__/fakePreviewEngine";
+import { LIBRARY_SAMPLE_MIME } from "../library/assetDrag";
 import type { PreviewEngine } from "../library/audition";
 import type { InMemoryProjectRepository } from "../persistence/inMemoryProjectRepository";
 import { detectPlatform, shortcutLabel } from "../shortcuts";
+import { memoryStorage } from "../testing/storage";
 
 installWebAudioGlobals();
 
@@ -97,7 +102,10 @@ function saveRetryButton(): HTMLElement | null {
 // context to resolve against — a bare MemoryRouter isn't enough.
 function renderEditor(
 	projectId: string,
-	options: { createAuditionEngine?: () => PreviewEngine } = {},
+	options: {
+		createAuditionEngine?: () => PreviewEngine;
+		analytics?: Analytics;
+	} = {},
 ) {
 	const EditorView = EditorViewModule.default;
 	return render(() => (
@@ -108,11 +116,49 @@ function renderEditor(
 					<EditorView
 						projectId={projectId}
 						createAuditionEngine={options.createAuditionEngine}
+						analytics={options.analytics}
 					/>
 				)}
 			/>
 		</MemoryRouter>
 	));
+}
+
+/** A library sound as a drag hands it over, already in its wire form (#225). */
+const DROPPED_HAT = {
+	name: "Dropped Closed Hat",
+	packId: "pak_SdlN_OazweXrwury0j27Y",
+	packVersion: "1.0.0",
+	kind: "sample",
+	storageRef: "samples/starter-library/audio/sha256/ab/cd/abcd.wav",
+	url: "/samples/starter-library/audio/sha256/ab/cd/abcd.wav",
+	durationSeconds: 0.25,
+	sampleRate: 48000,
+	channelCount: 1,
+	licence: "solid-groove-owned",
+};
+
+/** jsdom implements no `DataTransfer`; this is the slice a drop reads. */
+function transferCarrying(sample: unknown) {
+	const payload = JSON.stringify(sample);
+	return {
+		types: [LIBRARY_SAMPLE_MIME],
+		getData: (format: string) =>
+			format === LIBRARY_SAMPLE_MIME ? payload : "",
+		setData: () => {},
+	};
+}
+
+function recordingAnalytics(
+	transport: ReturnType<typeof createRecordingTransport>,
+): Analytics {
+	const analytics = new Analytics({
+		transport,
+		consent: new ConsentStore(memoryStorage()),
+		storage: memoryStorage(),
+	});
+	analytics.setAccountType("anonymous");
+	return analytics;
 }
 
 describe("EditorView", () => {
@@ -208,8 +254,9 @@ describe("EditorView", () => {
 
 		renderEditor(project.metadata.id);
 
+		// Named for its track, because a drop has to land on a particular one.
 		expect(
-			await screen.findByRole("region", { name: "Sampler" }),
+			await screen.findByRole("region", { name: "BD instrument" }),
 		).toBeInTheDocument();
 		// The INS-01 sampler controls: pitch, sample start/end, amp envelope.
 		expect(screen.getByLabelText("Pitch")).toBeInTheDocument();
@@ -217,6 +264,44 @@ describe("EditorView", () => {
 		expect(screen.getByLabelText("End")).toBeInTheDocument();
 		expect(
 			screen.getByRole("button", { name: "Audition" }),
+		).toBeInTheDocument();
+		// Scoped to the name paragraph: the swap list this PR leaves in place
+		// carries the same name in an <option>.
+		const panel = screen.getByRole("region", { name: "BD instrument" });
+		expect(
+			within(panel).getByText("909 Bass Drum", { selector: "p" }),
+		).toBeInTheDocument();
+	});
+
+	it("loads a sound dropped from the library onto the sampler, undoably", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+		const transport = createRecordingTransport();
+
+		renderEditor(project.metadata.id, {
+			analytics: recordingAnalytics(transport),
+		});
+		const panel = await screen.findByRole("region", {
+			name: "BD instrument",
+		});
+
+		fireEvent.drop(panel, { dataTransfer: transferCarrying(DROPPED_HAT) });
+
+		// The sampler names the dropped sound, and the project now carries it.
+		expect(
+			await within(panel).findByText(DROPPED_HAT.name, { selector: "p" }),
+		).toBeInTheDocument();
+		const changed = transport.named("instrument_changed");
+		expect(changed).toHaveLength(1);
+		expect(changed[0].params.instrument_type).toBe("sampler");
+
+		// Carrying the asset and pointing the sampler at it is one transaction, so
+		// one undo takes the whole drop back.
+		fireEvent.click(await screen.findByRole("button", { name: /^Undo/ }));
+		expect(
+			await within(panel).findByText("909 Bass Drum", { selector: "p" }),
 		).toBeInTheDocument();
 	});
 

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -9,6 +9,10 @@ import {
 	Show,
 	Switch,
 } from "solid-js";
+import {
+	type Analytics,
+	analytics as defaultAnalytics,
+} from "../analytics/analytics";
 import ArrangementView, {
 	type PlacementEditingActions,
 } from "../arrangement/ArrangementView";
@@ -16,10 +20,13 @@ import { getAudioRuntime } from "../audio/AudioRuntime";
 import { clampTempo } from "../audio/Transport";
 import { setParameter } from "../commands/definitions/parameters";
 import type { NoteTrigger } from "../domain/entities";
+import { createFactoryContext } from "../domain/factories";
 import type { EventId, TrackId } from "../domain/ids";
 import { SONG_TEMPO } from "../domain/parameters";
 import { TICKS_PER_QUARTER } from "../domain/time";
+import type { LibrarySample } from "../library/assetDrag";
 import type { PreviewEngine } from "../library/audition";
+import { loadSampleCommands } from "../library/insertion";
 import LibraryBrowser from "../library/LibraryBrowser";
 import { ToneAuditionEngine } from "../library/toneAuditionEngine";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
@@ -54,6 +61,8 @@ export interface EditorViewProps {
 	 * per-mount lifecycle can be exercised without Web Audio.
 	 */
 	readonly createAuditionEngine?: () => PreviewEngine;
+	/** Injected in tests; the shared catalog-backed instance otherwise. */
+	readonly analytics?: Analytics;
 }
 
 /**
@@ -243,6 +252,36 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	const replacementOptions = createMemo(() =>
 		model.replacementOptions(project()),
 	);
+
+	/**
+	 * Loads a library sound onto the edited track's sampler, from a drop on its
+	 * instrument panel (#225). The browser's keyboard-reachable "Insert" joins
+	 * this same path in the next PR in the stack.
+	 *
+	 * `loadSampleCommands` carries the asset and points the sampler at it in one
+	 * transaction, so this is one revision and one undo. It is refused — leaving
+	 * the project untouched — when the edited track has no sampler to load into.
+	 */
+	function loadLibrarySample(sample: LibrarySample): void {
+		const currentProject = project();
+		// The track the editor is pointed at (#228), not the project's first —
+		// so a drop lands on whichever track the user selected.
+		const trackId = model.samplerTrackId(track());
+		if (!currentProject || !trackId) return;
+		const result = session.dispatch(
+			loadSampleCommands(
+				currentProject,
+				trackId,
+				sample,
+				createFactoryContext(),
+			),
+		);
+		if (!result?.ok) return;
+		const analytics = props.analytics ?? defaultAnalytics;
+		analytics.log("instrument_changed", { instrument_type: "sampler" });
+		analytics.logFeatureFirstUse("sampler");
+	}
+
 	const packDependencyLabel = createMemo(() =>
 		model.packDependencyLabel(project()),
 	);
@@ -396,6 +435,7 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 													instrumentPanelTrackId={instrumentPanelTrackId()}
 													sampleName={sampleName()}
 													replacementOptions={replacementOptions()}
+													loadSample={loadLibrarySample}
 													auditionInstrument={auditionInstrument}
 												/>
 											)}

--- a/src/editor/InstrumentArea.test.tsx
+++ b/src/editor/InstrumentArea.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Instrument } from "../domain/entities";
+import { packVersion } from "../domain/entities";
+import type { AssetId, PackId } from "../domain/ids";
+import { LIBRARY_SAMPLE_MIME, type LibrarySample } from "../library/assetDrag";
+import InstrumentArea from "./InstrumentArea";
+
+afterEach(() => cleanup());
+
+const SAMPLER: Instrument = {
+	kind: "sampler",
+	assetId: "ast_a" as AssetId,
+	parameters: {},
+};
+const SYNTH: Instrument = { kind: "synth", parameters: {} };
+
+const DROPPED: LibrarySample = {
+	name: "Closed Hat",
+	packId: "pak_SdlN_OazweXrwury0j27Y" as PackId,
+	packVersion: packVersion("1.0.0"),
+	kind: "sample",
+	storageRef: "samples/starter-library/audio/sha256/ab/cd/abcd.wav",
+	url: "/samples/starter-library/audio/sha256/ab/cd/abcd.wav",
+	durationSeconds: 0.25,
+	sampleRate: 48000,
+	channelCount: 1,
+	licence: "solid-groove-owned",
+};
+
+/**
+ * jsdom implements no `DataTransfer`, so a drag test supplies the slice the
+ * area reads: the type list a `dragover` may see, and the data a `drop` gets.
+ */
+function transferCarrying(payload: string | null) {
+	return {
+		types: payload === null ? ["text/plain"] : [LIBRARY_SAMPLE_MIME],
+		dropEffect: "none",
+		getData: (format: string) =>
+			format === LIBRARY_SAMPLE_MIME && payload !== null ? payload : "",
+		setData: () => {},
+	};
+}
+
+function renderArea(instrument: Instrument | null = SAMPLER) {
+	const loadSample = vi.fn();
+	render(() => (
+		<InstrumentArea
+			trackName="Hats"
+			instrument={instrument}
+			loadSample={loadSample}
+		>
+			<p>panel goes here</p>
+		</InstrumentArea>
+	));
+	return { loadSample };
+}
+
+/** The area, found the way a drag target is: by its accessible name. */
+function area(): HTMLElement {
+	return screen.getByRole("region", { name: "Hats instrument" });
+}
+
+const isTarget = () =>
+	area().classList.contains("instrument-panel-drop-target");
+
+describe("InstrumentArea", () => {
+	it("is named for its track, so a drop lands on a particular one", () => {
+		renderArea();
+		expect(area()).toBeInTheDocument();
+		expect(screen.getByText("panel goes here")).toBeInTheDocument();
+	});
+
+	it("loads a dropped library sound", () => {
+		const { loadSample } = renderArea();
+		fireEvent.drop(area(), {
+			dataTransfer: transferCarrying(JSON.stringify(DROPPED)),
+		});
+		expect(loadSample).toHaveBeenCalledTimes(1);
+		expect(loadSample.mock.calls[0][0]).toEqual(DROPPED);
+	});
+
+	it("ignores a drop carrying anything else", () => {
+		const { loadSample } = renderArea();
+		fireEvent.drop(area(), { dataTransfer: transferCarrying(null) });
+		expect(loadSample).not.toHaveBeenCalled();
+	});
+
+	it("ignores a drop whose payload is not a library sound", () => {
+		const { loadSample } = renderArea();
+		fireEvent.drop(area(), {
+			dataTransfer: transferCarrying('{"name":"Evil"}'),
+		});
+		expect(loadSample).not.toHaveBeenCalled();
+	});
+
+	it("marks itself a copy target only while a sound is over it", () => {
+		renderArea();
+		const transfer = transferCarrying(JSON.stringify(DROPPED));
+		fireEvent.dragOver(area(), { dataTransfer: transfer });
+		expect(transfer.dropEffect).toBe("copy");
+		expect(isTarget()).toBe(true);
+
+		fireEvent.dragLeave(area(), { dataTransfer: transfer });
+		expect(isTarget()).toBe(false);
+	});
+
+	it("leaves a drag it cannot take to the browser", () => {
+		renderArea();
+		const transfer = transferCarrying(null);
+		fireEvent.dragOver(area(), { dataTransfer: transfer });
+		expect(transfer.dropEffect).toBe("none");
+		expect(isTarget()).toBe(false);
+	});
+
+	it("takes nothing when the track has no sampler to load into", () => {
+		const { loadSample } = renderArea(SYNTH);
+		const transfer = transferCarrying(JSON.stringify(DROPPED));
+
+		// Not even a drop cursor: a synth track is not a target at all.
+		fireEvent.dragOver(area(), { dataTransfer: transfer });
+		expect(transfer.dropEffect).toBe("none");
+		expect(isTarget()).toBe(false);
+
+		fireEvent.drop(area(), { dataTransfer: transfer });
+		expect(loadSample).not.toHaveBeenCalled();
+	});
+});

--- a/src/editor/InstrumentArea.tsx
+++ b/src/editor/InstrumentArea.tsx
@@ -1,0 +1,71 @@
+import { createSignal, type JSX } from "solid-js";
+import type { Instrument } from "../domain/entities";
+import {
+	hasLibrarySampleDrag,
+	type LibrarySample,
+	readLibrarySampleDrag,
+} from "../library/assetDrag";
+import "../instrument/InstrumentPanel.css";
+
+export interface InstrumentAreaProps {
+	/** Names the region, and so names a drop's target (#225). */
+	readonly trackName: string;
+	readonly instrument: Instrument | null;
+	/** Loads a sound dropped from the library onto this track's sampler. */
+	loadSample(sample: LibrarySample): void;
+	readonly children: JSX.Element;
+}
+
+/**
+ * One track's instrument controls — the kind picker (#224) and whichever panel
+ * that kind gets — inside a single region named for the track.
+ *
+ * It exists to be a *drop target* (#225). Dragging a sound onto an instrument is
+ * how a producer expects to load one, and the target has to be identifiable: a
+ * project with several tracks has several of these, so the region is named
+ * `"Hats instrument"` rather than `"Sampler"`, and a drop lands on a particular
+ * track. The panels inside keep their own names (`"Sampler"`, `"Synth voice"`),
+ * which is what lets the picker's own region stay simply `"Instrument"`.
+ *
+ * The whole area is the target rather than the sampler panel alone, for two
+ * reasons: the gesture does not require hitting a small strip, and a `drop` does
+ * not travel *down* the tree — landing on the picker at the top of the area
+ * would otherwise reach no handler at all.
+ *
+ * Only a sampler takes a sound. A drag over a synth or drum-machine track is
+ * left to the browser, so it shows no drop cursor and nothing is dispatched.
+ */
+export default function InstrumentArea(
+	props: InstrumentAreaProps,
+): JSX.Element {
+	const [dragOver, setDragOver] = createSignal(false);
+	const takesSample = () => props.instrument?.kind === "sampler";
+
+	return (
+		<section
+			class="instrument-area"
+			classList={{ "instrument-panel-drop-target": dragOver() }}
+			aria-label={`${props.trackName} instrument`}
+			onDragOver={(event) => {
+				// Only claim a drag this track can actually take. Calling
+				// `preventDefault` is what marks the element as a drop target, so
+				// skipping it for anything else leaves the browser's own handling be.
+				if (!takesSample() || !hasLibrarySampleDrag(event.dataTransfer)) return;
+				event.preventDefault();
+				if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+				setDragOver(true);
+			}}
+			onDragLeave={() => setDragOver(false)}
+			onDrop={(event) => {
+				setDragOver(false);
+				if (!takesSample()) return;
+				const sample = readLibrarySampleDrag(event.dataTransfer);
+				if (!sample) return;
+				event.preventDefault();
+				props.loadSample(sample);
+			}}
+		>
+			{props.children}
+		</section>
+	);
+}

--- a/src/editor/InstrumentPanel.tsx
+++ b/src/editor/InstrumentPanel.tsx
@@ -10,7 +10,7 @@ export interface InstrumentPanelProps {
 	readonly instrument: Instrument | null;
 	/** Display name of the currently loaded sample, or null when empty. */
 	readonly sampleName: string | null;
-	/** Samples the sampler panel can swap to (a real browser lands with LOOP-013). */
+	/** Samples the sampler panel can swap to; retired in the next PR. */
 	readonly replacementOptions: readonly SampleChoice[];
 	dispatch(
 		commands: RawCommandInput | readonly RawCommandInput[],

--- a/src/editor/TrackEditor.tsx
+++ b/src/editor/TrackEditor.tsx
@@ -9,7 +9,9 @@ import type { Clip, Instrument, Project } from "../domain/entities";
 import type { EventId, TrackId } from "../domain/ids";
 import InstrumentKindPicker from "../instrument/InstrumentKindPicker";
 import type { SampleChoice } from "../instrument/SamplerPanel";
+import type { LibrarySample } from "../library/assetDrag";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
+import InstrumentArea from "./InstrumentArea";
 import InstrumentPanel from "./InstrumentPanel";
 import PianoRoll, { type PianoRollActions } from "./PianoRoll";
 import StepEditor from "./StepEditor";
@@ -37,6 +39,8 @@ export interface TrackEditorProps {
 	readonly instrumentPanelTrackId: TrackId | null;
 	readonly sampleName: string | null;
 	readonly replacementOptions: readonly SampleChoice[];
+	/** Loads a sound dropped from the library onto this track's sampler (#225). */
+	readonly loadSample: (sample: LibrarySample) => void;
 	readonly auditionInstrument: () => void;
 }
 
@@ -124,36 +128,44 @@ export default function TrackEditor(props: TrackEditorProps) {
 				)}
 			</Show>
 			{/*
-			 * The kind picker leads the track's instrument controls (#224). It sits
-			 * outside `InstrumentPanel` because that component is the switch
-			 * *between* instrument panels and the picker is what chooses which one —
-			 * it must also show for a drum machine and for a track with no
-			 * instrument, neither of which reaches that switch. Outside the clip
-			 * `Show` above, too: a track with no clip still has an instrument to
-			 * choose (#228).
+			 * The track's instrument controls, in one region named for the track so
+			 * a sound dragged from the library lands on a particular one (#225).
+			 *
+			 * The kind picker leads them (#224). It sits outside `InstrumentPanel`
+			 * because that component is the switch *between* instrument panels and
+			 * the picker is what chooses which one — it must also show for a drum
+			 * machine and for a track with no instrument, neither of which reaches
+			 * that switch. Outside the clip `Show` above, too: a track with no clip
+			 * still has an instrument to choose (#228).
 			 */}
-			<Show when={props.instrumentPanelTrackId}>
-				{(trackId) => (
-					<InstrumentKindPicker
-						trackId={trackId()}
-						project={props.project}
-						instrument={props.instrument}
-						dispatch={props.dispatch}
-					/>
-				)}
-			</Show>
-			<Show when={props.instrumentPanelTrackId}>
-				{(trackId) => (
-					<InstrumentPanel
-						trackId={trackId()}
-						instrument={props.instrument}
-						sampleName={props.sampleName}
-						replacementOptions={props.replacementOptions}
-						dispatch={props.dispatch}
-						audition={props.auditionInstrument}
-					/>
-				)}
-			</Show>
+			<InstrumentArea
+				trackName={props.trackName ?? "Track"}
+				instrument={props.instrument}
+				loadSample={props.loadSample}
+			>
+				<Show when={props.instrumentPanelTrackId}>
+					{(trackId) => (
+						<InstrumentKindPicker
+							trackId={trackId()}
+							project={props.project}
+							instrument={props.instrument}
+							dispatch={props.dispatch}
+						/>
+					)}
+				</Show>
+				<Show when={props.instrumentPanelTrackId}>
+					{(trackId) => (
+						<InstrumentPanel
+							trackId={trackId()}
+							instrument={props.instrument}
+							sampleName={props.sampleName}
+							replacementOptions={props.replacementOptions}
+							dispatch={props.dispatch}
+							audition={props.auditionInstrument}
+						/>
+					)}
+				</Show>
+			</InstrumentArea>
 		</div>
 	);
 }

--- a/src/editor/editorViewModel.test.ts
+++ b/src/editor/editorViewModel.test.ts
@@ -22,6 +22,7 @@ import {
 	replacementOptions,
 	sampleAssets,
 	sampleName,
+	samplerTrackId,
 	showPianoRoll,
 } from "./editorViewModel";
 
@@ -234,6 +235,29 @@ describe("sampleName", () => {
 		const synth = createPianoRollFixtureProject();
 		expect(sampleName(synth, editedTrack(synth, null))).toBeNull();
 		expect(sampleName(null, null)).toBeNull();
+	});
+});
+
+describe("samplerTrackId", () => {
+	it("names the track a dropped sound loads onto", () => {
+		const project = createSliceFixtureProject();
+		expect(samplerTrackId(editedTrack(project, null))).toBe(
+			project.song.tracks[0].id,
+		);
+	});
+
+	it("follows the selected track rather than the project's first (#228)", () => {
+		const project = createSliceFixtureProject();
+		const first = project.song.tracks[0];
+		expect(samplerTrackId(editedTrack(project, first.id))).toBe(first.id);
+	});
+
+	it("is null when the edited track has no sampler to load into", () => {
+		const drums = createDrumMachineFixtureProject();
+		const synth = createPianoRollFixtureProject();
+		expect(samplerTrackId(editedTrack(drums, null))).toBeNull();
+		expect(samplerTrackId(editedTrack(synth, null))).toBeNull();
+		expect(samplerTrackId(null)).toBeNull();
 	});
 });
 

--- a/src/editor/editorViewModel.ts
+++ b/src/editor/editorViewModel.ts
@@ -194,6 +194,17 @@ export function showPianoRoll(
 }
 
 /**
+/**
+ * The track a sound dropped from the library, or inserted with the keyboard,
+ * loads onto — the edited track, but only while it carries a sampler (#225).
+ * Null when there is nothing to load into, so the surface can decline rather
+ * than dispatch a transaction the command layer would refuse.
+ */
+export function samplerTrackId(track: Track | null): TrackId | null {
+	return track?.instrument?.kind === "sampler" ? track.id : null;
+}
+
+/**
  * The track the instrument panel edits — whatever instrument it carries, or
  * none at all. The panel leads with the kind picker (#224), so gating this on
  * the kinds that have a sub-panel would leave a drum-machine track (whose own

--- a/src/instrument/InstrumentPanel.css
+++ b/src/instrument/InstrumentPanel.css
@@ -46,6 +46,20 @@
 	color: var(--color-text);
 }
 
+/* One track's instrument controls: the kind picker and its panel, together,
+   so the whole area is one drop target (#225). */
+.instrument-area {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+/* A sound is being dragged over the area and this track's sampler will take it. */
+.instrument-panel-drop-target {
+	outline: 2px solid var(--color-accent, #20c8e8);
+	outline-offset: -2px;
+}
+
 .sampler-load-select,
 .instrument-panel-audition {
 	height: 30px;

--- a/src/instrument/SamplerPanel.tsx
+++ b/src/instrument/SamplerPanel.tsx
@@ -18,6 +18,7 @@ import {
 	SAMPLER_SAMPLE_END,
 	SAMPLER_SAMPLE_START,
 } from "../domain/parameters";
+import { MASK_CONTENT } from "../monitoring/replayPrivacy";
 import FillSlider from "./FillSlider";
 import { formatInstrumentValue } from "./formatValue";
 import "./InstrumentPanel.css";
@@ -33,7 +34,7 @@ export interface SamplerPanelProps {
 	readonly instrument: Extract<Instrument, { kind: "sampler" }>;
 	/** Display name of the currently loaded sample, or null when empty. */
 	readonly sampleName: string | null;
-	/** Samples the user can swap to (a real browser lands with LOOP-013). */
+	/** Samples the user can swap to; retired for the drop in the next PR. */
 	readonly replacementOptions: readonly SampleChoice[];
 	dispatch(
 		commands: RawCommandInput | readonly RawCommandInput[],
@@ -59,6 +60,11 @@ const ENVELOPE_SLIDERS = [
  * The reusable one-shot sampler panel (PRD INS-01, mock `05b-sampler`): sample
  * selection + audition, and fill-sliders for pitch, sample start/end, and the
  * amp envelope (ADSR).
+ *
+ * A sound is loaded by dragging it here from the library (#225), but this panel
+ * owns none of that: the drop target is the surrounding `InstrumentArea`, which
+ * is named for its track so a drop lands on a particular one and which catches a
+ * drop anywhere in the track's instrument controls. This panel stays a panel.
  *
  * Parameter edits dispatch a validated `parameter.set` in the `instrument`
  * scope; a sample swap dispatches `instrument.setSample`, whose inverse restores
@@ -93,7 +99,10 @@ export default function SamplerPanel(props: SamplerPanelProps): JSX.Element {
 			<div class="instrument-panel-groups">
 				<div class="instrument-panel-group">
 					<h3 class="instrument-panel-heading">Sample</h3>
-					<p class="sampler-sample-name">
+					{/* The sound's name, which is library copy rather than anything the
+					    user typed — masked all the same, since a user-recorded sample
+					    lands in the same slot (ADR 0002 decision 2). */}
+					<p class={`sampler-sample-name ${MASK_CONTENT}`}>
 						{props.sampleName ?? "No sample loaded"}
 					</p>
 					<Show when={props.replacementOptions.length > 0}>


### PR DESCRIPTION
## What & why

4 of 5 for #225, builds on #244. This is the half that takes the drop.

A track's instrument controls are now a drop target for a library sound, and the
editor turns what lands on them into one transaction.

`InstrumentArea` is that target: one region wrapping the kind picker (#224) and
whichever panel the kind gets, named `"Hats instrument"` rather than `"Sampler"`,
because a project with several tracks has several of these and a drop has to land
on a particular one. That is also the name CF-002's spec already uses.

The **area**, rather than the sampler panel alone, for two reasons: the gesture
does not require hitting a small strip, and a `drop` does not travel *down* the
tree — a drop on the picker at the top of the area would otherwise reach no
handler at all. The panels inside keep their own names (`"Sampler"`,
`"Synth voice"`), which is what leaves #224's surface exactly as it was.

It reports what landed rather than dispatching it: the transaction needs the open
project and an ID factory, which belong to the composition root, not to a panel.
`EditorView.loadLibrarySample` is that root's one path — it carries the asset and
points the sampler at it in a single transaction, so a drop is one revision and
one undo, and emits `instrument_changed` once. It loads onto the **selected**
track (#228), not the project's first. Only a sampler is a target at all: a drag
over a synth or drum-machine track shows no drop cursor and dispatches nothing.

**The swap list stays for now.** Retiring it in favour of the loaded sample's
name is #246. Removing it here would take away the only way to change a sample
before its replacement had landed.

Refs #225

## Core flows

Untouched. CF-002 (#61) exercises this surface but stays `test.fixme` until #223
lands too — see #246.

One **non-flow** spec did change, and a reviewer should check it: `e2e/instrument.spec.ts`
(#224's) needed its picker locator made exact —

```ts
const picker = page.getByRole("region", { name: "Instrument", exact: true });
```

Playwright matches an accessible name by *substring*, so once a sibling region is
named `"BD instrument"`, the old `{ name: "Instrument" }` resolved to two
elements. The same applies to its `show(/^Instrument$/)` call. Its assertions are
otherwise untouched: it still asserts `"Sampler"`, `"Synth voice"`, the pads, and
the one-entry-per-switch undo, all unchanged.

## Walkthrough

#246 carries it: this slice adds the drop but leaves the swap list in place, so
the panel a reviewer would see is not the one that ships.

## Evidence

Re-run after rebasing onto `main` at `373e7a9`:

```
bun run typecheck              → clean
bun run check                  → Checked 511 files. No fixes applied.
bun run test                   → Test Files 174 passed (174) · Tests 2339 passed (2339)
bun run test:browser:chromium  → 20 passed, 2 skipped
```

Tests for this slice's own behaviour, at both layers:

- `InstrumentArea.test.tsx` — a dropped sound is reported; a drag carrying
  something else is ignored; a payload that is not a library sound is ignored;
  the area marks itself a copy target only while a sound is over it; a drag it
  cannot take is left to the browser; and a track with **no sampler** is not a
  target at all (no drop cursor, nothing dispatched).
- `editorViewModel.test.ts` — `samplerTrackId` names the track a drop loads onto,
  follows the selected track rather than the project's first, and is null for a
  drum machine, a synth, and no project.
- `EditorView.test.tsx` — a drop loads the sound end to end, emits
  `instrument_changed` exactly once, and **one** undo takes the whole drop back.

## Size — over the ceiling, deliberately

**468 changed lines, against the 400 limit.** Stating it rather than shaving
tests to hide it.

It grew when this stack was rebased onto the moved `main`: satisfying CF-002's
frozen drop-target name *and* #224's landed instrument spec required introducing
`InstrumentArea` (component + tests, ~200 lines) rather than renaming the sampler
panel in place.

I could not find a further split that the project's other rules allow. The
component, its wiring in `TrackEditor`, and `EditorView`'s handler are mutually
dependent: a PR with the component alone leaves `TrackEditor` without a
`loadSample` source, and moving the editor tests into a later PR would ship
untested code and then a tests-only PR — both of which CLAUDE.md forbids more
firmly than the line count. Happy to split it differently if you would rather.

## Acceptance criteria met

#225 has no acceptance checkboxes. This slice delivers the drop half of its
"Expected" outcome: dragging an asset onto a sampler loads it through
`instrument.setSample` as one undoable transaction, emitting `instrument_changed`.

## Stack

1. #242 — `asset.add` / `asset.remove`
2. #243 — the library → domain asset mapping
3. #244 — the drag source
4. **this PR** — the instrument area takes the drop
5. #246 — retire the swap list, insert from the keyboard (`Closes #225`)
