### PR TITLE
Emit Vitest JSON run reports and upload them from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,20 @@ jobs:
         # where that project must still run, so nothing merges without it.
         # `vitest.config.ts` defines the projects.
         run: bun run test:all
+      # The machine-readable half of that run (`vitest.config.ts` configures the
+      # `json` reporter alongside the terminal one). Uploaded on failure too —
+      # that is the case it exists for: the artifact names every failing test,
+      # its file, its assertion messages and its duration, so a red run can be
+      # triaged from the run page instead of by scrolling the log or
+      # re-reproducing it locally. `!cancelled()` rather than `always()` so a
+      # superseded run does not upload a half-written report.
+      - name: Upload the unit + component test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: vitest-report-unit
+          path: vitest-report/unit.json
+          retention-days: 7
       - name: Validate the starter sound library
         # Renders all 200 assets and runs the full manifest validation
         # (docs/sample-library.md section 9), including the collection-level
@@ -174,6 +188,15 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Run Firebase Emulator suite
         run: bun run test:emulator
+      # As in the `checks` job: the same run, in machine-readable form, kept
+      # whether it passed or failed. `tests/emulator/vitest.config.ts` writes it.
+      - name: Upload the emulator test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: vitest-report-emulator
+          path: vitest-report/emulator.json
+          retention-days: 7
 
   # FND-001b (PRD OPS-01): proves the production build itself, and the "no
   # secret reaches the client bundle" check, on every push and PR -- not only

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ app.config.timestamp_*.js
 test-results/
 playwright-report/
 blob-report/
+# Vitest's JSON run reports (`vitest-report/unit.json`,
+# `vitest-report/emulator.json`). Written on every run, uploaded by CI as
+# build artifacts — never source. Kept out of `test-results/` because
+# Playwright empties that directory when it starts.
+vitest-report/
 # Core-flow walkthrough screenshots. `bun run walkthrough:capture` writes them
 # here and `bun run walkthrough:publish` pushes them to the `claude/walkthroughs`
 # orphan branch — they are review artefacts and must never enter `main`'s

--- a/biome.json
+++ b/biome.json
@@ -10,6 +10,7 @@
       "!docs/design",
       "!playwright-report",
       "!test-results",
+      "!vitest-report",
       "!scripts/starter-library/acquire/candidate-sources",
       "!scripts/starter-library/acquire/candidates.json",
       "!src/library/factoryLibrary.generated.ts",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -167,6 +167,52 @@ Two suites run here:
 
 Requires a JDK (the emulator runs on the JVM); `.github/workflows/ci.yml` installs Temurin 21.
 
+## Vitest JSON run reports
+
+Both Vitest suites write a machine-readable report of every run alongside the
+terminal output, via the built-in `json` reporter:
+
+| Suite | Config | Report |
+| --- | --- | --- |
+| Unit + component (`bun run test`, `test:all`, `test:library`, `test:watch`) | `vitest.config.ts` | `vitest-report/unit.json` |
+| Firebase Emulator (`bun run test:emulator`) | `tests/emulator/vitest.config.ts` | `vitest-report/emulator.json` |
+
+The report lists every test file, every assertion, its status, duration and
+failure messages, plus the run's totals — the same run the terminal just
+described, in a form a script or another agent can read. It is written whether
+the run passed or failed, which is the case it exists for: a failed run's
+report names exactly what failed without anyone re-reading the log or
+reproducing the run locally.
+
+Three things about it are easy to trip over:
+
+- **One report per run, overwritten each time.** `reporters` and `outputFile`
+  are root-only options in Vitest — a project cannot set its own — so a run
+  writes one file covering whichever projects it selected. `bun run test` (five
+  projects), `bun run test:all` (six) and `bun run test:library` (one) all
+  write `vitest-report/unit.json`, each replacing the last. The report describes
+  the most recent run, not a merged history, and it carries no project name per
+  file: attribute a file to a project through `vitest.config.ts`'s globs.
+- **`vitest-report/`, not `test-results/`.** Playwright empties `test-results/`
+  when it starts, so a report written there would vanish the moment a browser
+  suite ran. The directory is gitignored and `bun run clean` removes it.
+- **Watch mode rewrites it on every rerun**, so a report read while
+  `bun run test:watch` is running may be a partial-selection run.
+
+### CI keeps them as artifacts
+
+`.github/workflows/ci.yml` uploads each report from the job that produced it,
+under `if: ${{ !cancelled() }}` so a red run is captured as well as a green one
+(a *cancelled* run is skipped — its report would be half-written):
+
+| Job | Artifact | Contents |
+| --- | --- | --- |
+| `checks` | `vitest-report-unit` | `vitest-report/unit.json` from `bun run test:all` |
+| `emulator` | `vitest-report-emulator` | `vitest-report/emulator.json` from `bun run test:emulator` |
+
+Both are kept for 7 days, matching the Playwright report artifacts the browser
+jobs upload. Download them from the run's summary page.
+
 ## Which browsers run where
 
 The two browser suites below run three browsers, but not every environment can
