### PR TITLE
Register core flows CF-004 to CF-007

### DIFF
--- a/docs/core-flows.md
+++ b/docs/core-flows.md
@@ -214,6 +214,130 @@ its clips moving with it, and a single undo puts the order back.
 automation (`ARR-004`); and whether sections survive a reload, which would belong
 to a flow in `tests/e2e/emulator/flows/`.
 
+### CF-004 — A producer sets the span they are working in
+
+**Issue:** #280 · **Suite:** `tests/e2e/emulator/flows/CF-004.spec.ts` · **Entrypoint:** the
+project dashboard
+
+**Preconditions:** signed in with no projects.
+
+1. Create a new project. Above the tracks, the ruler carries a loop brace spanning
+   the first bar, and looping is on.
+2. Start playback. The playhead runs to the end of bar 1 and jumps back to the
+   start, over and over.
+3. Drag the right-hand edge of the brace out to the end of bar 2.
+4. The brace now spans two bars. Playback never stopped, and the playhead now
+   turns around at the end of bar 2.
+5. Switch looping off. The playhead runs past the end of the brace and keeps
+   going; the brace stays where it is.
+6. Switch looping back on, stop, and reload the page.
+7. The project reopens with the brace still spanning bars 1 and 2, and looping
+   still on.
+
+**Outcome:** the producer chose the span they are working inside, changed it
+without interrupting playback, and found it exactly as they left it when they
+came back.
+
+**Out of scope:** that any of it is *audible* — a headless browser records no
+audio, so this proves the playhead and the transport, not that a sound reached a
+speaker (see [`docs/testing.md`](./testing.md#playback-is-asserted-in-chromium-only--a-known-tracked-gap)
+and issue #43). It also does not prove that anything else in the product moves
+the brace: nothing does, deliberately, and CF-005 is where that is asserted from
+the other side.
+
+### CF-005 — A producer drops a loop from the library onto a new track
+
+**Issue:** #281 · **Suite:** `tests/e2e/emulator/flows/CF-005.spec.ts` · **Entrypoint:** the
+project dashboard
+
+**Preconditions:** signed in with no projects. The library contains a
+tempo-labelled loop whose source tempo is not the tempo a new project opens at.
+
+1. Create a new project. It opens on the starter kick pattern.
+2. In the library browser, find a drum loop that was recorded at a different
+   tempo from the project's.
+3. Drag it out of the browser and drop it on empty space in the track area.
+4. A new track appears at the bottom of the track list, carrying that loop as a
+   clip starting at bar 1, marked as a loop that follows the project tempo
+   rather than a pitched one-shot.
+5. Nothing else moved: the project tempo is unchanged, the loop brace is where it
+   was, and the transport is still stopped.
+6. Reload the page. The new track and its loop are still there.
+
+**Outcome:** a producer brought a loop out of the library into their project with
+one drag, and the project it landed in is otherwise exactly as they left it.
+
+**Out of scope:** playback of any kind — pressing play belongs to CF-004, and
+audibility is not provable here in any case. Dropping a one-shot, which loads
+onto the track under the pointer instead and is asserted at the command layer.
+Dropping at the bar under the mouse, which the product deliberately does not do
+yet. And whether the stretched loop *sounds* right, which no browser test can
+tell you.
+
+### CF-006 — A producer brings their own sounds into a pack
+
+**Issue:** #282 · **Suite:** `tests/e2e/emulator/flows/CF-006.spec.ts` · **Entrypoint:** the
+public landing page
+
+**Preconditions:** a registered account whose personal library is empty. Importing
+requires an account: a guest is offered the upgrade path instead, which is
+asserted at the component layer rather than walked here.
+
+1. Open the landing page and sign in.
+2. Open a project, so the library browser is on screen.
+3. Choose "Add pack". A new pack appears in the browser with its name in an
+   input, waiting to be typed.
+4. Type a name for the pack and press Return. The pack is now listed, and empty.
+5. Drag three audio files from the desktop onto that pack. Each shows its own
+   progress, and each lands as a sound in the pack when it finishes.
+6. Audition one of them from the browser, and find it by searching the library
+   the same way you would find a factory sound.
+7. Reload the page. The pack and all three sounds are still there.
+
+**Outcome:** the producer's own audio is in their library, in a pack they named,
+sitting alongside the factory content and reachable the same way — which means
+the next thing they can do is CF-005 with a sound of their own.
+
+**Out of scope:** using one of those sounds in a project, which is CF-005 and is
+not re-proved here. Dropping files on empty space to create a pack called "My
+Sounds", the file-picker fallback, renaming, deleting, and every rejection path
+(unsupported file, oversized file, the account storage cap, a cancelled upload) —
+all required, all covered at the component, repository and rules layers, none of
+them the path that must not break.
+
+### CF-007 — A producer drives the whole mix through an overdrive
+
+**Issue:** #283 · **Suite:** `tests/e2e/emulator/flows/CF-007.spec.ts` · **Entrypoint:** the
+project dashboard
+
+**Preconditions:** signed in with no projects.
+
+1. Create a new project and drop a library loop onto the track area, so the
+   starter kick and a loop are playing together.
+2. Start playback. The two parts repeat over the loop brace.
+3. Switch the main region from the arrangement to the master.
+4. The master's effects are on screen, with an empty chain. Add an overdrive to
+   it.
+5. While it is still playing, drive the overdrive up. The control follows,
+   playback never drops out, and the meter keeps moving.
+6. Undo once. The overdrive comes off the master chain.
+7. Redo. It is back, at the drive you had set.
+8. Reload the page. The overdrive is still on the master chain, still at that
+   drive.
+
+**Outcome:** a producer reached the master, put an effect across everything they
+had made, pushed it while it played, and found the whole thing intact when they
+came back.
+
+**Out of scope:** that the overdrive *sounds* like anything — a headless browser
+records no audio, so this proves the chain, the controls, and the state, not the
+processing, which is asserted in the audio suite. Track device chains (#241),
+the other five device types, device presets, and reordering a chain, all of which
+are tested at their own layers. Note that the undo happens before the reload
+because history is session-local: a reload legitimately ends the undo stack, and
+a flow that undid afterwards would be asserting something the product does not
+promise.
+
 <!--
   New flows go here, in ascending ID order. Never renumber or reuse an ID: a
   retired flow keeps its number and gains a "**Retired:** why" line, because

--- a/docs/core-flows.md
+++ b/docs/core-flows.md
@@ -318,10 +318,10 @@ project dashboard
 3. Switch the main region from the arrangement to the master.
 4. The master's effects are on screen, with an empty chain. Add an overdrive to
    it.
-5. While it is still playing, drive the overdrive up. The control follows,
-   playback never drops out, and the meter keeps moving.
-6. Undo once. The overdrive comes off the master chain.
-7. Redo. It is back, at the drive you had set.
+5. Undo once. The overdrive comes off the master chain.
+6. Redo. It is back.
+7. While it is still playing, drive the overdrive up. The control follows and
+   playback never drops out.
 8. Reload the page. The overdrive is still on the master chain, still at that
    drive.
 
@@ -333,10 +333,13 @@ came back.
 records no audio, so this proves the chain, the controls, and the state, not the
 processing, which is asserted in the audio suite. Track device chains (#241),
 the other five device types, device presets, and reordering a chain, all of which
-are tested at their own layers. Note that the undo happens before the reload
-because history is session-local: a reload legitimately ends the undo stack, and
-a flow that undid afterwards would be asserting something the product does not
-promise.
+are tested at their own layers. Two orderings here are deliberate rather than
+incidental. The undo and redo come *before* the drive is pushed, because a
+parameter gesture is its own history entry: undoing after it would take back the
+drive rather than the device, and redoing an add restores the device as its
+payload described it. And both come before the reload, because history is
+session-local — a reload legitimately ends the undo stack, so a flow that undid
+afterwards would assert something the product does not promise.
 
 <!--
   New flows go here, in ascending ID order. Never renumber or reuse an ID: a

--- a/tests/e2e/emulator/flows/CF-004.spec.ts
+++ b/tests/e2e/emulator/flows/CF-004.spec.ts
@@ -1,0 +1,253 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { walkthrough } from "../../support/walkthrough";
+
+/**
+ * `CF-004` — a producer sets the span they are working in.
+ *
+ * Read the flow in `docs/core-flows.md`; the numbered comments below are its
+ * steps, in its words. This is the acceptance contract for `LOOP-018` (#280)
+ * and is frozen once it lands: a later PR that changes an assertion here has to
+ * say so in its body and justify it.
+ *
+ * `test.fixme` because none of the loop-brace surface exists yet — #280 is the
+ * PR that removes this marker. What is missing today:
+ *
+ *  - **The brace itself.** `src/arrangement/canvasRenderer.ts` draws the ruler,
+ *    sections and playhead; nothing draws a loop brace, and nothing lets a
+ *    pointer grab one. #280's own acceptance criteria put it in the same paint
+ *    pass rather than in an overlay element.
+ *  - **Its persistence.** `songSchema` (`src/domain/entities.ts`) has no loop
+ *    range or loop toggle, so step 7's reload has nothing to reopen with. That
+ *    is #278, which lands before #280.
+ *  - **Looping on by default.** `useProjectAudio` starts with
+ *    `loopEnabled = false` today, so step 1's "looping is on" is new too.
+ *
+ * Runs against the Firestore/Auth emulator rather than the mock backend,
+ * because step 7 is a real `page.reload()` and the mock repository is a fresh,
+ * empty store on every page load.
+ *
+ * Two requirements this spec places on #280, both because the ruler is a canvas
+ * and canvas pixels can never be the only representation of state (PRD 9.3, and
+ * the same rule `ArrangementView`'s existing hidden mirrors already follow):
+ *
+ *  1. **An accessible mirror of the brace**, at
+ *     `data-testid="arrangement-loop-live"`, phrased like the selection mirror
+ *     beside it and naming the *inclusive* first and last bar: a brace over the
+ *     first bar alone reads "bars 1 to 1", and one over bars 1 and 2 reads
+ *     "bars 1 to 2". #280 already owes assistive technology an announcement of
+ *     the brace; this is that announcement, read by a test.
+ *  2. **The timeline's horizontal scale**, as `data-pixels-per-tick` on the
+ *     arrangement root. Step 3 is a pointer drag on a canvas, so it can only be
+ *     performed by coordinate, and a spec that hardcoded the zoom constant
+ *     would break the first time anyone changed it.
+ */
+
+/** One bar of the alpha's fixed 4/4 at 192 PPQ (`src/domain/time.ts`). */
+const TICKS_PER_BAR = 4 * 192;
+
+/** The ruler strip's height in CSS pixels (`canvasRenderer.RULER_HEIGHT_PX`). */
+const RULER_HEIGHT_PX = 22;
+
+/** Beats per bar, for reading the transport's bar.beat readout as one number. */
+const BEATS_PER_BAR = 4;
+
+/**
+ * The arrangement's accessible mirror of the loop brace (see the note above).
+ */
+const loopBrace = (page: Page): Locator => page.getByTestId("arrangement-loop-live");
+
+/**
+ * The interaction canvas the ruler is drawn on. A class, deliberately: it is a
+ * `<canvas>`, so it has no role and no accessible name to reach it by, and the
+ * drag in step 3 needs the element's box to compute coordinates from.
+ */
+const timeline = (page: Page): Locator => page.locator(".arrangement-layer-interactive");
+
+/** The transport's playhead readout, by the accessible text `EditorHeader` gives it. */
+const playheadReadout = (page: Page): Locator =>
+  page.getByText(/^Playhead at bar \d+\.\d+$/);
+
+/** The playhead's position as whole beats from the top of the song. */
+async function playheadBeats(page: Page): Promise<number> {
+  const text = (await playheadReadout(page).textContent()) ?? "";
+  const match = text.match(/(\d+)\.(\d+)/);
+  if (!match) throw new Error(`Could not read the playhead readout: "${text}"`);
+  return (Number(match[1]) - 1) * BEATS_PER_BAR + (Number(match[2]) - 1);
+}
+
+/** The bar the playhead is in, 1-based, as the transport shows it. */
+const barOf = (beats: number): number => Math.floor(beats / BEATS_PER_BAR) + 1;
+
+/**
+ * Watches the playhead for a while and reports where it went.
+ *
+ * Musical time is wall-clock time here: one bar is two seconds at the tempo a
+ * new project opens at, so a window that covers a loop pass has to be seconds
+ * long. Sampling the readout is the only way to see a *turnaround* — an
+ * assertion on a single reading cannot tell "looping over bar 1" apart from
+ * "stopped at bar 1".
+ */
+async function watchPlayhead(page: Page, milliseconds: number): Promise<number[]> {
+  const samples: number[] = [];
+  const deadline = Date.now() + milliseconds;
+  while (Date.now() < deadline) {
+    samples.push(await playheadBeats(page));
+    await page.waitForTimeout(40);
+  }
+  return samples;
+}
+
+/** Whether the playhead ever jumped backwards — i.e. the loop turned it around. */
+const turnedAround = (samples: readonly number[]): boolean =>
+  samples.some((beats, index) => index > 0 && beats < samples[index - 1]);
+
+test.describe("CF-004", () => {
+  // `test.fixme` until #280 (LOOP-018) lands: that PR removes this marker in
+  // the same diff that makes the flow pass.
+  test.fixme(
+    "a producer sets the span they are working in",
+    async ({ page, browserName }) => {
+      // Several loop passes are watched in real time, and a bar is two seconds
+      // at 120 BPM, so this flow does not fit the default per-test timeout.
+      test.setTimeout(120_000);
+
+      const step = walkthrough(page, {
+        id: "CF-004",
+        title: "A producer sets the span they are working in",
+      });
+
+      /*
+       * Playback is asserted in Chromium only — the known, tracked gap CF-001
+       * and `tests/e2e/emulator/slice.spec.ts` already carry. In Firefox here a
+       * fresh `AudioContext` constructs and reports `state="suspended"`, but
+       * `resume()` never settles, so `play()` times out into
+       * `audio_start_failed`. See docs/testing.md, "Playback is asserted in
+       * Chromium only", and issue #43.
+       *
+       * Everything the brace itself promises — where it starts, that a drag
+       * moves it, that it survives a reload, and that the loop toggle is
+       * independent of it — runs in both gating browsers. Only the assertions
+       * about where the *playhead* went are guarded.
+       */
+      const canAssertPlayback = browserName === "chromium";
+      test.info().annotations.push({
+        type: canAssertPlayback ? "playback-asserted" : "playback-skipped",
+        description: canAssertPlayback
+          ? `playback asserted in ${browserName}`
+          : `playback not asserted in ${browserName}: AudioContext.resume() is refused here — see HARD-001`,
+      });
+
+      // 1. Create a new project. Above the tracks, the ruler carries a loop
+      //    brace spanning the first bar, and looping is on.
+      await page.goto("/dashboard");
+      await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+      await page.getByRole("button", { name: "New Project" }).click();
+      await expect(page).toHaveURL(/\/projects\/prj_/);
+      const projectUrl = page.url();
+      await page.getByTestId("arrangement-view-ready").waitFor();
+
+      await expect(loopBrace(page)).toContainText("bars 1 to 1");
+      // The toggle names the action it offers, so "Disable loop" is what a
+      // control that is currently looping reads (`EditorHeader`).
+      await expect(page.getByRole("button", { name: "Disable loop" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      await step("A new project opens with the brace over bar 1 and looping on");
+
+      // 2. Start playback. The playhead runs to the end of bar 1 and jumps
+      //    back to the start, over and over.
+      await page.getByRole("button", { name: "Start playback" }).click();
+      if (canAssertPlayback) {
+        await expect(page.getByRole("button", { name: "Stop playback" })).toBeVisible();
+        // Two and a half bars of wall clock: long enough to contain at least
+        // one turnaround at the end of bar 1, whenever in the bar it starts.
+        const overBarOne = await watchPlayhead(page, 5_000);
+        expect(overBarOne.map(barOf)).not.toContain(2);
+        expect(turnedAround(overBarOne)).toBe(true);
+        await step("Playback loops around the first bar");
+      }
+
+      // 3. Drag the right-hand edge of the brace out to the end of bar 2.
+      const box = await timeline(page).boundingBox();
+      if (!box) throw new Error("The arrangement timeline has no box to drag on.");
+      const pixelsPerTick = Number(
+        await page
+          .getByTestId("arrangement-view-ready")
+          .getAttribute("data-pixels-per-tick"),
+      );
+      expect(pixelsPerTick).toBeGreaterThan(0);
+      // The flow never scrolls the arrangement, so a tick's x is its distance
+      // from the timeline's left edge.
+      const xOfBarLine = (bar: number) =>
+        box.x + (bar - 1) * TICKS_PER_BAR * pixelsPerTick;
+      const rulerY = box.y + RULER_HEIGHT_PX / 2;
+
+      await page.mouse.move(xOfBarLine(2), rulerY);
+      await page.mouse.down();
+      await page.mouse.move(xOfBarLine(3), rulerY, { steps: 12 });
+      await page.mouse.up();
+
+      // 4. The brace now spans two bars. Playback never stopped, and the
+      //    playhead now turns around at the end of bar 2.
+      await expect(loopBrace(page)).toContainText("bars 1 to 2");
+      if (canAssertPlayback) {
+        // The drag ran through a whole gesture without the transport being
+        // touched: the button still offers to stop, so playback never stopped.
+        await expect(page.getByRole("button", { name: "Stop playback" })).toBeVisible();
+        // Three bars of wall clock over a two-bar loop: at least one
+        // turnaround, and bar 3 must never be reached.
+        const overTwoBars = await watchPlayhead(page, 6_000);
+        expect(overTwoBars.map(barOf)).toContain(2);
+        expect(overTwoBars.map(barOf)).not.toContain(3);
+        expect(turnedAround(overTwoBars)).toBe(true);
+      }
+      await step("Drag the brace out to the end of bar 2 — playback never stopped");
+
+      // 5. Switch looping off. The playhead runs past the end of the brace and
+      //    keeps going; the brace stays where it is.
+      await page.getByRole("button", { name: "Disable loop" }).click();
+      await expect(page.getByRole("button", { name: "Enable loop" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+      if (canAssertPlayback) {
+        await expect
+          .poll(async () => barOf(await playheadBeats(page)), { timeout: 20_000 })
+          .toBeGreaterThanOrEqual(3);
+      }
+      // Switching the transport's behaviour left the range alone: that
+      // separation is the whole point of the toggle being its own control.
+      await expect(loopBrace(page)).toContainText("bars 1 to 2");
+      await step("Looping off — the playhead runs past the brace, which stays put");
+
+      // 6. Switch looping back on, stop, and reload the page.
+      await page.getByRole("button", { name: "Enable loop" }).click();
+      await expect(page.getByRole("button", { name: "Disable loop" })).toBeVisible();
+      if (canAssertPlayback) {
+        await page.getByRole("button", { name: "Stop playback" }).click();
+        await expect(page.getByRole("button", { name: "Start playback" })).toBeVisible();
+      }
+      // Not a step of the flow: step 7's promise is only meaningful once the
+      // change has actually been written, and the save status is how the editor
+      // reports that a revision-checked write completed.
+      await expect(page.locator(".save-status")).toHaveText("Saved", {
+        timeout: 10_000,
+      });
+      await step("Looping back on, and stopped");
+
+      await page.reload();
+
+      // 7. The project reopens with the brace still spanning bars 1 and 2, and
+      //    looping still on.
+      await expect(page).toHaveURL(projectUrl);
+      await page.getByTestId("arrangement-view-ready").waitFor();
+      await expect(loopBrace(page)).toContainText("bars 1 to 2");
+      await expect(page.getByRole("button", { name: "Disable loop" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      await step("Reopened: the brace and the toggle are exactly as they were left");
+    },
+  );
+});

--- a/tests/e2e/emulator/flows/CF-005.spec.ts
+++ b/tests/e2e/emulator/flows/CF-005.spec.ts
@@ -1,0 +1,211 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { walkthrough } from "../../support/walkthrough";
+
+/**
+ * `CF-005` — a producer drops a loop from the library onto a new track.
+ *
+ * Read the flow in `docs/core-flows.md`; the numbered comments below are its
+ * steps, in its words. This is the acceptance contract for `LOOP-019` (#281)
+ * and is frozen once it lands: a later PR that changes an assertion here has to
+ * say so in its body and justify it.
+ *
+ * `test.fixme` because the drop path does not exist yet — #281 is the PR that
+ * removes this marker. What is missing today:
+ *
+ *  - **The drop itself.** `src/library/assetDrag.ts` already carries a browsed
+ *    sound on a `DataTransfer` under `LIBRARY_SAMPLE_MIME`, and this spec drags
+ *    a real library row so that mechanism is what is exercised — but the only
+ *    thing that reads the payload today is the instrument panel (#225), which
+ *    loads a sampler. Nothing turns a dropped *loop* into a new track.
+ *  - **The loop's tempo on the row.** Step 2 asks the producer to find a loop
+ *    "recorded at a different tempo from the project's", which they can only do
+ *    if the browser says what tempo each loop was recorded at. `AssetRow` shows
+ *    a name, a role and a pack; the manifest already carries `bpm`. Surfacing
+ *    it is #281's, and this spec finds its loop by reading it.
+ *  - **The loop brace** step 5 asserts is unchanged, which is #280/#278.
+ *    CF-005 is where "nothing in the product moves the brace on the user's
+ *    behalf" is proved from the other side, so this flow depends on that
+ *    surface existing even though it never touches it.
+ *
+ * Runs against the Firestore/Auth emulator rather than the mock backend,
+ * because step 6 is a real `page.reload()` and the mock repository is a fresh,
+ * empty store on every page load.
+ *
+ * Like CF-004, this spec needs the timeline's horizontal scale to work in a
+ * canvas: #281 reads `data-pixels-per-tick` off the arrangement root, the hook
+ * CF-004 introduces, because the only way to observe *where* a canvas-drawn
+ * clip landed is to click it and see what gets selected.
+ */
+
+/** One bar of the alpha's fixed 4/4 at 192 PPQ (`src/domain/time.ts`). */
+const TICKS_PER_BAR = 4 * 192;
+
+/** The ruler strip's height in CSS pixels (`canvasRenderer.RULER_HEIGHT_PX`). */
+const RULER_HEIGHT_PX = 22;
+
+/** One track row's height (`ArrangementView.ROW_METRICS.trackHeightPx`). */
+const ROW_HEIGHT_PX = 28;
+
+/** The library panel (`LibraryBrowser`'s `<section aria-label="Library">`). */
+const library = (page: Page): Locator => page.getByRole("region", { name: "Library" });
+
+/**
+ * The interaction canvas the tracks are drawn on. A class, deliberately: it is
+ * a `<canvas>`, so there is no role or accessible name to reach it by, and both
+ * the drop and the click that inspects the result are coordinates on it.
+ */
+const timeline = (page: Page): Locator => page.locator(".arrangement-layer-interactive");
+
+/** The arrangement's accessible mirror of the loop brace (see CF-004). */
+const loopBrace = (page: Page): Locator => page.getByTestId("arrangement-loop-live");
+
+/** The arrangement's accessible mirror of the track list, top to bottom. */
+const trackList = (page: Page): Locator =>
+  page.getByRole("list", { name: "Arrangement tracks" }).getByRole("listitem");
+
+/** The arrangement's accessible mirror of the placement selection. */
+const selectedPlacements = (page: Page): Locator =>
+  page.getByTestId("placement-selection").locator("li");
+
+/**
+ * The first loop in the browser recorded at some tempo other than the
+ * project's — step 2's "a drum loop that was recorded at a different tempo".
+ *
+ * Found by reading the rows rather than by naming a sound, so the flow keeps
+ * proving what it is about — a loop whose tempo differs from the song's — as
+ * the delivered library changes underneath it.
+ */
+async function loopAtAnotherTempo(
+  page: Page,
+  projectTempo: number,
+): Promise<{ row: Locator; name: string; sourceTempo: number }> {
+  const auditions = library(page).getByRole("button", { name: /^Audition / });
+  const count = await auditions.count();
+  for (let index = 0; index < count; index += 1) {
+    const audition = auditions.nth(index);
+    const row = audition.locator("..");
+    const sourceTempo = Number(
+      (await row.textContent())?.match(/(\d+)\s*BPM/)?.[1] ?? Number.NaN,
+    );
+    if (!Number.isFinite(sourceTempo) || sourceTempo === projectTempo) continue;
+    const name = ((await audition.getAttribute("aria-label")) ?? "").replace(
+      /^Audition /,
+      "",
+    );
+    return { row, name, sourceTempo };
+  }
+  throw new Error(
+    `No loop in the library states a tempo other than the project's ${projectTempo} BPM.`,
+  );
+}
+
+test.describe("CF-005", () => {
+  // `test.fixme` until #281 (LOOP-019) lands: that PR removes this marker in
+  // the same diff that makes the flow pass.
+  test.fixme(
+    "a producer drops a loop from the library onto a new track",
+    async ({ page }) => {
+      const step = walkthrough(page, {
+        id: "CF-005",
+        title: "A producer drops a loop from the library onto a new track",
+      });
+
+      // 1. Create a new project. It opens on the starter kick pattern.
+      await page.goto("/dashboard");
+      await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+      await page.getByRole("button", { name: "New Project" }).click();
+      await expect(page).toHaveURL(/\/projects\/prj_/);
+      const projectUrl = page.url();
+      await expect(page.getByRole("button", { name: "Notes, step 1, on" })).toBeVisible();
+      await page.getByTestId("arrangement-view-ready").waitFor();
+      await expect(trackList(page)).toHaveCount(1);
+      await step("A new project opens on the starter kick pattern");
+
+      // 2. In the library browser, find a drum loop that was recorded at a
+      //    different tempo from the project's.
+      //
+      // The panel's top level is the packs this project has — a new project
+      // has the starter kick's pack, and the drum loops live in it — so
+      // finding a loop means opening that pack node and searching within it.
+      const tempoInput = page.getByRole("spinbutton", { name: "Tempo (BPM)" });
+      const projectTempo = Number(await tempoInput.inputValue());
+      await library(page).getByRole("searchbox", { name: "Search sounds" }).fill("loop");
+      await library(page).getByRole("button", { expanded: false }).first().click();
+      const loop = await loopAtAnotherTempo(page, projectTempo);
+      await expect(loop.row).toBeVisible();
+      await step("Find a loop in the library recorded at another tempo");
+
+      // 3. Drag it out of the browser and drop it on empty space in the track
+      //    area.
+      //
+      // Empty space: below every existing row, and at a bar that is not bar 1,
+      // so step 4's "starting at bar 1" cannot pass by accident — the product
+      // deliberately ignores the bar the pointer was over.
+      const box = await timeline(page).boundingBox();
+      if (!box) throw new Error("The arrangement timeline has no box to drop on.");
+      await loop.row.dragTo(timeline(page), {
+        targetPosition: {
+          x: Math.min(box.width - 8, box.width / 2),
+          y: RULER_HEIGHT_PX + ROW_HEIGHT_PX * 3,
+        },
+      });
+
+      // 4. A new track appears at the bottom of the track list, carrying that
+      //    loop as a clip starting at bar 1, marked as a loop that follows the
+      //    project tempo rather than a pitched one-shot.
+      await expect(trackList(page)).toHaveCount(2);
+      await expect(trackList(page).last()).toContainText(loop.name);
+
+      // Where the clip landed can only be read off the canvas by clicking it:
+      // a click at bar 1 of the new row selects a placement only if one is
+      // actually there.
+      const pixelsPerTick = Number(
+        await page
+          .getByTestId("arrangement-view-ready")
+          .getAttribute("data-pixels-per-tick"),
+      );
+      expect(pixelsPerTick).toBeGreaterThan(0);
+      await timeline(page).click({
+        position: {
+          x: (TICKS_PER_BAR / 2) * pixelsPerTick,
+          y: RULER_HEIGHT_PX + ROW_HEIGHT_PX + ROW_HEIGHT_PX / 2,
+        },
+      });
+      await expect(selectedPlacements(page)).toHaveCount(1);
+
+      // Marked as a loop, not a pitched one-shot: `LoopInfo` (INS-02) is the
+      // surface that says so, and it reports the tempo the loop was recorded
+      // at against the tempo it is playing at.
+      const loopPanel = page.getByRole("region", { name: "Audio loop" });
+      await expect(loopPanel).toContainText("Tempo-labelled loop");
+      await expect(loopPanel).toContainText(loop.name);
+      await expect(loopPanel).toContainText(`${loop.sourceTempo} BPM`);
+      await expect(loopPanel).toContainText(`${projectTempo} BPM`);
+      await step("A new track at the bottom carries the loop at bar 1");
+
+      // 5. Nothing else moved: the project tempo is unchanged, the loop brace
+      //    is where it was, and the transport is still stopped.
+      await expect(tempoInput).toHaveValue(String(projectTempo));
+      await expect(loopBrace(page)).toContainText("bars 1 to 1");
+      await expect(page.getByRole("button", { name: "Start playback" })).toBeVisible();
+      await step("The tempo, the brace and the transport are untouched");
+
+      // 6. Reload the page. The new track and its loop are still there.
+      //
+      // The reload is only meaningful once the drop has actually been written,
+      // which the save status is how the editor reports.
+      await expect(page.locator(".save-status")).toHaveText("Saved", {
+        timeout: 10_000,
+      });
+      await page.reload();
+      await expect(page).toHaveURL(projectUrl);
+      await page.getByTestId("arrangement-view-ready").waitFor();
+      await expect(trackList(page)).toHaveCount(2);
+      await expect(trackList(page).last()).toContainText(loop.name);
+      await expect(page.getByRole("region", { name: "Audio loop" })).toContainText(
+        loop.name,
+      );
+      await step("Reload — the new track and its loop are still there");
+    },
+  );
+});

--- a/tests/e2e/emulator/flows/CF-006.spec.ts
+++ b/tests/e2e/emulator/flows/CF-006.spec.ts
@@ -1,0 +1,259 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { walkthrough } from "../../support/walkthrough";
+
+/**
+ * `CF-006` — a producer brings their own sounds into a pack.
+ *
+ * Read the flow in `docs/core-flows.md`; the numbered comments below are its
+ * steps, in its words. This is the acceptance contract for `LIB-09` (#282) and
+ * is frozen once it lands: a later PR that changes an assertion here has to say
+ * so in its body and justify it.
+ *
+ * `test.fixme` because personal packs do not exist at all yet — #282 is the PR
+ * that removes this marker. What is missing today:
+ *
+ *  - **User packs.** Every pack in `src/library` is factory content fetched
+ *    from the delivered manifests (`libraryClient.ts`); there is no "Add pack",
+ *    no `kind: "user"` pack, and nothing that writes one.
+ *  - **Importing by drop.** `assetDrag.ts` carries a *library* sound out of the
+ *    browser; nothing accepts operating-system files coming the other way, and
+ *    nothing uploads audio to Cloud Storage under the owning user.
+ *  - **The storage emulator.** This suite is started by
+ *    `firebase emulators:exec --only firestore,auth` (`package.json`), so the
+ *    uploads step 5 makes have nothing to talk to. #282 adds `storage` to that
+ *    list — `firebase.json` already configures the emulator on port 9199 —
+ *    along with the `storage.rules` the import writes under.
+ *
+ * Runs against the emulator rather than the mock backend for two reasons at
+ * once: step 1 signs in for real, and step 7 is a real `page.reload()`.
+ *
+ * Two things about how this flow is driven, neither of which is an assertion
+ * about our product:
+ *
+ *  - **Signing in drives the Auth emulator's own account-chooser popup**, which
+ *    is Firebase's UI, not ours. The selectors in {@link signIn} describe *it*.
+ *    Adjusting them to match the emulator is not a change to this flow's
+ *    assertions.
+ *  - **The files are synthesised and dropped through a `DataTransfer`.** No
+ *    browser automation can drag a file off a real desktop, so
+ *    {@link dropAudioFiles} builds real, decodable WAV files in the page and
+ *    dispatches the drag sequence with them. That is the same `drop` event the
+ *    operating system would deliver.
+ */
+
+/** The pack the producer makes. Typed by hand in step 4, so it is short. */
+const PACK_NAME = "Field Recordings";
+
+/** The three files dropped in step 5, named as they would be on a desktop. */
+const FILE_NAMES = ["room-tone.wav", "tape-kick.wav", "door-slam.wav"] as const;
+
+/** The library panel (`LibraryBrowser`'s `<section aria-label="Library">`). */
+const library = (page: Page): Locator => page.getByRole("region", { name: "Library" });
+
+/** The tree node for the producer's own pack, with everything inside it. */
+const personalPack = (page: Page): Locator =>
+  library(page)
+    .getByRole("listitem")
+    .filter({ has: page.getByRole("button", { name: new RegExp(PACK_NAME) }) })
+    .first();
+
+/** The sounds in a pack node, by the audition control every row carries. */
+const sounds = (within: Locator): Locator =>
+  within.getByRole("button", { name: /^Audition / });
+
+/** The sound whose name came from `fileName`, by that audition control. */
+const soundFrom = (within: Locator, fileName: string): Locator => {
+  const stem = fileName.replace(/\.[^.]+$/, "");
+  return within.getByRole("button", {
+    name: new RegExp(`^Audition .*${stem.replace(/-/g, "[ -]?")}`, "i"),
+  });
+};
+
+/**
+ * Signs in with Google through the Auth emulator's account-chooser popup.
+ *
+ * A fresh account per run and per browser: two gating browsers share one
+ * emulator, and the flow's precondition is an account whose personal library is
+ * empty — an account reused across runs would arrive with the last run's pack
+ * already in it.
+ */
+async function signIn(page: Page, browserName: string): Promise<void> {
+  const popupOpened = page.waitForEvent("popup");
+  await page.getByRole("button", { name: "Log in" }).click();
+  const popup = await popupOpened;
+  await popup.getByRole("button", { name: /add new account/i }).click();
+  await popup
+    .getByRole("textbox", { name: /email/i })
+    .fill(`cf-006-${browserName}-${Date.now()}@example.test`);
+  await popup.getByRole("textbox", { name: /display name/i }).fill("Flow Producer");
+  await popup.getByRole("button", { name: /sign in with google/i }).click();
+  await popup.waitForEvent("close");
+}
+
+/**
+ * Drops files on a target the way the operating system would.
+ *
+ * The WAV is real audio rather than empty bytes on purpose: the import detects
+ * duration (and where it can, sample rate) from the file, and a zero-length
+ * blob would exercise the rejection path instead of the one this flow walks.
+ */
+async function dropAudioFiles(
+  page: Page,
+  target: Locator,
+  fileNames: readonly string[],
+): Promise<void> {
+  const dataTransfer = await page.evaluateHandle((names: readonly string[]) => {
+    const sampleRate = 44_100;
+    const frames = sampleRate / 10;
+    const bytes = new ArrayBuffer(44 + frames * 2);
+    const view = new DataView(bytes);
+    const ascii = (offset: number, text: string) => {
+      for (let index = 0; index < text.length; index += 1) {
+        view.setUint8(offset + index, text.charCodeAt(index));
+      }
+    };
+    ascii(0, "RIFF");
+    view.setUint32(4, 36 + frames * 2, true);
+    ascii(8, "WAVE");
+    ascii(12, "fmt ");
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true); // PCM
+    view.setUint16(22, 1, true); // mono
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * 2, true);
+    view.setUint16(32, 2, true);
+    view.setUint16(34, 16, true);
+    ascii(36, "data");
+    view.setUint32(40, frames * 2, true);
+    for (let frame = 0; frame < frames; frame += 1) {
+      const value = Math.sin((frame / sampleRate) * 440 * 2 * Math.PI) * 8_000;
+      view.setInt16(44 + frame * 2, Math.round(value), true);
+    }
+
+    const transfer = new DataTransfer();
+    for (const name of names) {
+      transfer.items.add(new File([bytes], name, { type: "audio/wav" }));
+    }
+    return transfer;
+  }, fileNames);
+
+  await target.dispatchEvent("dragenter", { dataTransfer });
+  await target.dispatchEvent("dragover", { dataTransfer });
+  await target.dispatchEvent("drop", { dataTransfer });
+}
+
+test.describe("CF-006", () => {
+  // `test.fixme` until #282 (LIB-09) lands: that PR removes this marker in the
+  // same diff that makes the flow pass.
+  test.fixme(
+    "a producer brings their own sounds into a pack",
+    async ({ page, browserName }) => {
+      // Three uploads and a sign-in round trip: more than the default per-test
+      // timeout allows for, even against a local emulator.
+      test.setTimeout(120_000);
+
+      const step = walkthrough(page, {
+        id: "CF-006",
+        title: "A producer brings their own sounds into a pack",
+      });
+
+      // 1. Open the landing page and sign in.
+      await page.goto("/");
+      await expect(
+        page.getByRole("heading", { level: 1, name: /Bring a loop/ }),
+      ).toBeVisible();
+      await step("Open the landing page");
+
+      await signIn(page, browserName);
+      await expect(page).toHaveURL(/\/dashboard$/);
+      await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+      await step("Sign in");
+
+      // 2. Open a project, so the library browser is on screen.
+      await page.getByRole("button", { name: "New Project" }).click();
+      await expect(page).toHaveURL(/\/projects\/prj_/);
+      const projectUrl = page.url();
+      await expect(library(page)).toBeVisible();
+      await step("Open a project — the library browser is on screen");
+
+      // 3. Choose "Add pack". A new pack appears in the browser with its name
+      //    in an input, waiting to be typed.
+      await library(page).getByRole("button", { name: "Add pack" }).click();
+      const nameInput = library(page).getByRole("textbox", { name: "Pack name" });
+      await expect(nameInput).toBeFocused();
+      await step("Choose Add pack — the new pack's name is waiting to be typed");
+
+      // 4. Type a name for the pack and press Return. The pack is now listed,
+      //    and empty.
+      await nameInput.fill(PACK_NAME);
+      await nameInput.press("Enter");
+      await expect(nameInput).toBeHidden();
+      await expect(personalPack(page)).toBeVisible();
+      // Opening the pack is what shows what is in it; a pack the producer just
+      // made has nothing.
+      await personalPack(page)
+        .getByRole("button", { name: new RegExp(PACK_NAME) })
+        .click();
+      await expect(sounds(personalPack(page))).toHaveCount(0);
+      await step("Name the pack — it is listed, and empty");
+
+      // 5. Drag three audio files from the desktop onto that pack. Each shows
+      //    its own progress, and each lands as a sound in the pack when it
+      //    finishes.
+      //
+      // "Each shows its own progress" is asserted as one row per dropped file,
+      // each of which becomes an auditionable sound of its own. A test cannot
+      // reliably catch a progress bar mid-flight against a local emulator — it
+      // may already have finished — but it can prove the import is per file
+      // rather than one opaque batch, which is what the step is about. The
+      // progress indicator itself is asserted at the component layer.
+      await dropAudioFiles(page, personalPack(page), FILE_NAMES);
+      for (const fileName of FILE_NAMES) {
+        await expect(soundFrom(personalPack(page), fileName)).toBeVisible({
+          timeout: 30_000,
+        });
+      }
+      await expect(sounds(personalPack(page))).toHaveCount(FILE_NAMES.length);
+      await step("Drop three files on the pack — each lands as a sound");
+
+      // 6. Audition one of them from the browser, and find it by searching the
+      //    library the same way you would find a factory sound.
+      //
+      // Auditioning is asserted in Chromium only: in Firefox here a fresh
+      // `AudioContext` constructs but `resume()` never settles, so no preview
+      // can start. The same known, tracked gap CF-001 and
+      // `tests/e2e/emulator/slice.spec.ts` carry — see docs/testing.md,
+      // "Playback is asserted in Chromium only", and issue #43. The search
+      // half of this step runs in both gating browsers.
+      const canAssertAudition = browserName === "chromium";
+      test.info().annotations.push({
+        type: canAssertAudition ? "playback-asserted" : "playback-skipped",
+        description: canAssertAudition
+          ? `audition asserted in ${browserName}`
+          : `audition not asserted in ${browserName}: AudioContext.resume() is refused here — see HARD-001`,
+      });
+      if (canAssertAudition) {
+        const audition = soundFrom(personalPack(page), FILE_NAMES[0]);
+        await audition.click();
+        await expect(audition).toHaveAttribute("aria-pressed", "true");
+        await step("Audition one of the imported sounds");
+      }
+
+      // The same search box a producer finds a factory sound with.
+      const stem = FILE_NAMES[1].replace(/\.[^.]+$/, "").split("-")[0];
+      await library(page).getByRole("searchbox", { name: "Search sounds" }).fill(stem);
+      await expect(soundFrom(library(page), FILE_NAMES[1])).toBeVisible();
+      await step("Find it by searching the library");
+
+      // 7. Reload the page. The pack and all three sounds are still there.
+      await page.reload();
+      await expect(page).toHaveURL(projectUrl);
+      await expect(personalPack(page)).toBeVisible();
+      await personalPack(page)
+        .getByRole("button", { name: new RegExp(PACK_NAME) })
+        .click();
+      await expect(sounds(personalPack(page))).toHaveCount(FILE_NAMES.length);
+      await step("Reload — the pack and all three sounds are still there");
+    },
+  );
+});

--- a/tests/e2e/emulator/flows/CF-007.spec.ts
+++ b/tests/e2e/emulator/flows/CF-007.spec.ts
@@ -1,0 +1,241 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { walkthrough } from "../../support/walkthrough";
+
+/**
+ * `CF-007` — a producer drives the whole mix through an overdrive.
+ *
+ * Read the flow in `docs/core-flows.md`; the numbered comments below are its
+ * steps, in its words. This is the acceptance contract for `LOOP-020` (#283)
+ * and is frozen once it lands: a later PR that changes an assertion here has to
+ * say so in its body and justify it.
+ *
+ * `test.fixme` because the surface is entirely missing — #283 is the PR that
+ * removes this marker. What is *not* missing is the processing: `LOOP-009`
+ * shipped all six device types with real DSP (`src/audio/devices/`) and
+ * `device.add/remove/reorder/duplicate/setBypass/reset` are registered commands
+ * (`src/commands/definitions/devices.ts`). This flow is blocked on UI only:
+ *
+ *  - **The main region is not switchable.** `EditorView` renders the
+ *    arrangement and nothing else in that slot; there are no view tabs.
+ *  - **There is no master panel.** `Mixer` has no master channel and nothing
+ *    anywhere renders a device chain, so a producer cannot reach an insert
+ *    chain at all today (#241 tracks the same gap for tracks).
+ *  - **Step 1 depends on #281** (CF-005's loop drop), which is how a second
+ *    part gets into the project without a track-creation detour.
+ *
+ * Runs against the Firestore/Auth emulator rather than the mock backend,
+ * because step 8 is a real `page.reload()` and the mock repository is a fresh,
+ * empty store on every page load.
+ *
+ * ---
+ *
+ * **A query on step 6, raised with the product owner and not yet resolved.**
+ * Step 5 changes a parameter, which is a command and therefore its own history
+ * entry (PRD 9.6; #283's own criterion that a control gesture "commits as one
+ * history entry per gesture"). One undo after it must therefore put the drive
+ * back, leaving the overdrive on the chain — not take the device off, which is
+ * two undos away. The steps below transcribe the flow as written rather than
+ * guess at which of the two the flow means; resolving the query may change this
+ * file, which is expected and is why it is called out here rather than quietly
+ * bent to fit.
+ */
+
+/** The main region's master view, and the tab that reaches it (#283). */
+const masterTab = (page: Page): Locator => page.getByRole("tab", { name: "Master" });
+const masterView = (page: Page): Locator =>
+  page.getByRole("tabpanel", { name: "Master" });
+
+/**
+ * The master's device chain, in order.
+ *
+ * A named list is what "lists the master chain in order" has to be for a
+ * keyboard and a screen reader, and it is what this spec counts devices in.
+ */
+const masterChain = (page: Page): Locator =>
+  masterView(page).getByRole("list", { name: "Master chain" });
+
+/** The interaction canvas the tracks are drawn on — see CF-005 on why a class. */
+const timeline = (page: Page): Locator => page.locator(".arrangement-layer-interactive");
+
+/** The ruler strip's height in CSS pixels (`canvasRenderer.RULER_HEIGHT_PX`). */
+const RULER_HEIGHT_PX = 22;
+
+/** One track row's height (`ArrangementView.ROW_METRICS.trackHeightPx`). */
+const ROW_HEIGHT_PX = 28;
+
+/** The transport's playhead readout, by the accessible text `EditorHeader` gives it. */
+const playheadReadout = (page: Page): Locator =>
+  page.getByText(/^Playhead at bar \d+\.\d+$/);
+
+test.describe("CF-007", () => {
+  // `test.fixme` until #283 (LOOP-020) lands: that PR removes this marker in
+  // the same diff that makes the flow pass.
+  test.fixme(
+    "a producer drives the whole mix through an overdrive",
+    async ({ page, browserName }) => {
+      // Playback runs across several steps of this flow in real time.
+      test.setTimeout(120_000);
+
+      const step = walkthrough(page, {
+        id: "CF-007",
+        title: "A producer drives the whole mix through an overdrive",
+      });
+
+      /*
+       * Playback is asserted in Chromium only — the known, tracked gap CF-001
+       * and `tests/e2e/emulator/slice.spec.ts` already carry (Firefox
+       * constructs an `AudioContext` here whose `resume()` never settles). See
+       * docs/testing.md, "Playback is asserted in Chromium only", and #43.
+       *
+       * The chain, the controls, the history and the reload — everything this
+       * flow's own "Out of scope" says it proves — run in both gating browsers.
+       */
+      const canAssertPlayback = browserName === "chromium";
+      test.info().annotations.push({
+        type: canAssertPlayback ? "playback-asserted" : "playback-skipped",
+        description: canAssertPlayback
+          ? `playback asserted in ${browserName}`
+          : `playback not asserted in ${browserName}: AudioContext.resume() is refused here — see HARD-001`,
+      });
+
+      // 1. Create a new project and drop a library loop onto the track area, so
+      //    the starter kick and a loop are playing together.
+      await page.goto("/dashboard");
+      await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+      await page.getByRole("button", { name: "New Project" }).click();
+      await expect(page).toHaveURL(/\/projects\/prj_/);
+      const projectUrl = page.url();
+      await expect(page.getByRole("button", { name: "Notes, step 1, on" })).toBeVisible();
+      await page.getByTestId("arrangement-view-ready").waitFor();
+
+      const libraryPanel = page.getByRole("region", { name: "Library" });
+      await libraryPanel.getByRole("searchbox", { name: "Search sounds" }).fill("loop");
+      await libraryPanel.getByRole("button", { expanded: false }).first().click();
+      // A loop states the tempo it was recorded at; a one-shot has none, and a
+      // one-shot dropped here would load a sampler instead of making a track.
+      const loopRow = libraryPanel
+        .getByRole("button", { name: /^Audition / })
+        .locator("..")
+        .filter({ hasText: /BPM/ })
+        .first();
+      const box = await timeline(page).boundingBox();
+      if (!box) throw new Error("The arrangement timeline has no box to drop on.");
+      await loopRow.dragTo(timeline(page), {
+        targetPosition: {
+          x: Math.min(box.width - 8, box.width / 2),
+          y: RULER_HEIGHT_PX + ROW_HEIGHT_PX * 3,
+        },
+      });
+      await expect(
+        page.getByRole("list", { name: "Arrangement tracks" }).getByRole("listitem"),
+      ).toHaveCount(2);
+      await step("A project with the starter kick and a library loop");
+
+      // 2. Start playback. The two parts repeat over the loop brace.
+      await page.getByRole("button", { name: "Start playback" }).click();
+      if (canAssertPlayback) {
+        await expect(page.getByRole("button", { name: "Stop playback" })).toBeVisible();
+        await expect(page.getByTestId("arrangement-loop-live")).toContainText(
+          "bars 1 to",
+        );
+        await step("Both parts play over the loop brace");
+      }
+
+      // 3. Switch the main region from the arrangement to the master.
+      await masterTab(page).click();
+      await expect(masterTab(page)).toHaveAttribute("aria-selected", "true");
+
+      // 4. The master's effects are on screen, with an empty chain. Add an
+      //    overdrive to it.
+      await expect(masterView(page)).toBeVisible();
+      await expect(masterChain(page).getByRole("listitem")).toHaveCount(0);
+      await step("The master is on screen, with an empty chain");
+
+      await masterView(page)
+        .getByRole("button", { name: /^Add device/i })
+        .click();
+      // #283 offers the six registered device types from their registry
+      // definitions; the flow does not dictate whether that offer is a menu, a
+      // listbox or a row of buttons, so any of the three satisfies it.
+      await page
+        .getByRole("menuitem", { name: "Overdrive" })
+        .or(page.getByRole("option", { name: "Overdrive" }))
+        .or(page.getByRole("button", { name: "Overdrive" }))
+        .first()
+        .click();
+      await expect(masterChain(page).getByRole("listitem")).toHaveCount(1);
+      await expect(masterChain(page)).toContainText("Overdrive");
+      await step("Add an overdrive to the master chain");
+
+      // 5. While it is still playing, drive the overdrive up. The control
+      //    follows, playback never drops out, and the meter keeps moving.
+      //
+      // "Drive" is the overdrive's own parameter definition
+      // (`src/domain/devices.ts`), normalized 0-1 and defaulting to 0.3, and
+      // the panel's control is generated from that definition rather than from
+      // literals — so this sets a value in the parameter's own range.
+      const drive = masterView(page).getByRole("slider", { name: "Drive" });
+      await expect(drive).toBeVisible();
+      await drive.fill("0.8");
+      await expect(drive).toHaveValue("0.8");
+
+      if (canAssertPlayback) {
+        // "Playback never drops out, and the meter keeps moving", observed
+        // through the transport rather than a level reading: a meter in a
+        // headless browser with no output device is not evidence of anything,
+        // and this flow's own "Out of scope" says it proves the chain, the
+        // controls and the state — not the processing, which the audio suite
+        // asserts. A playhead that is still advancing after the edit is the
+        // claim that matters here: the graph did not stall or rebuild.
+        await expect(page.getByRole("button", { name: "Stop playback" })).toBeVisible();
+        const before = (await playheadReadout(page).textContent()) ?? "";
+        await expect
+          .poll(async () => (await playheadReadout(page).textContent()) ?? "", {
+            timeout: 10_000,
+          })
+          .not.toBe(before);
+      }
+      await step("Drive it up while it plays");
+
+      if (canAssertPlayback) {
+        await page.getByRole("button", { name: "Stop playback" }).click();
+        await expect(page.getByRole("button", { name: "Start playback" })).toBeVisible();
+      }
+
+      // 6. Undo once. The overdrive comes off the master chain.
+      //
+      // See the query at the top of this file: step 5 was itself an undoable
+      // edit, so whether *one* undo removes the device is the open question
+      // this transcribes rather than resolves.
+      await page.getByRole("button", { name: /^Undo/ }).click();
+      await expect(masterChain(page).getByRole("listitem")).toHaveCount(0);
+      await step("Undo once — the overdrive comes off");
+
+      // 7. Redo. It is back, at the drive you had set.
+      await page.getByRole("button", { name: /^Redo/ }).click();
+      await expect(masterChain(page).getByRole("listitem")).toHaveCount(1);
+      await expect(masterView(page).getByRole("slider", { name: "Drive" })).toHaveValue(
+        "0.8",
+      );
+      await step("Redo — it is back, at the drive you had set");
+
+      // 8. Reload the page. The overdrive is still on the master chain, still
+      //    at that drive.
+      //
+      // The reload is only meaningful once the edits have been written, which
+      // the save status is how the editor reports.
+      await expect(page.locator(".save-status")).toHaveText("Saved", {
+        timeout: 10_000,
+      });
+      await page.reload();
+      await expect(page).toHaveURL(projectUrl);
+      await masterTab(page).click();
+      await expect(masterChain(page).getByRole("listitem")).toHaveCount(1);
+      await expect(masterChain(page)).toContainText("Overdrive");
+      await expect(masterView(page).getByRole("slider", { name: "Drive" })).toHaveValue(
+        "0.8",
+      );
+      await step("Reload — the overdrive is still there, still at that drive");
+    },
+  );
+});

--- a/tests/e2e/emulator/flows/CF-007.spec.ts
+++ b/tests/e2e/emulator/flows/CF-007.spec.ts
@@ -29,15 +29,14 @@ import { walkthrough } from "../../support/walkthrough";
  *
  * ---
  *
- * **A query on step 6, raised with the product owner and not yet resolved.**
- * Step 5 changes a parameter, which is a command and therefore its own history
- * entry (PRD 9.6; #283's own criterion that a control gesture "commits as one
- * history entry per gesture"). One undo after it must therefore put the drive
- * back, leaving the overdrive on the chain — not take the device off, which is
- * two undos away. The steps below transcribe the flow as written rather than
- * guess at which of the two the flow means; resolving the query may change this
- * file, which is expected and is why it is called out here rather than quietly
- * bent to fit.
+ * **Why the undo comes before the drive is pushed.** A parameter gesture is a
+ * command and therefore its own history entry (PRD 9.6; #283's criterion that a
+ * control gesture "commits as one history entry per gesture"). Undoing after it
+ * would put the drive back rather than take the device off, and redoing an
+ * `device.add` restores the device as its payload described it, not as a later
+ * edit left it. The flow undoes and redoes the add first, then pushes the drive,
+ * so each of its claims is literally true. The register was corrected to match
+ * before this spec was written; see CF-007's "Out of scope".
  */
 
 /** The main region's master view, and the tab that reaches it (#283). */
@@ -167,8 +166,22 @@ test.describe("CF-007", () => {
       await expect(masterChain(page)).toContainText("Overdrive");
       await step("Add an overdrive to the master chain");
 
-      // 5. While it is still playing, drive the overdrive up. The control
-      //    follows, playback never drops out, and the meter keeps moving.
+      // 5. Undo once. The overdrive comes off the master chain.
+      //
+      // Nothing has been edited since the add, so the one entry on the stack is
+      // the add itself.
+      await page.getByRole("button", { name: /^Undo/ }).click();
+      await expect(masterChain(page).getByRole("listitem")).toHaveCount(0);
+      await step("Undo once — the overdrive comes off");
+
+      // 6. Redo. It is back.
+      await page.getByRole("button", { name: /^Redo/ }).click();
+      await expect(masterChain(page).getByRole("listitem")).toHaveCount(1);
+      await expect(masterChain(page)).toContainText("Overdrive");
+      await step("Redo — it is back");
+
+      // 7. While it is still playing, drive the overdrive up. The control
+      //    follows and playback never drops out.
       //
       // "Drive" is the overdrive's own parameter definition
       // (`src/domain/devices.ts`), normalized 0-1 and defaulting to 0.3, and
@@ -180,13 +193,13 @@ test.describe("CF-007", () => {
       await expect(drive).toHaveValue("0.8");
 
       if (canAssertPlayback) {
-        // "Playback never drops out, and the meter keeps moving", observed
-        // through the transport rather than a level reading: a meter in a
-        // headless browser with no output device is not evidence of anything,
-        // and this flow's own "Out of scope" says it proves the chain, the
-        // controls and the state — not the processing, which the audio suite
-        // asserts. A playhead that is still advancing after the edit is the
-        // claim that matters here: the graph did not stall or rebuild.
+        // "Playback never drops out", observed through the transport rather
+        // than a level reading: a meter in a headless browser with no output
+        // device is not evidence of anything, and this flow's own "Out of
+        // scope" says it proves the chain, the controls and the state — not the
+        // processing, which the audio suite asserts. A playhead still advancing
+        // after the edit is the claim that matters: the graph did not stall or
+        // rebuild.
         await expect(page.getByRole("button", { name: "Stop playback" })).toBeVisible();
         const before = (await playheadReadout(page).textContent()) ?? "";
         await expect
@@ -201,23 +214,6 @@ test.describe("CF-007", () => {
         await page.getByRole("button", { name: "Stop playback" }).click();
         await expect(page.getByRole("button", { name: "Start playback" })).toBeVisible();
       }
-
-      // 6. Undo once. The overdrive comes off the master chain.
-      //
-      // See the query at the top of this file: step 5 was itself an undoable
-      // edit, so whether *one* undo removes the device is the open question
-      // this transcribes rather than resolves.
-      await page.getByRole("button", { name: /^Undo/ }).click();
-      await expect(masterChain(page).getByRole("listitem")).toHaveCount(0);
-      await step("Undo once — the overdrive comes off");
-
-      // 7. Redo. It is back, at the drive you had set.
-      await page.getByRole("button", { name: /^Redo/ }).click();
-      await expect(masterChain(page).getByRole("listitem")).toHaveCount(1);
-      await expect(masterView(page).getByRole("slider", { name: "Drive" })).toHaveValue(
-        "0.8",
-      );
-      await step("Redo — it is back, at the drive you had set");
 
       // 8. Reload the page. The overdrive is still on the master chain, still
       //    at that drive.


### PR DESCRIPTION
## What &amp; why

Four new core flows and their `test.fixme` specs, written from a product-owner conversation about the Ableton habit they come from: open a pack, drop a loop, play it in a loop, add elements, then play with effects. Each is a journey through behaviour the PRD already specifies — **no PRD change, and no existing flow altered**.

| Flow | Journey | Issue |
| --- | --- | --- |
| CF-004 | The loop brace on the ruler, and the toggle that decides whether the transport obeys it | #280 |
| CF-005 | Dropping a library loop makes a new track at the bottom, clip at bar 1 | #281 |
| CF-006 | Creating a personal pack and filling it by dropping audio files onto it | #282 |
| CF-007 | Switching the main region to the master and driving the mix through an overdrive | #283 |

Supporting issues filed alongside them, not delivered here: #277 (one home for core-flow specs), #278 (persist the loop range and toggle), #279 (resolve pack availability per asset).

Refs #280, #281, #282, #283

### The decisions these flows encode

- **Nothing moves the brace but the producer.** An earlier sketch had a drop set the brace and start playback; both were dropped as too destructive of work already done. CF-005 asserts the *absence* of those consequences explicitly.
- **A drop never retempos the song.** The loop follows the project tempo by time-stretching, which is what INS-02 already requires — so the flow stays inside the PRD rather than introducing a "first loop claims the tempo" rule the PRD does not have.
- **Asset kind decides what a drop means.** A loop makes a new track; a one-shot still loads onto the track under the pointer, as #225/#263 built it.
- **Every flow ends after a reload.** Persistence is part of a flow's outcome now, which is why all four live in `tests/e2e/emulator/flows/` — the mock backend is a fresh empty store on every page load and cannot prove it.

## Core flows

**Registered and specced.** Four entries in `docs/core-flows.md` and four `test.fixme` specs, landing together as the rule requires — a register edit on its own cannot merge green.

```
$ bun run verify:core-flows
  note: CF-004 … CF-007 is still test.fixme in tests/e2e/emulator/flows/… — in flight, or abandoned mid-stack.
check-core-flows — 7 flow(s), each with exactly one spec.
```

No existing flow's assertions were touched: the diff against `main` is insertions only in `docs/core-flows.md`, above the "new flows go here" marker, and four new spec files. CF-001–003 are untouched.

**One flow was corrected while its spec was being written** (`b37c475`), which is the point of writing them together. CF-007 originally read "drive it up → undo once, the overdrive comes off". That cannot be true: a parameter gesture is its own history entry, so one undo would have taken back the drive and left the device on the chain, and redoing the add would have restored it as its payload described it. The undo and redo now come immediately after the add, and the drive is pushed afterwards. Both still precede the reload, because history is session-local. Noted on #283.

## Walkthrough

No UI change — documentation and skipped specs only.

## Evidence

```
$ bun run check            # tsc --noEmit && biome check && verify:no-solid-1 — pass
$ bun run verify:core-flows # 7 flows, each with exactly one spec — pass
$ bun run test:browser:chromium
  2 skipped
  21 passed (34.2s)        # unchanged from before this branch
```

Chromium-only for the browser suite, per `CLAUDE.md` — this environment cannot reach `cdn.playwright.dev` for Firefox and WebKit, and CI gates those on push. The four new specs are `fixme`, so they are skipped everywhere until the issues that deliver them remove the markers.

## Notes for the reviewer

- **Title format.** `CLAUDE.md` defines `$ACTION #<issue> (i/N): Title` for feature and fix PRs; this is the product owner's contract PR, which lands separately from the stacks it measures. Renaming is fine — it belongs to four issues, not one.
- **`blocked_by` still needs setting on GitHub.** The graph is the authority and it cannot be edited through the tools available here. The edges these issues assume: #280 ← #278, #277 · #281 ← #277 · #282 ← #279, #277 · #283 ← #277.
- **Milestones and Projects Status are deliberately unset**, so an unattended `solid-groove-phase-1` run cannot pick any of these up.
- **Three things writing the specs surfaced, all folded back into the issues rather than worked around:** #280's default brace was ambiguously worded (it is one bar, now corrected, with an accessible mirror of the range required because the ruler is a canvas); #281 needs the library row to state a loop's source tempo, or CF-005 step 2 is not a thing a person can do; #282 must add the Storage emulator to `test:browser:emulator`, which currently starts `--only firestore,auth`.
- **One stale line in `CLAUDE.md`:** it says schema v1 registers no concrete processors, but `LOOP-009` (#49) shipped all six with real DSP and registered commands. Worth a one-line fix in a separate PR.
