### PR TITLE
Fix #43 (1/1): CF-001 asserts playback in Firefox, where it cannot start

### DIFF
--- a/e2e/flows/CF-001.spec.ts
+++ b/e2e/flows/CF-001.spec.ts
@@ -30,7 +30,10 @@ import { walkthrough } from "../support/walkthrough";
  * nothing about persistence. `e2e-emulator/` is where that belongs.
  */
 test.describe("CF-001", () => {
-	test("a visitor with no account reaches a playing loop", async ({ page }) => {
+	test("a visitor with no account reaches a playing loop", async ({
+		page,
+		browserName,
+	}) => {
 		const step = walkthrough(page, {
 			id: "CF-001",
 			title: "A visitor with no account reaches a playing loop",
@@ -89,10 +92,37 @@ test.describe("CF-001", () => {
 		// assertion that a sound reached a speaker: a headless browser records no
 		// audio and Playwright captures none. See docs/core-flows.md's "Out of
 		// scope" for this flow, docs/testing.md, and issue #43.
+		//
+		// Asserted in Chromium only — the known, tracked gap this flow's own "Out
+		// of scope" already names, and the same guard `e2e/smoke.spec.ts` and
+		// `e2e-emulator/slice.spec.ts` carry. In Firefox here `AudioContext`
+		// constructs but its `resume()` never settles, so `play()` times out into
+		// `audio_start_failed` and the button never becomes "Stop playback".
+		// `LOOP-003` bounded that hang; it did not make Firefox play. The cause is
+		// `HARD-001`'s real-hardware cross-browser pass — do not unguard this
+		// before then. See docs/testing.md, "Playback is asserted in Chromium
+		// only", and issue #43.
+		const canAssertPlayback = browserName === "chromium";
+		test.info().annotations.push({
+			type: canAssertPlayback ? "playback-asserted" : "playback-skipped",
+			description: canAssertPlayback
+				? `playback asserted in ${browserName}`
+				: `playback not asserted in ${browserName}: AudioContext.resume() is refused here — see HARD-001`,
+		});
+
+		// The click itself runs in every gating browser: the gesture, the command
+		// path behind it and the button staying mounted are real coverage, and a
+		// crash on click would still fail here. Only the transport's *playing*
+		// state is Chromium-only.
 		await page.getByRole("button", { name: "Start playback" }).click();
-		await expect(
-			page.getByRole("button", { name: "Stop playback" }),
-		).toBeVisible();
-		await step("Start playback — the transport is running");
+		if (canAssertPlayback) {
+			await expect(
+				page.getByRole("button", { name: "Stop playback" }),
+			).toBeVisible();
+			// The walkthrough is captured from the Chromium run
+			// (`walkthrough:capture` passes `--project=chromium`), so this caption
+			// is only ever recorded from a run that actually asserted it.
+			await step("Start playback — the transport is running");
+		}
 	});
 });


### PR DESCRIPTION
## What & why

`CF-001` fails in Firefox on `main`, reddening the gating `browser e2e (firefox)` job ([run 31131664838](https://github.com/afternoon/solid-groove/actions/runs/31131664838)):

```
Error: expect(locator).toBeVisible() failed
  Locator: getByRole('button', { name: 'Stop playback' })
  Expected: visible
  Timeout: 15000ms
  Error: element(s) not found
    at e2e/flows/CF-001.spec.ts:95:5

1 failed
  [firefox] › e2e/flows/CF-001.spec.ts:33:2 › CF-001 › a visitor with no account reaches a playing loop
```

The cause is the already-diagnosed, already-documented gap, not a new regression. In Firefox on a headless runner an `AudioContext` constructs but its `resume()` never settles, so `useProjectAudio.play()` times out into `audio_start_failed` and never reaches `setIsPlaying(true)` — the transport button stays on "Start playback". `LOOP-003` (#43) bounded that hang with `DEFAULT_RESUME_TIMEOUT_MS`; it deliberately did not make Firefox play, and `docs/testing.md` records that the guard stays until `HARD-001`'s real-hardware pass.

`e2e/smoke.spec.ts` and `e2e-emulator/slice.spec.ts` both carry a `browserName === "chromium"` guard for exactly this. `CF-001` was written without one, even though its own **Out of scope** in `docs/core-flows.md` already says *"Playback is asserted in Chromium only — see docs/testing.md and issue #43."* This PR makes the spec match the register.

- Adds the same `canAssertPlayback` guard and the same `playback-asserted`/`playback-skipped` annotation the two sibling suites use, so the gap stays visible in the report.
- The **click still runs in every gating browser** — the gesture, the command path behind it, and the button staying mounted are real coverage, and a crash on click would still fail. Only the transport's *playing state* is Chromium-only.
- No product code changed. No behavior changed in Chromium.

Refs #43

## Core flows

`CF-001` — **live** (it was already live; this PR does not remove or add a `test.fixme`). `CF-002` and `CF-003` are untouched and remain parked at `test.fixme`.

**This PR modifies a flow spec's assertions, so per CLAUDE.md here is exactly what changed and why.** The step-7 playback assertion becomes conditional on `browserName === "chromium"`; nothing else in the spec changed, and `docs/core-flows.md` and `docs/prd.md` are untouched.

The justification is that the register and the spec disagreed, and the register is the one that is right: CF-001's **Out of scope** paragraph already scopes playback to Chromium and links the tracked issue. The spec asserted it unconditionally anyway. A reviewer should check this against `docs/core-flows.md` CF-001 "Out of scope" and `docs/testing.md` § "Playback is asserted in Chromium only — a known, tracked gap", whose closing line is *"Revisit the guard when `HARD-001` runs against real hardware; do not restore it before then."* The alternative — making Firefox actually play — is `HARD-001`'s cross-browser pass against real hardware, not something this suite can settle.

`bun run verify:core-flows` still reports 3 flows, each with exactly one spec.

## Walkthrough

No UI change — this PR touches one E2E spec and no product code.

The walkthrough capture is unaffected: `walkthrough:capture` runs `--project=chromium`, so the `step("Start playback — the transport is running")` caption is still recorded, and now only ever from a run that actually asserted it.

## Evidence

**Reproducing the Firefox failure locally.** This sandbox cannot download Playwright's Firefox build — the network policy denies `cdn.playwright.dev` and `playwright.download.prss.microsoft.com` with `403 request rejected: host not permitted`, and `apt` only offers a snap transitional package. So the failure was reproduced by injecting Firefox's measured behavior (context stays `suspended`, `resume()` never settles — the exact row in `docs/testing.md`'s instrumentation table) into a real Chromium page, behind a throwaway fixture that also reports `browserName` as `"firefox"`. That harness ran the **unmodified spec body from `HEAD`**, not a paraphrase of it:

```
1) [chromium] › zz-CF-001-prefix-as-firefox.spec.ts:33:2 › CF-001 › a visitor with no account reaches a playing loop
   Error: expect(locator).toBeVisible() failed
     Locator: getByRole('button', { name: 'Stop playback' })
     Expected: visible
     Timeout: 15000ms
     Error: element(s) not found
       at .../zz-CF-001-prefix-as-firefox.spec.ts:95:5
1 failed
```

Same locator, same timeout, same line 95 as CI. The same harness against the fixed spec:

```
✓  1 [chromium] › zz-CF-001-as-firefox.spec.ts:33:2 › CF-001 › a visitor with no account reaches a playing loop (11.2s)
1 passed
```

The harness files were deleted before committing; the diff is the one spec.

**Caveat, stated plainly:** that is a faithful reproduction of the *condition*, not a run of real Firefox. Chromium-only evidence is not PRD section 10 gating evidence — CI's firefox job is, and it runs on push to `claude/**`.

**Suites run locally:**

```
bun run typecheck   → tsc --noEmit, clean
bun run check       → Checked 490 files in 875ms. No fixes applied.
bun run test        → Test Files 170 passed (170) / Tests 2281 passed (2281)
bun run verify:core-flows → check-core-flows — 3 flow(s), each with exactly one spec.
bunx playwright test --project=chromium        → 20 passed, 2 skipped
bunx playwright test --project=chromium e2e/flows → 1 passed, 2 skipped (CF-001 green, playback asserted)
```

## Acceptance criteria met

- CF-001 passes in Chromium with the playback assertion fully intact, and no longer fails the gating Firefox job.
- The register (`docs/core-flows.md`), the PRD, and the other two flow specs are untouched; no `test.fixme` marker was added or removed.
- Coverage does not dip: every non-playback step of CF-001 still runs in all three browsers, and the play click itself still runs in all three.
- Not addressed here, by design: *why* Firefox refuses the unlock. That is `HARD-001`'s real-hardware cross-browser pass, and `docs/testing.md` explicitly says not to unguard before then.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtZDDsgHFdLgE1cwqsS5E9)_