@@ -323,10 +369,10 @@ bun run check     # tsc --noEmit && biome check
 
 `.github/workflows/ci.yml` runs on every push to `main` and every pull request:
 
-1. **`checks`** — `bun run typecheck`, `bun run check:ci`, then a null-ALSA-device setup step (see "Unit and component tests" above) before `bun run test`, and finally `bun run library:validate` (see "Starter sound library" below), which validates the whole 200-asset catalogue rather than the representative sample the unit suite renders. Everything else depends on this.
+1. **`checks`** — `bun run typecheck`, `bun run check:ci`, then a null-ALSA-device setup step (see "Unit and component tests" above) before `bun run test`, and finally `bun run library:validate` (see "Starter sound library" below), which validates the whole 200-asset catalogue rather than the representative sample the unit suite renders. Everything else depends on this. Uploads the run's JSON report as the `vitest-report-unit` artifact, pass or fail (see "Vitest JSON run reports" above).
 2. **`browser`** — the Playwright suite, matrixed over `chromium`, `firefox`, `webkit`. Chromium/Firefox failures block the workflow; WebKit failures are reported but do not (`continue-on-error`).
 3. **`browser-emulator`** — `bun run test:browser:emulator` (`FND-009`), matrixed over the gating browsers `chromium`/`firefox` only, with a JDK installed for the Firestore emulator, exercising the foundation slice's add/play/undo/save/reload journey against a real (emulated) backend.
-4. **`emulator`** — `bun run test:emulator`, with a JDK installed for the Firestore emulator.
+4. **`emulator`** — `bun run test:emulator`, with a JDK installed for the Firestore emulator. Uploads its JSON report as the `vitest-report-emulator` artifact, pass or fail.
 5. **`build`** — `bun run build`, then `bun run verify:bundle` and `bun run verify:budget` (see "Deploy" below). Runs unconditionally, needs no Firebase project or credentials, and gates merges like every job above.
 6. **`deploy`** — builds, stamps, and ships the release to Firebase Hosting; see "Deploy" below for what it does and why it usually no-ops.
 
