### PR TITLE
Implement #95 (1/N): Record Anthropic's verified data posture in the disclosure

### DIFF
--- a/docs/adr/0007-assistant-off-platform-context-and-disclosure.md
+++ b/docs/adr/0007-assistant-off-platform-context-and-disclosure.md
@@ -56,7 +56,7 @@ This is a real cost and it is accepted rather than mitigated: a track named for 
 >
 > Solid Groove sends Anthropic — the AI service behind the assistant — your message along with a description of the project you're working in: its name, your track and section names, the tempo and structure, your mixer settings, and the notes in whatever you currently have selected. It does not send your audio, and it does not send the rest of your project.
 >
-> *[One sentence stating Anthropic's actual retention and training posture, written from their published terms on the day this ships.]*
+> Anthropic does not use anything we send it to train their AI models, and they delete it within 30 days — unless their automated safety systems flag something, in which case they can keep it for up to two years.
 >
 > Separately, Solid Groove keeps your conversations — your messages, the assistant's replies, and the changes it proposes, including any notes it writes for you — for 30 days. Our goal is to make the assistant better. The team may read them. After 30 days they are deleted.
 >
@@ -72,6 +72,13 @@ Wording stays tweakable without reopening this ADR; what may not change is that 
 `AI-006` reads Anthropic's published terms on the day it ships, writes that one sentence from what they actually say, and cites what it read in its PR. Shipping the bracketed placeholder is a defect; so is shipping a posture claim nobody checked.
 
 `DEC-005` recorded a *permission* — that the provider may retain and train on our requests — and permission is not knowledge. If the terms say Anthropic does not train on API traffic, then telling the cohort it might would be a false statement in the frightening direction, which fails ADR 0003 decision 5's standard exactly as a reassuring falsehood would.
+
+**Verification record — 2026-08-27.** Read on that date:
+[commercial terms](https://www.anthropic.com/legal/commercial-terms),
+[privacy policy](https://www.anthropic.com/legal/privacy),
+[commercial data retention](https://privacy.claude.com/en/articles/7996866-how-long-do-you-store-personal-data),
+[API and data retention](https://platform.claude.com/docs/en/manage-claude/api-and-data-retention).
+Finding: the commercial terms state "Anthropic may not train models on Customer Content from Services," where Customer Content is defined as Inputs and Outputs together — so the no-training posture is a term of the standard commercial agreement our API access already falls under, not an enterprise upgrade or an opt-out we have to request. Inputs and outputs are deleted within 30 days by default; content flagged by automated trust-and-safety systems is retained up to 2 years. Zero-data-retention agreements shorten the default but do not change the training answer, which is already "no" without one. **This check does not discharge the standing requirement above:** the terms can change under us, so `AI-006` re-reads them on the day it ships and corrects the sentence if they have.
 
 ### 7. The `AI-006` draft copy's central claim is withdrawn
 


### PR DESCRIPTION
## What & why

ADR 0007 decision 5 carried a bracketed placeholder where Anthropic's retention and training posture belongs. Decision 6 makes shipping that placeholder — or any posture claim nobody verified — a defect. This PR reads the terms, writes the sentence, and records the verification.

This is the first slice of `AI-006`: the rest of the task builds on approved disclosure copy, and one sentence of that copy could not be written until someone read the provider's terms. It closes nothing.

Refs #95

### The sentence

> Anthropic does not use anything we send it to train their AI models, and they delete it within 30 days — unless their automated safety systems flag something, in which case they can keep it for up to two years.

Second person, no defined terms, no "processor". Covers both halves decision 5 requires — what Anthropic keeps, and whether it trains on it — and hedges only where the terms hedge (the trust-and-safety carve-out).

### The terms it is written from

Read **2026-08-27**. Quoting so a reviewer can check the sentence without re-reading the sources.

[Commercial terms](https://www.anthropic.com/legal/commercial-terms), section B:

> "'Inputs' means submissions to the Services by Customer or its Users and 'Outputs' means responses generated by the Services to Inputs (Inputs and Outputs together are 'Customer Content')."

> "Anthropic may not train models on Customer Content from Services."

[API and data retention](https://platform.claude.com/docs/en/manage-claude/api-and-data-retention):

> "Retained data is never used for model training without your express permission."

> "Even with ZDR or HIPAA arrangements in place, Anthropic may retain data where required by law or where it has been flagged by Anthropic's automated trust and safety systems. As a result, if a chat or session is flagged, Anthropic may retain inputs and outputs for up to 2 years."

[Commercial data retention](https://privacy.claude.com/en/articles/7996866-how-long-do-you-store-personal-data):

> "For Anthropic API users, we automatically delete inputs and outputs on our backend within 30 days of receipt or generation"

[Privacy policy](https://www.anthropic.com/legal/privacy) — its "may use your Inputs and Outputs to train and improve Anthropic AI models, unless you opt out" line is **consumer-only** and explicitly disclaims our traffic:

> "This Privacy Policy does not apply to content that we process on behalf of customers of our business offerings, such as our Enterprise accounts. Our use of that data is governed by our customer agreements covering access to and use of those offerings."

### Answering decision 6's three questions

**(a) Training?** No, by default and without asking. The prohibition is in the standard commercial terms, and Customer Content is defined to cover both what we send and what comes back. The only stated route to training is express permission, which we do not give. The consumer opt-out model does not apply to API traffic.

**(b) Retention?** 30 days by default. Trust-and-safety flagging extends that to 2 years, and legal compliance can extend it further. A ZDR agreement removes at-rest storage but keeps both carve-outs.

**(c) Standard vs. enterprise?** Not for the training answer — that is already "no" on standard commercial access. ZDR only shortens retention. **There is no arrangement we need to request to make the sentence above true**, which is the finding that matters for `AI-006`'s scope.

### Reported, not edited

The verified posture contradicts `DEC-005`'s recorded permission that the provider "may retain and train on our requests". A permission is not a finding. Both records are the product owner's to revise, so I commented rather than edited:

- **#95** — its fourth acceptance criterion requires the disclosure to state the provider may retain and train, and its draft copy says the provider "may keep them and use them to improve its own models". Posted the finding with a proposed replacement criterion; the issue body is untouched.
- **#34** — added a new comment. The second partial-decision comment is a historical record and was not rewritten.

`docs/prd.md` untouched, as instructed — its privacy section is generic and stays true.

## Core flows

None. This PR changes a decision record, not behavior — no flow covers ADR prose, and no spec was touched. `AI-006`'s flows belong to the slices that build the disclosure UI on top of this approved copy.

## Walkthrough

No UI change. This is one sentence of ADR 0007 plus a verification record; the copy it approves is not rendered anywhere yet.

## Evidence

`bun run check`:

```
$ tsc --noEmit && biome check && bun run verify:no-solid-1
Checked 500 files in 393ms. No fixes applied.
$ node scripts/check-no-solid-1.mjs
check-no-solid-1 — no Solid 1 idioms found.
```

`bun run test`:

```
 Test Files  159 passed (159)
      Tests  2053 passed (2053)
   Start at  20:58:31
   Duration  95.30s (transform 32.84s, setup 75.87s, import 63.97s, tests 101.80s, environment 234.84s)
```

Two environment notes, neither caused by this change and neither requiring action from a reviewer:

- `node_modules` was stale in my working copy — `bun run check` failed with `Cannot find module '@solidjs/vite-plugin'` and `solid-js has no exported member 'onSettled'` until `bun install`. Confirmed pre-existing by stashing this diff and reproducing the identical errors on a clean tree.
- An untracked, un-gitignored `.output/` directory (a stale Nitro build artifact from before client start mode) was in the working copy at the start of this session and made `biome check` report 5584 errors across vendored build output. I moved it aside to get a clean run and **restored it afterwards** — it is not mine to delete. Worth gitignoring or removing separately; it is not part of this PR.

Diff is 8 insertions, 1 deletion in one file — well inside the 400-line ceiling.

## Acceptance criteria met

None of `AI-006`'s checkboxes are claimed. This slice discharges ADR 0007 decision 6's requirement that the posture sentence be written from verified terms and cited in its PR, which is a precondition for the disclosure criteria rather than one of them.

The verification record added under decision 6 is deliberately **additive**: decision 6's standing requirement to re-read the terms at ship time is preserved verbatim, since the terms can change under us. Note also that the 30-day and 2-year figures are published policy (privacy center, platform docs) rather than clauses of the commercial terms, so they are more changeable than the no-training clause — another reason the re-check obligation stays.
