### PR TITLE
Declare the instrument kinds once, for both surfaces

### DIFF
--- a/e2e/instrument.spec.ts
+++ b/e2e/instrument.spec.ts
@@ -38,13 +38,12 @@ test("changes a track's instrument from its own panel", async ({ page }) => {
 	).toBeEnabled();
 	await step("Pick Synth: the synth panel replaces the sampler's");
 
-	// ...and on to the drum machine, which arrives with pads to load.
+	// ...and on to the drum machine, which arrives with the same pads a track
+	// created as a drum machine gets (BD/SD/HH/CP, from the shared kind table).
 	await picker.getByText("Drum machine", { exact: true }).click();
-	await expect(
-		page.getByRole("button", { name: "Audition Kick" }),
-	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Audition BD" })).toBeVisible();
 	await show(/^Drum machine/);
-	await step("Pick Drum machine: it arrives with pads ready for sounds");
+	await step("Pick Drum machine: it arrives with pads to load");
 
 	// The route back off a drum machine — the direction that had no UI at all,
 	// since the drum machine's own panel is mounted elsewhere.
@@ -53,9 +52,7 @@ test("changes a track's instrument from its own panel", async ({ page }) => {
 
 	// Each switch is one history entry, so undo walks back a step at a time.
 	await page.getByRole("button", { name: /^Undo/ }).click();
-	await expect(
-		page.getByRole("button", { name: "Audition Kick" }),
-	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Audition BD" })).toBeVisible();
 	await show(/^Drum machine/);
 	await step("Undo returns the drum machine, one switch at a time");
 });

--- a/src/editor/trackCreation.ts
+++ b/src/editor/trackCreation.ts
@@ -1,77 +1,55 @@
-import type { InstrumentTypeKey } from "../analytics/catalog";
-import type { Clip, Instrument, Placement, Track } from "../domain/entities";
+import type { Clip, Placement, Track } from "../domain/entities";
 import {
-	createDrumMachineInstrument,
-	createDrumPad,
 	createNoteClip,
 	createPlacement,
-	createSamplerInstrument,
-	createSynthInstrument,
 	createTrack,
 	type DomainFactoryContext,
 } from "../domain/factories";
 import { TICKS_PER_BAR } from "../domain/time";
+import {
+	createInstrumentOfKind,
+	INSTRUMENT_KINDS,
+	type InstrumentKind,
+	type InstrumentKindSpec,
+} from "../instrument/instrumentKinds";
 
 /**
  * What creating a track produces, and the kinds it can be created as (#223).
  *
  * Track creation used to mint a synth and nothing else, so a sampler or a drum
- * machine could only ever arrive with the starter project or a fixture. The
- * kinds live in one table here — framework-free and testable without rendering
- * the mixer — so the affordance that offers them, the instrument each mints,
- * and the analytics value each reports cannot drift apart.
+ * machine could only ever arrive with the starter project or a fixture. Which
+ * kinds exist, what each is called, what instrument each mints, and what each
+ * reports to analytics are `src/instrument/instrumentKinds.ts`'s to say — the
+ * instrument panel's kind picker chooses from the same set, and the two had
+ * begun to disagree. What is track creation's alone stays here: the button's
+ * accessible name, and the clip and placement a new track opens with.
  *
  * Nothing here mutates a project: it builds the entities a `track.add` command
  * carries, so the mixer's dispatch stays the one mutation path (PRD 9.6).
  */
 
 /** The instrument kinds a new track can be created with. */
-export type NewTrackKind = "sampler" | "drumMachine" | "synth";
+export type NewTrackKind = InstrumentKind;
 
-export interface NewTrackKindSpec {
-	readonly kind: NewTrackKind;
-	/** The button's visible text. */
-	readonly label: string;
+export interface NewTrackKindSpec extends InstrumentKindSpec {
 	/**
-	 * The button's accessible name. It contains {@link label} so the visible
-	 * text is a prefix of what a speech-input user has to say (WCAG 2.5.3).
+	 * The button's accessible name. It contains {@link InstrumentKindSpec.label}
+	 * so the visible text is a prefix of what a speech-input user has to say
+	 * (WCAG 2.5.3), which is why it is derived from the label rather than
+	 * written out beside it.
 	 */
 	readonly actionLabel: string;
-	/** `track_added`'s `instrument_type` for a track of this kind (PRD OPS-02). */
-	readonly analyticsType: InstrumentTypeKey;
 }
 
 /**
- * The kinds offered, in the order they are offered. Sampler leads because it is
- * what the starter project arrives with and what a loop is usually built from.
+ * The kinds offered, in the order they are offered — the shared order, so the
+ * mixer's buttons and the instrument panel's picker read the same way.
  */
-export const NEW_TRACK_KINDS: readonly NewTrackKindSpec[] = [
-	{
-		kind: "sampler",
-		label: "Sampler",
-		actionLabel: "Add sampler track",
-		analyticsType: "sampler",
-	},
-	{
-		kind: "drumMachine",
-		label: "Drum machine",
-		actionLabel: "Add drum machine track",
-		analyticsType: "drum_machine",
-	},
-	{
-		kind: "synth",
-		label: "Synth",
-		actionLabel: "Add synth track",
-		analyticsType: "synth",
-	},
-];
-
-/**
- * The lanes a new drum machine opens with: the four voices a beat is built
- * from. Each starts empty — a pad's sample is chosen in the drum panel, the
- * same way an existing kit's is (PRD INS-01).
- */
-const DEFAULT_PAD_NAMES = ["BD", "SD", "HH", "CP"] as const;
+export const NEW_TRACK_KINDS: readonly NewTrackKindSpec[] =
+	INSTRUMENT_KINDS.map((spec) => ({
+		...spec,
+		actionLabel: `Add ${spec.label.toLowerCase()} track`,
+	}));
 
 export interface NewTrack {
 	readonly track: Track;
@@ -106,7 +84,7 @@ export function createNewTrack(
 		name,
 		order: options.order,
 		type: "instrument",
-		instrument: createInstrument(context, options.kind),
+		instrument: createInstrumentOfKind(context, options.kind),
 	});
 	const clip = createNoteClip(context, {
 		trackId: track.id,
@@ -129,36 +107,12 @@ export function newTrackKindSpec(kind: NewTrackKind): NewTrackKindSpec {
 	return spec;
 }
 
-/** The `instrument_type` an existing track reports, or undefined if it has none. */
-export function instrumentTypeKey(
-	instrument: Instrument | null,
-): InstrumentTypeKey | undefined {
-	if (!instrument) return undefined;
-	return newTrackKindSpecFor(instrument.kind)?.analyticsType;
-}
-
-function newTrackKindSpecFor(kind: string): NewTrackKindSpec | undefined {
-	return NEW_TRACK_KINDS.find((candidate) => candidate.kind === kind);
-}
-
-function createInstrument(
-	context: DomainFactoryContext,
-	kind: NewTrackKind,
-): Instrument {
-	switch (kind) {
-		case "sampler":
-			// No sample yet: one is loaded from the library or the sampler panel.
-			return createSamplerInstrument();
-		case "drumMachine":
-			return createDrumMachineInstrument(
-				DEFAULT_PAD_NAMES.map((padName) =>
-					createDrumPad(context, { name: padName }),
-				),
-			);
-		case "synth":
-			return createSynthInstrument();
-	}
-}
+/**
+ * The `instrument_type` an existing track reports. Re-exported so a caller
+ * working in track terms need not reach past this module for it; the value set
+ * itself belongs to the shared kind table.
+ */
+export { instrumentTypeKey } from "../instrument/instrumentKinds";
 
 /**
  * `Sampler`, then `Sampler 2`, `Sampler 3`, ... Numbering by collision rather

--- a/src/instrument/InstrumentKindPicker.tsx
+++ b/src/instrument/InstrumentKindPicker.tsx
@@ -16,9 +16,9 @@ import "./InstrumentPanel.css";
 import {
 	countPadTriggeredHits,
 	createInstrumentOfKind,
-	INSTRUMENT_KIND_CHOICES,
+	INSTRUMENT_KINDS,
 	type InstrumentKind,
-	instrumentTypeKey,
+	instrumentKindSpec,
 	type PadTriggeredHits,
 	padTriggeredHits,
 } from "./instrumentKinds";
@@ -90,11 +90,11 @@ export default function InstrumentKindPicker(
 			...hits.map((hit) => removeNotes(hit.clipId, hit.eventIds)),
 			changeInstrument(
 				props.trackId,
-				createInstrumentOfKind(kind, factoryContext()),
+				createInstrumentOfKind(factoryContext(), kind),
 			),
 		]);
 		if (!result?.ok) return;
-		const type = instrumentTypeKey(kind);
+		const type = instrumentKindSpec(kind).analyticsType;
 		analytics().log("instrument_changed", { instrument_type: type });
 		analytics().logFeatureFirstUse(type);
 	}
@@ -106,9 +106,10 @@ export default function InstrumentKindPicker(
 		change(kind, strandedHits(kind));
 	}
 
-	const pendingLabel = () =>
-		INSTRUMENT_KIND_CHOICES.find((choice) => choice.kind === pendingKind())
-			?.label ?? "";
+	const pendingLabel = () => {
+		const kind = pendingKind();
+		return kind ? instrumentKindSpec(kind).label : "";
+	};
 	const pendingHitCount = () => {
 		const kind = pendingKind();
 		return kind ? countPadTriggeredHits(strandedHits(kind)) : 0;
@@ -121,9 +122,9 @@ export default function InstrumentKindPicker(
 				<OptionGroup
 					legend="Instrument type"
 					value={props.instrument?.kind ?? null}
-					options={INSTRUMENT_KIND_CHOICES.map((choice) => ({
-						value: choice.kind,
-						label: choice.label,
+					options={INSTRUMENT_KINDS.map((spec) => ({
+						value: spec.kind,
+						label: spec.label,
 					}))}
 					onSelect={select}
 				/>

--- a/src/instrument/instrumentKinds.test.ts
+++ b/src/instrument/instrumentKinds.test.ts
@@ -8,12 +8,13 @@ import {
 	createSliceFixtureProject,
 } from "../domain/fixtures";
 import { createSeededIdFactory } from "../domain/ids";
+import { createNewTrack, NEW_TRACK_KINDS } from "../editor/trackCreation";
 import { createManualClock } from "../shared/clock";
 import {
 	countPadTriggeredHits,
 	createInstrumentOfKind,
-	DEFAULT_DRUM_PAD_NAMES,
-	INSTRUMENT_KIND_CHOICES,
+	INSTRUMENT_KINDS,
+	instrumentKindSpec,
 	instrumentTypeKey,
 	padTriggeredHits,
 } from "./instrumentKinds";
@@ -21,39 +22,66 @@ import {
 const context = () =>
 	createFactoryContext({ ids: createSeededIdFactory(224), now: 0 });
 
-describe("instrumentTypeKey", () => {
-	it("maps every offered kind to its OPS-02 analytics key", () => {
-		expect(INSTRUMENT_KIND_CHOICES.map((choice) => choice.kind)).toEqual([
+describe("the shared instrument-kind table", () => {
+	it("covers every kind the domain has, each with its OPS-02 value", () => {
+		expect(INSTRUMENT_KINDS.map((spec) => spec.kind)).toEqual([
 			"sampler",
-			"synth",
 			"drumMachine",
+			"synth",
 		]);
-		expect(instrumentTypeKey("sampler")).toBe("sampler");
-		expect(instrumentTypeKey("synth")).toBe("synth");
-		expect(instrumentTypeKey("drumMachine")).toBe("drum_machine");
+		expect(instrumentKindSpec("sampler").analyticsType).toBe("sampler");
+		expect(instrumentKindSpec("synth").analyticsType).toBe("synth");
+		expect(instrumentKindSpec("drumMachine").analyticsType).toBe(
+			"drum_machine",
+		);
+	});
+
+	it("reads an existing instrument's analytics value from the same table", () => {
+		for (const spec of INSTRUMENT_KINDS) {
+			const instrument = createInstrumentOfKind(context(), spec.kind);
+			expect(instrumentTypeKey(instrument), spec.kind).toBe(spec.analyticsType);
+		}
+		expect(instrumentTypeKey(null)).toBeUndefined();
+	});
+
+	/**
+	 * The regression this table exists to prevent: creating a track and
+	 * switching an existing one used to build their instruments from separate
+	 * copies of these facts, so a created drum machine and a switched-to drum
+	 * machine opened with different pads.
+	 */
+	it("gives a created track and a switched track the same instrument", () => {
+		for (const spec of NEW_TRACK_KINDS) {
+			const created = createNewTrack(context(), {
+				kind: spec.kind,
+				order: 0,
+				existingNames: [],
+			}).track.instrument;
+			const switched = createInstrumentOfKind(context(), spec.kind);
+			expect(created, spec.kind).toEqual(switched);
+		}
 	});
 });
 
 describe("createInstrumentOfKind", () => {
 	it("builds an empty sampler and a default synth", () => {
-		expect(createInstrumentOfKind("sampler", context())).toEqual({
+		expect(createInstrumentOfKind(context(), "sampler")).toEqual({
 			kind: "sampler",
 			assetId: null,
 			parameters: {},
 		});
-		expect(createInstrumentOfKind("synth", context())).toEqual({
+		expect(createInstrumentOfKind(context(), "synth")).toEqual({
 			kind: "synth",
 			parameters: {},
 		});
 	});
 
 	it("builds a drum machine with named, sample-less, uniquely identified pads", () => {
-		const instrument = createInstrumentOfKind("drumMachine", context());
+		const instrument = createInstrumentOfKind(context(), "drumMachine");
 		if (instrument.kind !== "drumMachine")
 			throw new Error("expected a machine");
-		expect(instrument.pads.map((pad) => pad.name)).toEqual([
-			...DEFAULT_DRUM_PAD_NAMES,
-		]);
+		expect(instrument.pads.length).toBeGreaterThan(0);
+		expect(instrument.pads.every((pad) => pad.name.length > 0)).toBe(true);
 		expect(instrument.pads.every((pad) => pad.assetId === null)).toBe(true);
 		expect(new Set(instrument.pads.map((pad) => pad.id)).size).toBe(
 			instrument.pads.length,
@@ -110,7 +138,7 @@ describe("changing a track's instrument through the command kernel", () => {
 		const result = execute(project, [
 			changeInstrument(
 				trackId,
-				createInstrumentOfKind("drumMachine", context()),
+				createInstrumentOfKind(context(), "drumMachine"),
 			),
 		]);
 		expect(result.ok).toBe(true);
@@ -119,7 +147,7 @@ describe("changing a track's instrument through the command kernel", () => {
 	it("rejects leaving a drum machine until its hits go with it", () => {
 		const project = createDrumMachineFixtureProject();
 		const trackId = project.song.tracks[0].id;
-		const synth = () => createInstrumentOfKind("synth", context());
+		const synth = () => createInstrumentOfKind(context(), "synth");
 
 		expect(execute(project, [changeInstrument(trackId, synth())]).ok).toBe(
 			false,

--- a/src/instrument/instrumentKinds.ts
+++ b/src/instrument/instrumentKinds.ts
@@ -1,3 +1,4 @@
+import type { InstrumentTypeKey } from "../analytics/catalog";
 import type { Instrument, Project } from "../domain/entities";
 import {
 	createDrumMachineInstrument,
@@ -9,76 +10,85 @@ import {
 import type { ClipId, EventId, TrackId } from "../domain/ids";
 
 /**
- * The pure half of changing a track's instrument (#224).
+ * The instrument kinds the app offers, and what moving a track between them
+ * costs (#224, #223).
  *
- * A track's instrument is replaced by the existing `instrument.change` command,
- * which takes the whole replacement instrument in its payload — so the choice
- * of *what* to install, and what a switch costs the track's clips, is decided
- * here rather than in the command layer. Both answers are plain functions of
- * the project, so `InstrumentKindPicker` stays a thin dispatch surface.
+ * Two surfaces choose an instrument kind — creating a track (`trackCreation`)
+ * and changing an existing track's (`InstrumentKindPicker`) — and they were
+ * written in parallel, each with its own copy of these facts. That divergence
+ * was visible: a track *created* as a drum machine opened with different pads
+ * from one *switched* to a drum machine. So the kind, its label, the
+ * `instrument_type` it reports, and the instrument it mints are declared once,
+ * here, and both surfaces read them.
+ *
+ * Nothing here mutates a project. `createInstrumentOfKind` builds the
+ * instrument an `instrument.change` (or `track.add`) payload carries, so the
+ * command layer stays the one mutation path (PRD section 9.6).
  */
 
 export type InstrumentKind = Instrument["kind"];
 
-export interface InstrumentKindChoice {
+export interface InstrumentKindSpec {
 	readonly kind: InstrumentKind;
+	/** The control's visible text. */
 	readonly label: string;
+	/** This kind's `instrument_type` in the OPS-02 catalog. */
+	readonly analyticsType: InstrumentTypeKey;
 }
 
-/** The instrument kinds a track can be switched to, in panel order. */
-export const INSTRUMENT_KIND_CHOICES: readonly InstrumentKindChoice[] = [
-	{ kind: "sampler", label: "Sampler" },
-	{ kind: "synth", label: "Synth" },
-	{ kind: "drumMachine", label: "Drum machine" },
-];
-
 /**
- * The pads a track gets when it becomes a drum machine. A machine with no pads
- * has nothing to load a sample into and no lane to program — and no UI adds a
- * pad yet (`drum.addPad` exists, `DrumMachinePanel` does not expose it) — so a
- * switch that produced an empty machine would be a dead end. Four named,
- * sample-less pads give the user somewhere to drop sounds immediately.
+ * Every kind, in the order both surfaces offer them. Sampler leads because it
+ * is what the starter project arrives with and what a loop is usually built
+ * from.
  */
-export const DEFAULT_DRUM_PAD_NAMES: readonly string[] = [
-	"Kick",
-	"Snare",
-	"Hat",
-	"Clap",
+export const INSTRUMENT_KINDS: readonly InstrumentKindSpec[] = [
+	{ kind: "sampler", label: "Sampler", analyticsType: "sampler" },
+	{ kind: "drumMachine", label: "Drum machine", analyticsType: "drum_machine" },
+	{ kind: "synth", label: "Synth", analyticsType: "synth" },
 ];
 
-/** The OPS-02 `instrument_type` (and `feature_first_use`) key for a kind. */
+export function instrumentKindSpec(kind: InstrumentKind): InstrumentKindSpec {
+	const spec = INSTRUMENT_KINDS.find((candidate) => candidate.kind === kind);
+	if (!spec) throw new TypeError(`Unknown instrument kind "${kind}"`);
+	return spec;
+}
+
+/** The `instrument_type` an existing track reports, or undefined if it has none. */
 export function instrumentTypeKey(
-	kind: InstrumentKind,
-): "sampler" | "synth" | "drum_machine" {
-	switch (kind) {
-		case "sampler":
-			return "sampler";
-		case "synth":
-			return "synth";
-		case "drumMachine":
-			return "drum_machine";
-	}
+	instrument: Instrument | null,
+): InstrumentTypeKey | undefined {
+	if (!instrument) return undefined;
+	return INSTRUMENT_KINDS.find((spec) => spec.kind === instrument.kind)
+		?.analyticsType;
 }
 
 /**
- * A fresh instrument of `kind`, at its defaults: an empty sampler, a synth, or
- * a drum machine with {@link DEFAULT_DRUM_PAD_NAMES}. Every ID it needs is
- * minted here, so the command payload carries them explicitly and a replay,
- * redo, or assistant preview reproduces the same project.
+ * The lanes a new drum machine opens with: the four voices a beat is built
+ * from. Each starts empty — a pad's sample is chosen in the drum panel, the
+ * same way an existing kit's is (PRD INS-01). A machine with no pads at all
+ * would be a dead end, since no surface exposes `drum.addPad` yet.
+ */
+const DEFAULT_PAD_NAMES = ["BD", "SD", "HH", "CP"] as const;
+
+/**
+ * A fresh instrument of `kind`, at its defaults. Every ID it needs is minted
+ * here, so the command payload carries them explicitly and a replay, redo, or
+ * assistant preview reproduces the same project.
  */
 export function createInstrumentOfKind(
-	kind: InstrumentKind,
 	context: DomainFactoryContext,
+	kind: InstrumentKind,
 ): Instrument {
 	switch (kind) {
 		case "sampler":
-			return createSamplerInstrument(null);
-		case "synth":
-			return createSynthInstrument();
+			// No sample yet: one is loaded from the library or the sampler panel.
+			return createSamplerInstrument();
 		case "drumMachine":
 			return createDrumMachineInstrument(
-				DEFAULT_DRUM_PAD_NAMES.map((name) => createDrumPad(context, { name })),
+				DEFAULT_PAD_NAMES.map((name) => createDrumPad(context, { name })),
 			);
+		case "synth":
+			return createSynthInstrument();
 	}
 }
 


### PR DESCRIPTION
## What & why

#232 (for #223) and #234 (for #224) were written in parallel and merged two minutes apart. Both needed the same facts — which instrument kinds exist, what each is called, what `instrument_type` each reports, and what instrument each mints — and each landed its own copy. The copies had already diverged where a user could see it: a track *created* as a drum machine opened with `BD / SD / HH / CP`, one *switched* to a drum machine with `Kick / Snare / Hat / Clap`.

`src/instrument/instrumentKinds.ts` now declares each kind once — label, `instrument_type`, and the instrument it mints — and both surfaces read it. `src/editor/trackCreation.ts` keeps what is only track creation's: the button's accessible name (now derived from the shared label rather than written out beside it) and the clip and placement a new track opens with.

**Its exported surface is unchanged** — `NEW_TRACK_KINDS`, `NewTrackKind`, `NewTrackKindSpec`, `newTrackKindSpec`, `createNewTrack`, and `instrumentTypeKey` all still resolve, the last as a re-export. That is deliberate: the mixer half of #223 is not landed yet, and this must not break the branch it is on.

Closes #247

### Two consequences, stated rather than left to be found

- **A track switched to a drum machine now opens with `BD / SD / HH / CP`**, adopting what creating one already gave. Picking the other set would have changed a landed feature's behaviour, which is beyond a dedupe — but `Kick / Snare / Hat / Clap` is arguably the friendlier label set for a tool aiming at "accessible and intuitive", and it is now a one-line change in `DEFAULT_PAD_NAMES` if that call is wrong.
- **The picker now offers the shared order** — sampler, drum machine, synth — rather than its own sampler, synth, drum machine. One order for the same three choices.

`e2e/instrument.spec.ts` changes its two `Audition Kick` assertions to `Audition BD` as a direct consequence of the first bullet. That is the only assertion change in this PR, and it follows the behaviour rather than accommodating it.

## Core flows

None — #247 is a bug report and links no core flow ID. `bun run verify:core-flows` passes and reports the three registered flows unchanged; no flow spec was touched.

## Walkthrough

Recaptured from the passing `e2e/instrument.spec.ts` after this change, in Chromium. The visible difference is step 3: the pads now read `BD / SD / HH / CP`, and the picker lists drum machine second.

### issue-224 — Change a track's instrument

**1. Open a project: the track's instrument is a sampler**

![issue-224 step 1](https://github.com/afternoon/solid-groove/raw/refs/heads/claude/walkthroughs/224/issue-224/01-open-a-project-the-track-s-instrument-is-a-sampler.png)

**2. Pick Synth: the synth panel replaces the sampler's**

![issue-224 step 2](https://github.com/afternoon/solid-groove/raw/refs/heads/claude/walkthroughs/224/issue-224/02-pick-synth-the-synth-panel-replaces-the-sampler-s.png)

**3. Pick Drum machine: it arrives with pads to load**

![issue-224 step 3](https://github.com/afternoon/solid-groove/raw/refs/heads/claude/walkthroughs/224/issue-224/03-pick-drum-machine-it-arrives-with-pads-to-load.png)

**4. Undo returns the drum machine, one switch at a time**

![issue-224 step 4](https://github.com/afternoon/solid-groove/raw/refs/heads/claude/walkthroughs/224/issue-224/04-undo-returns-the-drum-machine-one-switch-at-a-time.png)

<sub>Captured by `bun run walkthrough:capture` and published to the `claude/walkthroughs` branch by `bun run walkthrough:publish`.</sub>

> **`walkthrough:publish` emits URLs that cannot be posted from an agent session.** A `raw.githubusercontent.com` URL is rewritten to backtick-wrapped text on the way into a PR body or comment, so the image renders as an empty code span — that is why #235 merged with four broken images, and why the stray comment below is unreadable. The same file served from the `github.com` `/raw/refs/heads/...` path is not filtered, which is what this section uses. `scripts/walkthrough/publish.mjs` should emit that form instead; happy to raise it as its own issue.

## Evidence

```
$ bun run check:ci
Checked 490 files in 624ms. No fixes applied.

$ bun run test
Test Files  170 passed (170)
     Tests  2278 passed (2278)

$ bun run test:browser:chromium -- e2e/instrument.spec.ts
1 passed (15.1s)
  ✓ e2e/instrument.spec.ts:8:1 › changes a track's instrument from its own panel

$ bun run verify:core-flows
check-core-flows — 3 flow(s), each with exactly one spec.
```

The regression test that makes this stick, in `instrumentKinds.test.ts`, builds the instrument **both ways** for every kind and asserts they are equal:

```ts
const created = createNewTrack(context(), { kind: spec.kind, ... }).track.instrument;
const switched = createInstrumentOfKind(context(), spec.kind);
expect(created, spec.kind).toEqual(switched);
```

It fails on `main` as it stands (`Kick` ≠ `BD`), which is the bug in #247. `src/editor/trackCreation.test.ts` is untouched and its 6 tests pass unchanged — including the WCAG 2.5.3 check that each button's visible label is inside its accessible name, which the derived `actionLabel` still satisfies.

Firefox and WebKit are CI's to gate: this environment cannot reach `cdn.playwright.dev`, so the Chromium run is a pre-flight, not PRD section 10 evidence. Note also that `main` is currently red on `browser e2e (firefox)` at `e2e/flows/CF-001.spec.ts:95` — the documented `AudioContext.resume()` gap, unrelated to this change.

## Acceptance criteria met

- ✅ One declaration of the kinds, their labels, their `instrument_type`, and the instrument each mints, read by both surfaces.
- ✅ A drum machine is the same drum machine whichever door the user came through, with a test that fails if the two drift apart again.
- ✅ A fourth kind would now be added in one place.
- ✅ No behaviour change beyond the two consequences named above; `trackCreation.ts`'s exported surface is unchanged so the unlanded #223 mixer PR still compiles.