@@ -664,7 +710,7 @@ A second run of the same command should report every audio object and the versio
 bun run clean
 ```
 
-Deletes `.vinxi`, `.output`, `node_modules/.vinxi`, `node_modules/.vite`, and the `test-results` / `playwright-report` / `blob-report` output directories. It does **not** touch `node_modules` itself, so no reinstall is needed afterwards, and it leaves `public/samples` alone — those are generated artifacts rather than caches, and regenerating them is slow (see above).
+Deletes `.vinxi`, `.output`, `node_modules/.vinxi`, `node_modules/.vite`, and the `test-results` / `playwright-report` / `blob-report` / `vitest-report` output directories. It does **not** touch `node_modules` itself, so no reinstall is needed afterwards, and it leaves `public/samples` alone — those are generated artifacts rather than caches, and regenerating them is slow (see above).
 
 It exists because of a failure mode that is genuinely hard to recognise. Vite's dependency pre-bundling cache lives *inside* `node_modules/`, so it survives `git checkout`, `bun install`, and restarting the dev server. A long-lived local clone can therefore serve module output built from a commit you are no longer on, and nothing in the normal workflow invalidates it.
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prebuild": "bun run samples",
     "build": "vinxi build",
     "start": "vinxi start",
-    "clean": "rm -rf .vinxi .output node_modules/.vinxi node_modules/.vite test-results playwright-report blob-report",
+    "clean": "rm -rf .vinxi .output node_modules/.vinxi node_modules/.vite test-results playwright-report blob-report vitest-report",
     "firebase:emulator": "firebase emulators:start --only firestore,auth --project demo-solid-groove",
     "test": "vitest run --project=domain --project=audio --project=ui --project=data --project=platform",
     "test:all": "vitest run",

--- a/tests/emulator/vitest.config.ts
+++ b/tests/emulator/vitest.config.ts
@@ -16,6 +16,24 @@ export default defineConfig({
   // the full copies under `.claude/worktrees/` that the agent workflow creates.
   root: fileURLToPath(new URL(".", import.meta.url)),
   test: {
+    // A machine-readable transcript of the run alongside the terminal output,
+    // uploaded by CI as an artifact (`.github/workflows/ci.yml`). The path is
+    // resolved from this file rather than left relative because Vitest resolves
+    // `outputFile` against the project root pinned above — a relative path
+    // would bury the report inside `tests/emulator/`, away from every other
+    // suite's. `vitest-report/` is the repo root's, shared with the unit
+    // suite's own `unit.json`.
+    reporters: [
+      "default",
+      [
+        "json",
+        {
+          outputFile: fileURLToPath(
+            new URL("../../vitest-report/emulator.json", import.meta.url),
+          ),
+        },
+      ],
+    ],
     environment: "node",
     include: ["**/*.test.ts"],
     hookTimeout: 30_000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,20 @@ const jestDomSetupPath = fileURLToPath(
   import.meta.resolve("@testing-library/jest-dom/vitest"),
 );
 
+/**
+ * Where a run's machine-readable report lands.
+ *
+ * Resolved from this file rather than left relative, because Vitest resolves a
+ * relative `outputFile` against the *project root*, which differs per project
+ * here — a relative path would scatter one run's report across several
+ * directories. `vitest-report/` sits alongside Playwright's `playwright-report/`
+ * and is deliberately **not** under `test-results/`: Playwright empties that
+ * directory when it starts, which would delete a Vitest report captured
+ * moments earlier.
+ */
+const jsonReport = (name: string) =>
+  fileURLToPath(new URL(`vitest-report/${name}.json`, import.meta.url));
+
 /** Shared by every project: never collect from a nested worktree checkout. */
 const exclude = [...configDefaults.exclude, "tests/**", ".claude/**"];
 
@@ -110,6 +124,18 @@ const appProject = (name: string, include: string[]) => ({
  */
 export default defineConfig({
   test: {
+    // The terminal reporter a human reads, plus a machine-readable transcript
+    // of the same run. The JSON report is what CI uploads as an artifact
+    // (`.github/workflows/ci.yml`), so a failure can be inspected — which test,
+    // which file, which assertion, how long it took — without re-reading a
+    // wall of log output or re-running the suite locally to reproduce it.
+    //
+    // `reporters` and `outputFile` are root-only options in Vitest: a project
+    // cannot set its own, so this one file covers whichever projects a run
+    // selects. That means `bun run test`, `bun run test:all` and `bun run
+    // test:library` each overwrite `unit.json` with *their* run — the report
+    // describes the last run, not a merged history.
+    reporters: ["default", ["json", { outputFile: jsonReport("unit") }]],
     projects: [
       // The pure contract layers: no Firebase, Tone, or Solid imports.
       appProject("domain", [


### PR DESCRIPTION
## What & why

Both Vitest suites now run the built-in `json` reporter alongside the terminal one, and CI keeps the result as a build artifact.

| Suite | Config | Report |
| --- | --- | --- |
| Unit + component (`bun run test`, `test:all`, `test:library`, `test:watch`) | `vitest.config.ts` | `vitest-report/unit.json` |
| Firebase Emulator (`bun run test:emulator`) | `tests/emulator/vitest.config.ts` | `vitest-report/emulator.json` |

The report lists every test file, every assertion, its status, duration and failure messages, plus the run's totals. It is written whether the run passed or failed, which is the case it exists for: a red run can be triaged from the artifact instead of by scrolling the log or reproducing it locally.

Three decisions worth a reviewer's attention:

- **One report per run, at the root config.** `reporters`/`outputFile` are root-only options in Vitest — a project cannot set its own — so the unit config sets one path covering whichever of its six projects a run selected. `bun run test`, `test:all` and `test:library` each overwrite `unit.json` with *their* run. Documented in the config comment and in `docs/testing.md`.
- **Paths resolved from the config file, not left relative.** Vitest resolves a relative `outputFile` against the *project root*, which differs per project here and is `tests/emulator/` for the emulator suite — a relative path would scatter one run's report across directories.
- **`vitest-report/`, not `test-results/`.** Playwright empties `test-results/` when it starts, so a report written there would vanish the moment a browser suite ran. The new directory is gitignored, excluded from Biome, and removed by `bun run clean`.

CI uploads each report from the job that produced it, under `if: ${{ !cancelled() }}` so a failed run is captured too (a *cancelled* one is skipped — its report would be half-written), with the same 7-day retention as the existing Playwright report artifacts:

| Job | Artifact | Contents |
| --- | --- | --- |
| `checks` | `vitest-report-unit` | `vitest-report/unit.json` from `bun run test:all` |
| `emulator` | `vitest-report-emulator` | `vitest-report/emulator.json` from `bun run test:emulator` |

No product code changes; no PRD requirement or issue drives this — it is test-tooling work requested directly, so there is no `Closes #<n>` and no `$ACTION #<issue> (i/N)` title.

## Core flows

None. This changes no user-facing behavior and touches no flow spec — `docs/core-flows.md` and `tests/e2e/` are untouched.

## Walkthrough

No UI change.

## Evidence

**CI on `d1e568d` — every job green, and both artifacts actually materialised** ([run 32949317737](https://github.com/afternoon/solid-groove/actions/runs/32949317737)):

- `vitest-report-unit` — 101,985 bytes, from the `checks` job.
- `vitest-report-emulator` — 2,519 bytes, from the `emulator` job.
- Alongside the five pre-existing `playwright-report-*` artifacts, unchanged.

Local, before pushing:

- `bun run check` → `Checked 496 files in 577ms. No fixes applied.` (tsc clean)
- `bun run test` → `Test Files 158 passed (158)`, `Tests 2045 passed (2045)`, and `JSON report written to …/vitest-report/unit.json`. The written report parses and reports `158` files / `2045` tests / `success: true`.
- `bun run verify:test-projects` → `174 test file(s), each owned by exactly one of 6 projects.`
- **The failing case, which is the point of the change:** a temporary always-failing test under `src/shared/` still produced the report, with `success: false`, `numFailedTests: 1`, and the failing test named (`fails on purpose`). The temporary file was deleted afterwards and is not in the diff.
- The emulator config's path resolution was checked without standing up an emulator (`vitest run --config tests/emulator/vitest.config.ts --passWithNoTests no-such-file`) → the report landed in the repo root's `vitest-report/`, not `tests/emulator/`. CI's `emulator` job then exercised it end to end, per the artifact above.

## Acceptance criteria met

No issue, so no checkboxes. Against the request as stated: JSON reports are enabled for both Vitest suites, and both are captured as CI artifacts including on failure.
