### PR TITLE
Implement #34 (1/1): Record the alpha's AI provider, limits, and off-platform context as ADRs

### DIFF
--- a/docs/adr/0006-anthropic-behind-a-model-agnostic-gateway.md
+++ b/docs/adr/0006-anthropic-behind-a-model-agnostic-gateway.md
@@ -1,0 +1,91 @@
+# ADR 0006 - Anthropic behind a model-agnostic gateway, and what the alpha assistant may cost
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Date | 2026-08-27 |
+| Decides | Which AI provider and model the private alpha's assistant calls, and the per-user and organization-wide limits that bound what it can spend |
+| Affects | `DEC-005` ([#34](https://github.com/afternoon/solid-groove/issues/34)), `AI-001` ([#69](https://github.com/afternoon/solid-groove/issues/69)), `REL-002` ([#74](https://github.com/afternoon/solid-groove/issues/74)) |
+
+## Context
+
+`DEC-005` had settled two things by comment and left four open: provider and model, per-user budget, usage limits, and the project context the assistant may send off-platform. This ADR takes the first three. [ADR 0007](./0007-assistant-off-platform-context-and-disclosure.md) takes the fourth together with the disclosure copy, because that question is about data rather than about vendors.
+
+`AI-001` — the provider-independent server gateway — was blocked on all of it, which is why the assistant milestone had not started.
+
+Two facts frame the choice. First, the thing the assistant is judged on is not prose quality but **structured tool-use accuracy**: the assistant changes a project only by returning validated commands from an allowlisted schema, and a proposal that fails validation costs a retry, a regeneration, and a tester's patience. Second, the alpha cohort is 8-20 hand-recruited testers, so the money at stake is small enough that it is not the deciding variable — roughly $35-70 for a four-week alpha at current rates. What actually needs bounding is not the expected bill but the unexpected one: a retry loop, or an account that is not a tester.
+
+## Decision
+
+### 1. Anthropic is the provider for the alpha
+
+Credentials and provider objects stay server-side behind the `AI-001` gateway and never reach the client or enter domain state. Adding a second provider, or replacing this one, requires a superseding ADR.
+
+### 2. The model is configuration, not a literal
+
+The alpha starts on `claude-sonnet-5`. `claude-haiku-4-5` is also under evaluation during dogfooding. **The product owner switches models on their own judgement from that evaluation, and a switch does not reopen this ADR and does not reopen `REL-002`'s AI producer gate.**
+
+This is the point of the decision, not a footnote to it. A model choice made before anyone has used the assistant is a guess; the cheaper tiers may well be sufficient for structured command generation, and the way to find out is to use it. Welding a model into the gateway would mean a quality failure discovered at the `REL-002` gate could only be answered by reopening a product decision, which is the expensive way to learn something a config change can fix.
+
+### 3. The gateway abstracts the request shape per model, not just the model string
+
+The models under evaluation do not take the same request:
+
+- `claude-sonnet-5` uses adaptive thinking and `output_config.effort`.
+- `claude-haiku-4-5` **rejects** `effort` and uses the older `thinking: {type: "enabled", budget_tokens: N}` form.
+- Context windows differ by a factor of five (1M against 200K), so the conversation history resent on each turn is **bounded** rather than allowed to grow with the session.
+
+A gateway that hardcodes one request shape will fail the moment the config value in decision 2 is changed — that is, at exactly the moment the decision is being exercised. Per-model request shape belongs in the provider abstraction, and a test covers each configured model.
+
+### 4. The assistant requires an authenticated account
+
+The anonymous-start path gets the rest of the product and not the assistant. An unauthenticated request path to a metered third-party API is the standard way to be billed for someone else's traffic, and no per-user limit is meaningful without a user.
+
+### 5. Per-user limit: 100 messages per account per rolling 24 hours
+
+Every provider call counts, **retries included**, because the cap exists to track real spend rather than user intent. Hitting it is a hard stop with a recoverable error that names when the window resets. A rolling window rather than a calendar day, so it cannot be gamed by waiting for midnight and does not reset in the middle of a European evening session.
+
+### 6. Two kill switches, one manual and one automatic
+
+A server-side flag that disables the assistant immediately without a deploy, and an automatic cut-off at **$25/day** of organization-wide spend. That figure is roughly eight times expected cohort load, so it fires on something being wrong rather than on a busy test week.
+
+The manual flag alone leaves nothing watching overnight or over a weekend, which is when a runaway loop is most expensive. The automatic ceiling alone leaves no way to stop an incident quickly. Both are cheap; neither substitutes for the other.
+
+### 7. The limits are configuration in one module
+
+The cap, the window, the spend ceiling, and the model ID live in one place alongside the assistant transcript retention window, rather than as literals spread across the gateway, the quota check, and the UI copy that has to tell a user what the limit is.
+
+## Consequences
+
+### What this buys
+
+- `AI-001` is unblocked, and with it the assistant milestone.
+- The cheapest defensible model gets a fair trial in real use, and switching away from it costs a config change rather than a reopened decision.
+- The expensive failure modes — an unauthenticated caller, a retry loop, a weekend leak — each have something specific stopping them rather than a general intention to be careful.
+
+### What this costs, and what we do about it
+
+- **Sonnet 5 may generate more proposals that fail validation than a larger model would.** The mitigation is that failure is safe rather than silent: an invalid proposal is rejected before it mutates anything, and decision 2 makes the model swappable the moment dogfooding says so. If proposal quality is the thing that fails, we will find out from use rather than from argument.
+- **A shared organization ceiling means one account's runaway takes the assistant down for everyone.** Accepted at cohort scale, where "everyone" is twenty people and someone will notice within the hour. It stops being acceptable at a larger cohort — see *Revisit when*.
+- **Authenticated-only means the anonymous first-run path cannot show the assistant.** A demo to someone who has not signed up shows the DAW and not the thing that most distinguishes it. Accepted for the alpha, where the cohort is invited and signs in anyway.
+- **Counting retries against a user's cap makes the number in the UI larger than the number of messages they sent.** The copy has to say "requests" honestly rather than imply message count, or a tester will report the cap as a bug.
+- **A rolling-window counter needs per-account storage and its own tests**, where a calendar-day counter would not.
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Start on Opus 5 for best proposal accuracy | Roughly 2.5x the per-turn cost, which across the whole alpha is about $100 — real but not decisive. The product owner would rather learn what the cheaper tiers actually do in dogfooding than pay to avoid finding out, and decision 2 makes that reversible |
+| Fix one model for the alpha, no switching | A quality failure could then only be answered by reopening `DEC-005` at the `REL-002` gate, which is the most expensive moment to discover it |
+| Let anonymous users reach the assistant | Best first-run experience, and an uncapped-by-identity path to a metered API. Not for an alpha whose sign-up is open |
+| Token-cost cap per user instead of a message cap | Truer to spend, and "you have $2 of assistant left" is meaningless to a producer mid-track. The message cap is the number a user can reason about |
+| No per-user cap, global ceiling only | One tester's script or one retry loop consumes the whole organization's budget before the ceiling notices |
+| Manual kill switch only | Nothing protects the account overnight or over a weekend |
+
+## Revisit when
+
+- Dogfooding shows proposal quality below the bar on the configured model — decision 2 is exercised, and this ADR is not reopened.
+- The cohort grows beyond roughly twenty people, at which point a shared organization kill switch stops being a proportionate response to one bad actor and per-account spend tracking earns its cost.
+- The automatic ceiling fires from genuine usage rather than from a defect, which would mean the figure in decision 6 is wrong rather than that something broke.
+- Anthropic's pricing or model line-up changes enough to alter the arithmetic in decision 2.
+- Public launch, where anonymous access, cohort size, and abuse surface all change together.

--- a/docs/adr/0007-assistant-off-platform-context-and-disclosure.md
+++ b/docs/adr/0007-assistant-off-platform-context-and-disclosure.md
@@ -1,0 +1,117 @@
+# ADR 0007 - What the assistant sends off-platform, and what we tell users about it
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Date | 2026-08-27 |
+| Decides | Which parts of a user's project may be sent to the AI provider, and the disclosure copy that describes it |
+| Supersedes | The draft disclosure copy in `AI-006` ([#95](https://github.com/afternoon/solid-groove/issues/95)), including its "no notes, no project contents beyond the project ID" claim |
+| Affects | `DEC-005` ([#34](https://github.com/afternoon/solid-groove/issues/34)), `AI-006` ([#95](https://github.com/afternoon/solid-groove/issues/95)), `AI-001` ([#69](https://github.com/afternoon/solid-groove/issues/69)), `src/projection/assistantContextProjection.ts`, `src/projection/projectAnalysisProjection.ts` |
+
+## Context
+
+[ADR 0006](./0006-anthropic-behind-a-model-agnostic-gateway.md) settles which provider the assistant calls and what it may cost. This one settles what we hand that provider, and what we say about it.
+
+Two terms were already recorded on `DEC-005` and are inherited here rather than reopened: assistant transcripts are retained first-party for **30 days**, and the alpha ships **no provider-level opt-out** — a user who does not want their prompts reaching the provider declines the assistant, which costs no manual DAW capability.
+
+The projections that would carry the payload already exist. `assistantContextProjection.ts` sends the project name, tempo, time signature, track and section names, instrument kinds, device and clip counts, mixer state and the current selection; `projectAnalysisProjection.ts` adds derived facts — pitch range, mean velocity, notes per bar, repetition ratio. **Neither sends a single note event.** That gap is not a detail: an assistant that can "add, remove, move, resize, and transform note events" cannot do any of it to material it has never seen. As built, the most-used half of the assistant's capability set was undeliverable.
+
+[ADR 0003](./0003-replay-canvas-capture-and-assistant-conversation-retention.md) decision 5 established the standard this decision is held to: when a disclosure's promise stops being true, the copy is corrected rather than defended. That is what happens below.
+
+## Decision
+
+### 1. The off-platform payload is an allowlist
+
+The assistant may be sent, for the project currently open:
+
+- project name, tempo, time signature, total length;
+- sections, with their names, positions and lengths;
+- tracks, with their names, type, instrument kind, device/clip/placement counts, and mixer state;
+- derived note statistics — register, mean velocity, density, repetition;
+- a description of the current selection;
+- **raw note events for the current selection only**;
+- the conversation so far, within the bound [ADR 0006](./0006-anthropic-behind-a-model-agnostic-gateway.md) decision 3 sets.
+
+Anything not on this list is not sent. Extending the list is a change to this ADR.
+
+### 2. What never leaves, regardless
+
+Audio of any kind. Note events outside the current selection. Asset URLs. Provider credentials or tokens. Account data beyond the pseudonymous identifier quota enforcement needs — no email address, no display name.
+
+### 3. Raw notes are scoped to the selection, and that is what makes the capability deliverable
+
+Sending the selection's notes is what lets the assistant edit notes at all. Scoping it to the selection is what keeps the exposure proportional: the material the user is actively working on goes, the rest of the project does not, and the payload does not grow without bound as the project does.
+
+Where the user has selected nothing, the assistant receives the song-level summary and no note events, and says it lacks the context rather than inventing it.
+
+### 4. User-entered names leave the platform, deliberately
+
+Project, track and section names are free text a user typed, and they go to the provider verbatim. An assistant that cannot say "I turned the bass down" — only "I turned track_7f3a down" — is visibly worse at the one thing it is for.
+
+This is a real cost and it is accepted rather than mitigated: a track named for a person, a label, or an unreleased collaboration goes off-platform along with everything else. What the decision requires instead is that the disclosure say so plainly, which the copy below does. Silently sending names while implying we do not is the outcome this rejects.
+
+### 5. The disclosure copy is approved as follows
+
+> **About the assistant**
+>
+> Solid Groove sends Anthropic — the AI service behind the assistant — your message along with a description of the project you're working in: its name, your track and section names, the tempo and structure, your mixer settings, and the notes in whatever you currently have selected. It does not send your audio, and it does not send the rest of your project.
+>
+> *[One sentence stating Anthropic's actual retention and training posture, written from their published terms on the day this ships.]*
+>
+> Separately, Solid Groove keeps your conversations — your messages, the assistant's replies, and the changes it proposes, including any notes it writes for you — for 30 days. Our goal is to make the assistant better. The team may read them. After 30 days they are deleted.
+>
+> ☑ Keep my conversations with the assistant for 30 days
+> This controls Solid Groove's own copy only. It does not take back anything already sent to Anthropic.
+>
+> The assistant behaves exactly the same either way, and every other part of Solid Groove works without it — if you would rather nothing was sent, you can simply not use the assistant.
+
+Wording stays tweakable without reopening this ADR; what may not change is that it remains true and specific about the same four things — what is sent, what the provider may do with it, what we keep and for how long, and what the control does and does not cover.
+
+### 6. The provider-posture sentence is written from verified terms, and shipping it unverified is a defect
+
+`AI-006` reads Anthropic's published terms on the day it ships, writes that one sentence from what they actually say, and cites what it read in its PR. Shipping the bracketed placeholder is a defect; so is shipping a posture claim nobody checked.
+
+`DEC-005` recorded a *permission* — that the provider may retain and train on our requests — and permission is not knowledge. If the terms say Anthropic does not train on API traffic, then telling the cohort it might would be a false statement in the frightening direction, which fails ADR 0003 decision 5's standard exactly as a reassuring falsehood would.
+
+### 7. The `AI-006` draft copy's central claim is withdrawn
+
+That draft told the user "Your music itself is not kept: no audio, no notes, and no clip or project contents beyond the ID of the project you were working in." It is false twice over. It is false about what is sent, under decisions 1 and 4. And it is false about our own store: `AI-006`'s record holds the proposals the assistant showed, and a proposal that writes a bassline **is** note data. The claim would have become untrue the first time the assistant did the thing it exists to do.
+
+### 8. The opt-out's scope limit renders on the control, in both places it appears
+
+The line stating that the control governs Solid Groove's copy only travels with the control itself — in the first-run dialog and in the durable settings surface, which is where most users will meet it on day three rather than day one. A true statement that only appears where a skimming user will not read it is doing the work of a misleading one.
+
+## Consequences
+
+### What this buys
+
+- The assistant can edit notes, which the assistant's alpha capability set assumed and the projections did not support.
+- The exposure is bounded by something specific — an allowlist and a selection — rather than by "we send a summary."
+- The disclosure describes what actually happens, including the parts that are not flattering, so the first cohort member who thinks about it does not find a gap between the copy and the payload.
+
+### What this costs, and what we do about it
+
+- **User-typed names reach a third party that may retain them.** No mitigation removes this; decision 4 accepts it and decision 5 discloses it. The alternative was an assistant that cannot name anything.
+- **The payload grows with the selection.** Selecting an entire dense track sends every note in it. Bounded in practice by what a user can select and by [ADR 0006](./0006-anthropic-behind-a-model-agnostic-gateway.md) decision 3's history bound, but it is not a fixed ceiling.
+- **The disclosure is longer than the draft it replaces.** Being specific about four things costs words, and a dialog people skim is a poor place to spend them. Decision 8 is the partial answer: the load-bearing sentence sits on the control.
+- **One sentence of the copy cannot be written until someone reads the provider's terms**, which makes `AI-006` depend on an external document that can change under it.
+- **The projections need extending**, and the note-event path needs its own test that nothing outside the selection is ever included.
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Stats and names only, no raw notes | Exactly what ships today, and it makes the assistant's note editing undeliverable. The gap would have surfaced as a failed acceptance criterion late in the milestone rather than as a decision made in the open |
+| Send the whole project's notes every turn | Best assistant quality; the payload grows without bound as the project does, and the material a user is not working on has no reason to leave |
+| Strip user-entered names, send IDs only | Nothing a user typed leaves, and the assistant can no longer refer to anything by name. Degrades every single reply to protect a case that the disclosure can honestly describe instead |
+| Keep the `AI-006` draft copy and its "no notes" line | It is false under decisions 1 and 4, and false about our own transcript store. ADR 0003 decision 5 settled that the copy gets corrected |
+| Keep the conservative "may retain and train" line unverified | Ships without an external dependency, at the price of possibly telling the cohort something untrue. A frightening falsehood is not the safe end of the error bar |
+| Add a provider-level opt-out now | Already deferred on `DEC-005` as `P2-005`, with `HARD-005` asking the cohort about it directly. Unparking it is that decision's to make, not this one's |
+
+## Revisit when
+
+- A user can import their own samples, at which point asset names stop being library facts we ship and become user content, exactly as [ADR 0003](./0003-replay-canvas-capture-and-assistant-conversation-retention.md) flagged for replay.
+- `HARD-005` reports that the cohort does care about provider-level opt-out, which unparks `P2-005` and changes what the copy has to offer.
+- Anthropic's published terms change, which changes decision 6's sentence and may change decision 1's calculus.
+- The assistant needs project-wide note context to do something it cannot do scoped to the selection — a real finding, not a convenience, and it reopens decision 3.
+- Public launch, where a larger and uninvited audience changes the privacy calculus for names.


### PR DESCRIPTION
## What & why

`DEC-005` had two terms settled by comment — 30-day transcript retention, and the recorded permission that the provider may retain and train — and four still open: provider and model, per-user budget, usage limits, and the acceptable off-platform project context, plus approval of the drafted disclosure copy. All of it is now decided by the product owner and recorded here as two ADRs.

Split into two because the vendor question and the data question have different revisit triggers:

- **ADR 0006 — Anthropic behind a model-agnostic gateway, and what the alpha assistant may cost.** Anthropic, behind the `AI-001` gateway, with the model held as configuration rather than a literal: the alpha starts on `claude-sonnet-5`, `claude-haiku-4-5` is evaluated in dogfooding, and switching between them is a config change rather than a reopened decision or a reopened `REL-002` gate. That freedom has a cost the gateway pays up front — the two models do not take the same request shape (Sonnet 5 takes `output_config.effort`; Haiku 4.5 rejects it and uses `thinking.budget_tokens`), so per-model request construction belongs in the provider abstraction or the swap fails at exactly the moment it is exercised. Authenticated accounts only, 100 requests per account per rolling 24 hours, a manual kill switch, and a $25/day organization spend ceiling.
- **ADR 0007 — What the assistant sends off-platform, and what we tell users about it.** An allowlist, which now includes raw note events **for the current selection only**. Without them the assistant's note-editing capability was undeliverable: the projections as built send no note events at all, so that gap would have surfaced as a failed acceptance criterion late in the milestone. User-entered names leave too, deliberately, and the disclosure says so plainly. The `AI-006` draft copy's "no notes, no project contents" claim is withdrawn — it was false about what is sent and false about our own transcript store, since a stored proposal contains notes. The provider-posture sentence is written from Anthropic's published terms verified on the day `AI-006` ships, because a frightening falsehood fails the [ADR 0003](../blob/main/docs/adr/0003-replay-canvas-capture-and-assistant-conversation-retention.md) decision 5 standard exactly as a reassuring one would.

**The PRD is untouched.** An earlier revision of this branch carried a one-line section 16 edit, written against a checkout that predated `ddbac01`/`6664245`. Those commits removed the "Product-owner decisions required before Alpha Milestone 3 or launch" subsection — which held the open question this decision answers — and recast section 16 as an explicitly project-outset list that ADRs supersede. Both halves of that edit are therefore moot, and the branch has been rebased with the PRD change dropped entirely.

Unblocks `AI-001` (#69), whose `blocked` label and body warning come off when this lands. Resolves `AI-006`'s (#95) `[provider]` placeholder and approves its copy.

Closes #34

## Core flows

None. This is a product-decision record: it changes no product behavior and no code, so there is no flow for it to deliver or spec.

## Walkthrough

No UI change. The disclosure copy is *approved* here, not implemented — `AI-006` (#95) builds the surface that shows it, and the walkthrough belongs to that PR.

## Evidence

Two new files under `docs/adr/`, 208 lines added, nothing else changed — no source file, and no PRD line.

```
$ bun run check
$ tsc --noEmit && biome check && bun run verify:no-solid-1
Checked 500 files in 687ms. No fixes applied.
$ node scripts/check-no-solid-1.mjs
check-no-solid-1 — no Solid 1 idioms found.
```

```
$ bun run test
 Test Files  159 passed (159)
      Tests  2053 passed (2053)
   Duration  104.90s
```

`bun run typecheck` is the `tsc --noEmit` that fronts `bun run check` above. The test run above was on the pre-rebase commit; the rebase changed no source file and dropped a docs line, so it stands. The browser and emulator suites were not run — this diff touches no source file, so there is nothing in it for them to exercise.

## Acceptance criteria met

`DEC-005` carries no acceptance checkboxes — it is a decision issue. Its four remaining open items are each answered:

- [x] **Provider and model choice** — ADR 0006 decisions 1–3.
- [x] **Per-user budget, usage limits** — ADR 0006 decisions 4–7.
- [x] **Acceptable off-platform project context** — ADR 0007 decisions 1–4.
- [x] **Final approval of the drafted copy** — ADR 0007 decision 5, with decisions 6–8 covering the one sentence that cannot be written until `AI-006` reads the provider's terms.

One item is deliberately left as a blocking step rather than resolved here: the provider-posture sentence. It is not knowable from a decision — it has to be read from Anthropic's published terms on the day the disclosure ships, and ADR 0007 decision 6 makes shipping it unverified a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149yKbAX16d515PhhFJ8zR6