### PR TITLE
Retire the sampler's swap list, and insert from the keyboard

### DIFF
--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -18,8 +18,10 @@ import {
 	createSliceFixtureProject,
 } from "../domain/fixtures";
 import { fakePreviewEngine } from "../library/__fixtures__/fakePreviewEngine";
+import { fixtureFetcher } from "../library/__fixtures__/fixtures";
 import { LIBRARY_SAMPLE_MIME } from "../library/assetDrag";
 import type { PreviewEngine } from "../library/audition";
+import { LibraryClient } from "../library/libraryClient";
 import type { InMemoryProjectRepository } from "../persistence/inMemoryProjectRepository";
 import { detectPlatform, shortcutLabel } from "../shortcuts";
 import { memoryStorage } from "../testing/storage";
@@ -104,6 +106,7 @@ function renderEditor(
 	projectId: string,
 	options: {
 		createAuditionEngine?: () => PreviewEngine;
+		libraryClient?: LibraryClient;
 		analytics?: Analytics;
 	} = {},
 ) {
@@ -116,6 +119,7 @@ function renderEditor(
 					<EditorView
 						projectId={projectId}
 						createAuditionEngine={options.createAuditionEngine}
+						libraryClient={options.libraryClient}
 						analytics={options.analytics}
 					/>
 				)}
@@ -265,12 +269,11 @@ describe("EditorView", () => {
 		expect(
 			screen.getByRole("button", { name: "Audition" }),
 		).toBeInTheDocument();
-		// Scoped to the name paragraph: the swap list this PR leaves in place
-		// carries the same name in an <option>.
+		// It says what it is holding rather than offering a list of the project's
+		// own samples to swap between (#225).
 		const panel = screen.getByRole("region", { name: "BD instrument" });
-		expect(
-			within(panel).getByText("909 Bass Drum", { selector: "p" }),
-		).toBeInTheDocument();
+		expect(within(panel).getByText("909 Bass Drum")).toBeInTheDocument();
+		expect(within(panel).queryByRole("combobox")).not.toBeInTheDocument();
 	});
 
 	it("loads a sound dropped from the library onto the sampler, undoably", async () => {
@@ -290,9 +293,7 @@ describe("EditorView", () => {
 		fireEvent.drop(panel, { dataTransfer: transferCarrying(DROPPED_HAT) });
 
 		// The sampler names the dropped sound, and the project now carries it.
-		expect(
-			await within(panel).findByText(DROPPED_HAT.name, { selector: "p" }),
-		).toBeInTheDocument();
+		expect(await screen.findByText(DROPPED_HAT.name)).toBeInTheDocument();
 		const changed = transport.named("instrument_changed");
 		expect(changed).toHaveLength(1);
 		expect(changed[0].params.instrument_type).toBe("sampler");
@@ -300,9 +301,42 @@ describe("EditorView", () => {
 		// Carrying the asset and pointing the sampler at it is one transaction, so
 		// one undo takes the whole drop back.
 		fireEvent.click(await screen.findByRole("button", { name: /^Undo/ }));
-		expect(
-			await within(panel).findByText("909 Bass Drum", { selector: "p" }),
-		).toBeInTheDocument();
+		expect(await screen.findByText("909 Bass Drum")).toBeInTheDocument();
+	});
+
+	it("inserts from the keyboard onto the same track a drop would reach", async () => {
+		repository = inMemoryModule.createInMemoryProjectRepository();
+		const project = createSliceFixtureProject();
+		const created = await repository.createProject(project);
+		if (!created.ok) throw new Error("fixture project failed to create");
+
+		renderEditor(project.metadata.id, {
+			libraryClient: new LibraryClient(fixtureFetcher()),
+		});
+
+		// The project's own pack is a fixture pack with no delivered manifest, so
+		// reach a real sound the way a user does with an empty shelf: the pack
+		// browser.
+		fireEvent.click(
+			await screen.findByRole("button", { name: "Browse packs" }),
+		);
+		const dialog = await screen.findByRole("dialog");
+		fireEvent.click(
+			await within(dialog).findByRole("button", {
+				name: /Core Electronic Drums/,
+			}),
+		);
+		const insert = (
+			await within(dialog).findAllByRole("button", { name: /^Insert / })
+		)[0];
+		const name = (insert.getAttribute("aria-label") ?? "").replace(
+			"Insert ",
+			"",
+		);
+		fireEvent.click(insert);
+
+		const panel = await screen.findByRole("region", { name: "BD instrument" });
+		expect(await within(panel).findByText(name)).toBeInTheDocument();
 	});
 
 	it("shows a track's instrument panel even before it has a clip (#228)", async () => {

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -26,8 +26,9 @@ import { SONG_TEMPO } from "../domain/parameters";
 import { TICKS_PER_QUARTER } from "../domain/time";
 import type { LibrarySample } from "../library/assetDrag";
 import type { PreviewEngine } from "../library/audition";
-import { loadSampleCommands } from "../library/insertion";
+import { loadSampleCommands, toLibrarySample } from "../library/insertion";
 import LibraryBrowser from "../library/LibraryBrowser";
+import type { LibraryClient } from "../library/libraryClient";
 import { ToneAuditionEngine } from "../library/toneAuditionEngine";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
 import { getProjectRepository } from "../projectRepositoryClient";
@@ -61,6 +62,8 @@ export interface EditorViewProps {
 	 * per-mount lifecycle can be exercised without Web Audio.
 	 */
 	readonly createAuditionEngine?: () => PreviewEngine;
+	/** Injected in tests; the browser fetches the delivered manifests otherwise. */
+	readonly libraryClient?: LibraryClient;
 	/** Injected in tests; the shared catalog-backed instance otherwise. */
 	readonly analytics?: Analytics;
 }
@@ -249,14 +252,12 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 	}
 
 	const sampleName = createMemo(() => model.sampleName(project(), track()));
-	const replacementOptions = createMemo(() =>
-		model.replacementOptions(project()),
-	);
 
 	/**
-	 * Loads a library sound onto the edited track's sampler, from a drop on its
-	 * instrument panel (#225). The browser's keyboard-reachable "Insert" joins
-	 * this same path in the next PR in the stack.
+	 * Loads a library sound onto the edited track's sampler — the one path both
+	 * the drag onto the instrument panel and the browser's "Insert" button take,
+	 * so the pointer gesture and its keyboard equivalent produce the same
+	 * transaction (PRD 9.3) and log the same event once (#225).
 	 *
 	 * `loadSampleCommands` carries the asset and points the sampler at it in one
 	 * transaction, so this is one revision and one undo. It is refused — leaving
@@ -344,7 +345,18 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 									 */}
 									<aside class="library-panel" aria-label="Library">
 										<LibraryBrowser
+											client={props.libraryClient}
 											previewEngine={createAuditionEngine()}
+											analytics={props.analytics}
+											/*
+											 * The keyboard-reachable half of the drag (PRD 9.3):
+											 * "Insert" loads the sound onto the track being
+											 * edited, through the same path a drop takes.
+											 */
+											onInsert={(asset) => {
+												const sample = toLibrarySample(asset);
+												if (sample) loadLibrarySample(sample);
+											}}
 											addedPackIds={addedPackIds()}
 											onAddPack={(pack) =>
 												setSessionPackIds((previous) =>
@@ -434,7 +446,6 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
 													registerPianoRollActions={setPianoRollActions}
 													instrumentPanelTrackId={instrumentPanelTrackId()}
 													sampleName={sampleName()}
-													replacementOptions={replacementOptions()}
 													loadSample={loadLibrarySample}
 													auditionInstrument={auditionInstrument}
 												/>

--- a/src/editor/InstrumentPanel.tsx
+++ b/src/editor/InstrumentPanel.tsx
@@ -2,7 +2,7 @@ import { Match, Switch } from "solid-js";
 import type { RawCommandInput, TransactionResult } from "../commands";
 import type { Instrument } from "../domain/entities";
 import type { TrackId } from "../domain/ids";
-import SamplerPanel, { type SampleChoice } from "../instrument/SamplerPanel";
+import SamplerPanel from "../instrument/SamplerPanel";
 import SynthPanel from "../instrument/SynthPanel";
 
 export interface InstrumentPanelProps {
@@ -10,8 +10,6 @@ export interface InstrumentPanelProps {
 	readonly instrument: Instrument | null;
 	/** Display name of the currently loaded sample, or null when empty. */
 	readonly sampleName: string | null;
-	/** Samples the sampler panel can swap to; retired in the next PR. */
-	readonly replacementOptions: readonly SampleChoice[];
 	dispatch(
 		commands: RawCommandInput | readonly RawCommandInput[],
 	): TransactionResult | undefined;
@@ -42,7 +40,6 @@ export default function InstrumentPanel(props: InstrumentPanelProps) {
 						trackId={props.trackId}
 						instrument={sampler()}
 						sampleName={props.sampleName}
-						replacementOptions={props.replacementOptions}
 						dispatch={props.dispatch}
 						audition={props.audition}
 					/>

--- a/src/editor/TrackEditor.tsx
+++ b/src/editor/TrackEditor.tsx
@@ -8,7 +8,6 @@ import type {
 import type { Clip, Instrument, Project } from "../domain/entities";
 import type { EventId, TrackId } from "../domain/ids";
 import InstrumentKindPicker from "../instrument/InstrumentKindPicker";
-import type { SampleChoice } from "../instrument/SamplerPanel";
 import type { LibrarySample } from "../library/assetDrag";
 import { MASK_CONTENT } from "../monitoring/replayPrivacy";
 import InstrumentArea from "./InstrumentArea";
@@ -38,7 +37,6 @@ export interface TrackEditorProps {
 	/** The edited track, when there is one; null while no project is open. */
 	readonly instrumentPanelTrackId: TrackId | null;
 	readonly sampleName: string | null;
-	readonly replacementOptions: readonly SampleChoice[];
 	/** Loads a sound dropped from the library onto this track's sampler (#225). */
 	readonly loadSample: (sample: LibrarySample) => void;
 	readonly auditionInstrument: () => void;
@@ -159,7 +157,6 @@ export default function TrackEditor(props: TrackEditorProps) {
 							trackId={trackId()}
 							instrument={props.instrument}
 							sampleName={props.sampleName}
-							replacementOptions={props.replacementOptions}
 							dispatch={props.dispatch}
 							audition={props.auditionInstrument}
 						/>

--- a/src/editor/editorViewModel.test.ts
+++ b/src/editor/editorViewModel.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Project } from "../domain/entities";
 import {
-	createDenseStepFixtureProject,
 	createDrumMachineFixtureProject,
 	createPianoRollFixtureProject,
 	createSliceFixtureProject,
@@ -19,7 +18,6 @@ import {
 	loopClips,
 	packDependencyLabel,
 	playheadLabel,
-	replacementOptions,
 	sampleAssets,
 	sampleName,
 	samplerTrackId,
@@ -239,7 +237,7 @@ describe("sampleName", () => {
 });
 
 describe("samplerTrackId", () => {
-	it("names the track a dropped sound loads onto", () => {
+	it("names the track a dropped or inserted sound loads onto", () => {
 		const project = createSliceFixtureProject();
 		expect(samplerTrackId(editedTrack(project, null))).toBe(
 			project.song.tracks[0].id,
@@ -258,31 +256,6 @@ describe("samplerTrackId", () => {
 		expect(samplerTrackId(editedTrack(drums, null))).toBeNull();
 		expect(samplerTrackId(editedTrack(synth, null))).toBeNull();
 		expect(samplerTrackId(null)).toBeNull();
-	});
-});
-
-describe("replacementOptions", () => {
-	it("offers every `sample`-kind asset as an id/name choice", () => {
-		const project = createDenseStepFixtureProject();
-		expect(replacementOptions(project).map((choice) => choice.name)).toEqual([
-			"909 Bass Drum",
-			"909 Snare",
-			"909 Closed Hat",
-		]);
-		expect(replacementOptions(project)[0].assetId).toBe(
-			project.song.assets[0].id,
-		);
-	});
-
-	it("excludes loop assets, matching sampleAssets", () => {
-		const project = createDrumMachineFixtureProject();
-		expect(replacementOptions(project)).toHaveLength(
-			sampleAssets(project).length,
-		);
-	});
-
-	it("is empty with no project open", () => {
-		expect(replacementOptions(null)).toEqual([]);
 	});
 });
 

--- a/src/editor/editorViewModel.ts
+++ b/src/editor/editorViewModel.ts
@@ -7,7 +7,6 @@ import type {
 } from "../domain/entities";
 import type { TrackId } from "../domain/ids";
 import { formatBarsBeatsSixteenths } from "../domain/time";
-import type { SampleChoice } from "../instrument/SamplerPanel";
 import type { SelectionState } from "../selection";
 
 /**
@@ -156,20 +155,6 @@ export function sampleName(
 		project?.song.assets.find((asset) => asset.id === current.assetId)?.name ??
 		null
 	);
-}
-
-/**
- * Samples the sampler panel can swap to: every `sample`-kind asset the
- * project already carries. A richer, genre-filtered browser lands with
- * LOOP-013; here it is a straight list of the project's own samples.
- */
-export function replacementOptions(
-	project: Project | null,
-): readonly SampleChoice[] {
-	return sampleAssets(project).map((asset) => ({
-		assetId: asset.id,
-		name: asset.name,
-	}));
 }
 
 /** The project's first pack dependency, labelled for display. */

--- a/src/instrument/InstrumentPanel.css
+++ b/src/instrument/InstrumentPanel.css
@@ -54,29 +54,25 @@
 	gap: 12px;
 }
 
+.sampler-load-hint {
+	margin: 0;
+	font-size: var(--font-size-tiny);
+	color: var(--color-foreground);
+}
+
 /* A sound is being dragged over the area and this track's sampler will take it. */
 .instrument-panel-drop-target {
 	outline: 2px solid var(--color-accent, #20c8e8);
 	outline-offset: -2px;
 }
 
-.sampler-load-select,
 .instrument-panel-audition {
 	height: 30px;
 	padding: 0 12px;
 	background-color: var(--color-background-tertiary);
-	color: var(--color-text);
 	border: none;
 	font-size: var(--font-size-small);
 	cursor: pointer;
-}
-
-.sampler-load-select:hover,
-.instrument-panel-audition:hover {
-	background-color: var(--color-background-hover);
-}
-
-.instrument-panel-audition {
 	align-self: flex-start;
 	color: var(--color-accent, #20c8e8);
 }

--- a/src/instrument/SamplerPanel.test.tsx
+++ b/src/instrument/SamplerPanel.test.tsx
@@ -7,18 +7,12 @@ import type { RawCommandInput, TransactionResult } from "../commands";
 import type { Instrument } from "../domain/entities";
 import type { AssetId, TrackId } from "../domain/ids";
 import { memoryStorage } from "../testing/storage";
-import SamplerPanel, { type SampleChoice } from "./SamplerPanel";
+import SamplerPanel from "./SamplerPanel";
 
 afterEach(() => cleanup());
 
 const TRACK_ID = "trk_sampler" as TrackId;
 const ASSET_A = "ast_a" as AssetId;
-const ASSET_B = "ast_b" as AssetId;
-
-const OPTIONS: SampleChoice[] = [
-	{ assetId: ASSET_A, name: "Clap" },
-	{ assetId: ASSET_B, name: "Snare" },
-];
 
 function renderPanel(
 	instrument: Extract<Instrument, { kind: "sampler" }> = {
@@ -26,6 +20,7 @@ function renderPanel(
 		assetId: ASSET_A,
 		parameters: {},
 	},
+	sampleName: string | null = "Clap",
 ) {
 	const dispatch = vi.fn<
 		(
@@ -45,8 +40,7 @@ function renderPanel(
 		<SamplerPanel
 			trackId={TRACK_ID}
 			instrument={instrument}
-			sampleName="Clap"
-			replacementOptions={OPTIONS}
+			sampleName={sampleName}
 			dispatch={dispatch}
 			audition={audition}
 			analytics={analytics}
@@ -65,6 +59,14 @@ describe("SamplerPanel", () => {
 		expect(screen.getByLabelText("Attack")).toBeInTheDocument();
 	});
 
+	it("says so when it is holding nothing, and how to fill it", () => {
+		renderPanel({ kind: "sampler", assetId: null, parameters: {} }, null);
+		expect(screen.getByText("No sample loaded")).toBeInTheDocument();
+		expect(
+			screen.getByText("Drag a sound here from the library"),
+		).toBeInTheDocument();
+	});
+
 	it("dispatches an instrument parameter.set once when a slider commits", () => {
 		const { dispatch, transport } = renderPanel();
 		const pitch = screen.getByLabelText("Pitch") as HTMLInputElement;
@@ -80,59 +82,6 @@ describe("SamplerPanel", () => {
 		expect(command.payload.target.scope).toBe("instrument");
 		expect(command.payload.target.parameterId).toBe("pitch");
 		// No instrument_changed for a plain parameter edit.
-		expect(transport.named("instrument_changed")).toHaveLength(0);
-	});
-
-	it("replacing the sample dispatches instrument.setSample and emits instrument_changed once", () => {
-		const { dispatch, transport } = renderPanel();
-		const select = screen.getByRole("combobox") as HTMLSelectElement;
-		fireEvent.change(select, { target: { value: ASSET_B } });
-
-		const command = dispatch.mock.calls.at(-1)?.[0] as {
-			type: string;
-			payload: { assetId: string };
-		};
-		expect(command.type).toBe("instrument.setSample");
-		expect(command.payload.assetId).toBe(ASSET_B);
-
-		const changed = transport.named("instrument_changed");
-		expect(changed).toHaveLength(1);
-		expect(changed[0].params.instrument_type).toBe("sampler");
-		expect(
-			transport
-				.named("feature_first_use")
-				.filter((e) => e.params.feature === "sampler"),
-		).toHaveLength(1);
-	});
-
-	it("does not emit instrument_changed when the sample swap is rejected", () => {
-		const dispatch = vi.fn<
-			(
-				commands: RawCommandInput | readonly RawCommandInput[],
-			) => TransactionResult | undefined
-		>(() => ({ ok: false, issues: [] }) as unknown as TransactionResult);
-		const transport = createRecordingTransport();
-		const consent = new ConsentStore(memoryStorage());
-		const analytics = new Analytics({
-			transport,
-			consent,
-			storage: memoryStorage(),
-		});
-		analytics.setAccountType("anonymous");
-		render(() => (
-			<SamplerPanel
-				trackId={TRACK_ID}
-				instrument={{ kind: "sampler", assetId: ASSET_A, parameters: {} }}
-				sampleName="Clap"
-				replacementOptions={OPTIONS}
-				dispatch={dispatch}
-				audition={vi.fn()}
-				analytics={analytics}
-			/>
-		));
-		fireEvent.change(screen.getByRole("combobox"), {
-			target: { value: ASSET_B },
-		});
 		expect(transport.named("instrument_changed")).toHaveLength(0);
 	});
 

--- a/src/instrument/SamplerPanel.tsx
+++ b/src/instrument/SamplerPanel.tsx
@@ -1,12 +1,12 @@
-import { For, type JSX, Show } from "solid-js";
+import { For, type JSX } from "solid-js";
 import {
 	type Analytics,
 	analytics as defaultAnalytics,
 } from "../analytics/analytics";
 import type { RawCommandInput, TransactionResult } from "../commands";
-import { setParameter, setSample } from "../commands";
+import { setParameter } from "../commands";
 import type { Instrument } from "../domain/entities";
-import type { AssetId, TrackId } from "../domain/ids";
+import type { TrackId } from "../domain/ids";
 import {
 	bareParameterId,
 	readInstrumentParameter,
@@ -23,19 +23,11 @@ import FillSlider from "./FillSlider";
 import { formatInstrumentValue } from "./formatValue";
 import "./InstrumentPanel.css";
 
-/** A sample the user can load into the sampler (from the project's assets). */
-export interface SampleChoice {
-	readonly assetId: AssetId;
-	readonly name: string;
-}
-
 export interface SamplerPanelProps {
 	readonly trackId: TrackId;
 	readonly instrument: Extract<Instrument, { kind: "sampler" }>;
 	/** Display name of the currently loaded sample, or null when empty. */
 	readonly sampleName: string | null;
-	/** Samples the user can swap to; retired for the drop in the next PR. */
-	readonly replacementOptions: readonly SampleChoice[];
 	dispatch(
 		commands: RawCommandInput | readonly RawCommandInput[],
 	): TransactionResult | undefined;
@@ -57,21 +49,20 @@ const ENVELOPE_SLIDERS = [
 ];
 
 /**
- * The reusable one-shot sampler panel (PRD INS-01, mock `05b-sampler`): sample
- * selection + audition, and fill-sliders for pitch, sample start/end, and the
+ * The reusable one-shot sampler panel (PRD INS-01, mock `05b-sampler`): the
+ * loaded sample, audition, and fill-sliders for pitch, sample start/end, and the
  * amp envelope (ADSR).
  *
- * A sound is loaded by dragging it here from the library (#225), but this panel
- * owns none of that: the drop target is the surrounding `InstrumentArea`, which
- * is named for its track so a drop lands on a particular one and which catches a
- * drop anywhere in the track's instrument controls. This panel stays a panel.
+ * A sound is chosen by dragging it here from the library (#225), which is why
+ * the panel names the loaded sample rather than offering a list to swap
+ * between: that list could only ever offer sounds the project already carried,
+ * which for a new project is the one it started with. The drop itself belongs
+ * to the surrounding `InstrumentArea`, named for its track so a drop lands on a
+ * particular one; this panel stays a panel.
  *
  * Parameter edits dispatch a validated `parameter.set` in the `instrument`
- * scope; a sample swap dispatches `instrument.setSample`, whose inverse restores
- * the previous asset so replacement is undoable and preserves the rest of the
- * sampler's settings. Replacing the sample emits `instrument_changed`
- * (`sampler`) and the `sampler` `feature_first_use` key. A continuous slider
- * commits once per gesture, so a drag is one command and emits nothing per tick.
+ * scope; a continuous slider commits once per gesture, so a drag is one command
+ * and emits nothing per tick.
  */
 export default function SamplerPanel(props: SamplerPanelProps): JSX.Element {
 	const analytics = () => props.analytics ?? defaultAnalytics;
@@ -86,14 +77,6 @@ export default function SamplerPanel(props: SamplerPanelProps): JSX.Element {
 		analytics().logFeatureFirstUse("sampler");
 	}
 
-	function replaceSample(assetId: AssetId): void {
-		if (assetId === props.instrument.assetId) return;
-		const result = props.dispatch(setSample(props.trackId, assetId));
-		if (!result?.ok) return;
-		analytics().log("instrument_changed", { instrument_type: "sampler" });
-		analytics().logFeatureFirstUse("sampler");
-	}
-
 	return (
 		<section class="instrument-panel sampler-panel" aria-label="Sampler">
 			<div class="instrument-panel-groups">
@@ -105,28 +88,7 @@ export default function SamplerPanel(props: SamplerPanelProps): JSX.Element {
 					<p class={`sampler-sample-name ${MASK_CONTENT}`}>
 						{props.sampleName ?? "No sample loaded"}
 					</p>
-					<Show when={props.replacementOptions.length > 0}>
-						<label class="sampler-load">
-							<span class="visually-hidden">Load sample</span>
-							<select
-								class="sampler-load-select"
-								value={props.instrument.assetId ?? ""}
-								onChange={(event) => {
-									const value = event.currentTarget.value;
-									if (value) replaceSample(value as AssetId);
-								}}
-							>
-								<option value="" disabled>
-									Load…
-								</option>
-								<For each={props.replacementOptions}>
-									{(choice) => (
-										<option value={choice.assetId}>{choice.name}</option>
-									)}
-								</For>
-							</select>
-						</label>
-					</Show>
+					<p class="sampler-load-hint">Drag a sound here from the library</p>
 				</div>
 				<div class="instrument-panel-group instrument-panel-sliders">
 					<h3 class="instrument-panel-heading">Playback</h3>


### PR DESCRIPTION
## What & why

5 of 5 for #225, builds on #245. This one completes the task.

The swap list could only ever offer sounds the project already carried — for a
new project, the single one it started with — which is exactly why the issue
calls the library "200 sounds a user can hear and cannot use". Now that a sound
can be dragged onto the sampler, the panel says what it is holding and how to
change it, and the list goes. `replacementOptions` goes with it: it was the last
consumer of the project's own sample list as a menu.

Dragging is a pointer gesture, so it cannot be the only way in (PRD 9.3). The
library row's "Insert" button was already built and simply never handed a
handler; wiring it to the same `EditorView.loadLibrarySample` the drop uses means
the keyboard path produces the same transaction, the same undo, and the same
event, rather than a second implementation that can drift.

Closes #225

## Core flows

Untouched. #225 links no core flow of its own. CF-002 (#61) leans on this
affordance in its `addSamplerTrack` helper and stays `test.fixme`, because its
other dependency — creating a sampler track, #223 — has not landed. Nothing in
`docs/core-flows.md` or in any flow spec changed in this stack; `bun run
verify:core-flows` passes and reports CF-002 and CF-003 still parked.

(One **non-flow** spec changed, in #245: `e2e/instrument.spec.ts`'s picker
locator had to become `exact`. Explained there.)

Two things CF-002 will need, worth flagging on #61 rather than working around
here:

- Its selectors for this half now exist and match what shipped: the row is a
  draggable `listitem`; the drop target is a `region` whose accessible name is
  the track's name followed by the word `instrument` (so `"Hats instrument"`);
  and it contains the loaded sound's name.
- **The delivered library is not present in a browser E2E run.** `public/samples`
  is gitignored and produced by `bun run library:build`, which CI does not run, so
  the library panel in `bun run test:browser` shows its empty/error state. That
  predates this stack, but CF-002 cannot pass until it is addressed.

## Walkthrough

Captured in Chromium against a locally built delivered library
(`bun run library:build`), and published with `bun run walkthrough:publish`.

**Not** captured from a core-flow spec, because the flow that covers this
(CF-002) is blocked on #223 and cannot run. It was captured by driving the same
steps from the same entrypoint the flow uses, so it shows real shipped behaviour;
the flow-derived walkthrough arrives with #61.

### A producer loads a library sound onto a sampler

**1. New project, on the starter kick**

![issue-225 step 1](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/225/issue-225/01-new-project-on-the-starter-kick.png)

**2. Search for a clap**

![issue-225 step 2](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/225/issue-225/02-search-for-a-clap.png)

**3. Drop it on the sampler**

![issue-225 step 3](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/225/issue-225/03-drop-it-on-the-sampler.png)

**4. One undo takes it back**

![issue-225 step 4](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/225/issue-225/04-one-undo-takes-it-back.png)

**5. Insert from the keyboard**

![issue-225 step 5](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/225/issue-225/05-insert-from-the-keyboard.png)

These were captured before the rebase onto `main` at `373e7a9`. The drop target's
accessible name is unchanged by that rebase, and the flow they show still passes
— but they do not show the kind picker (#224) that now sits above the panel, so
treat them as the interaction, not the current pixel layout.

## Evidence

Re-run after the rebase:

```
bun run typecheck              → clean
bun run check                  → Checked 511 files. No fixes applied.
bun run test                   → Test Files 174 passed (174) · Tests 2336 passed (2336)
bun run verify:core-flows      → 3 flow(s), each with exactly one spec (CF-002/CF-003 parked)
bun run test:browser:chromium  → 20 passed, 2 skipped
```

Chromium-only for the browser suite — this environment cannot reach
`cdn.playwright.dev` to install Firefox or WebKit, so that run is **not** the PRD
section 10 gating evidence; CI's full matrix on push is.

Diff: 290 changed lines.

## Acceptance criteria met

#225 has no acceptance checkboxes; against its "Expected" and "Notes":

- ✅ Dragging an asset from the library onto a sampler instrument loads it,
  dispatching `instrument.setSample` as one undoable transaction and emitting
  `instrument_changed`. (`asset.add` rides in the same transaction, since a
  browsed sound is not yet one of the project's assets.)
- ✅ The swap list is dropped in favour of a label showing the loaded sample's
  name, as the product owner asked.
- ✅ Drag-and-drop has a keyboard-reachable equivalent: the browser's existing
  `onInsert`, loading onto the track being edited, through the same code path.

Not in scope, and deliberately left: loading onto a **drum pad**
(`drum.setPadAsset` has the same gap, but the issue names the sampler). Choosing
*which* track a keyboard insert reaches is no longer a gap — after rebasing onto
#228's selected-track work, both the drop and the insert follow the selected
track.

## Stack

1. #242 — `asset.add` / `asset.remove`
2. #243 — the library → domain asset mapping
3. #244 — the drag source
4. #245 — the instrument area takes the drop
5. **this PR** — retire the swap list, insert from the keyboard (`Closes #225`)
