### PR TITLE
Fix #258 (1/1): Arrangement shortcuts go dead while the piano roll is showing

### DIFF
--- a/src/arrangement/ArrangementView.test.tsx
+++ b/src/arrangement/ArrangementView.test.tsx
@@ -224,6 +224,41 @@ describe("placement editing wiring (ARR-002)", () => {
     expect(selectedPlacementIds(container)).toEqual([placementId]);
   });
 
+  /**
+   * The preview showed two cyan boxes on one track at once: the shell's ARR-01
+   * bar range and the ARR-002 placement selection, each left standing by the
+   * click that made the other. "There should only be a single selection."
+   */
+  it("keeps exactly one arrangement selection live at a time", async () => {
+    const { renderView, placementId } = await setUpEditing();
+    const { container } = renderView();
+    const canvas = interactionCanvasOf(container);
+    const rowY = RULER_HEIGHT_PX + ROW_HEIGHT_PX / 2;
+    const barRangeText = () =>
+      screen.getByTestId("arrangement-selection-live").textContent;
+    const clickAt = (ticks: number) => {
+      firePointer(canvas, "pointerdown", {
+        clientX: ticks * PIXELS_PER_TICK,
+        clientY: rowY,
+      });
+      firePointer(canvas, "pointerup", { clientX: 0, clientY: 0 });
+    };
+
+    // Empty space, three bars along: the shell takes a bar range.
+    clickAt(TICKS_PER_BAR * 3);
+    expect(barRangeText()).toMatch(/^Selected /);
+
+    // The placement now becomes the only selection.
+    clickAt(TICKS_PER_BAR / 2);
+    expect(selectedPlacementIds(container)).toEqual([placementId]);
+    expect(barRangeText()).toBe("No selection");
+
+    // And back out to empty space: the bar range is the only one again.
+    clickAt(TICKS_PER_BAR * 3);
+    expect(barRangeText()).toMatch(/^Selected /);
+    expect(selectedPlacementIds(container)).toEqual([]);
+  });
+
   it("dragging a placement's body moves it, bar-snapped, through the command layer", async () => {
     const { session, renderView, placementId } = await setUpEditing();
     const { container } = renderView();

--- a/src/arrangement/ArrangementView.tsx
+++ b/src/arrangement/ArrangementView.tsx
@@ -436,6 +436,9 @@ export default function ArrangementView(props: ArrangementViewProps) {
       const hit = shell.hitTestAt(x, y);
       if (hit.kind === "placement") {
         const { tick } = shell.pointToArrangement(x, y);
+        // One selection at a time: the placement becomes it, so the shell's
+        // bar range from an earlier click stops being painted alongside it.
+        shell.setSelection(null);
         editing.beginDrag(hit.placementId, hit.handle, tick);
         activePointerId = event.pointerId;
         (event.currentTarget as Element).setPointerCapture?.(event.pointerId);
@@ -445,6 +448,9 @@ export default function ArrangementView(props: ArrangementViewProps) {
       }
     }
 
+    // ...and the other way round: a bar range is the selection now, so the
+    // placement selection it replaces is dropped rather than left on screen.
+    editing?.clearSelection();
     const selection = shell.handlePointerDown(x, y);
     bumpState();
     if (selection) noteFirstUse();
@@ -495,6 +501,7 @@ export default function ArrangementView(props: ArrangementViewProps) {
     if (!shell) return;
     const track = projection().tracks[rowIndex];
     if (!track) return;
+    editing?.clearSelection();
     shell.setSelection({
       trackId: track.id,
       startTick: 0,

--- a/src/arrangement/placementEditingController.test.ts
+++ b/src/arrangement/placementEditingController.test.ts
@@ -121,54 +121,19 @@ describe("discrete operations", () => {
   });
 });
 
-describe("paste anchor (#258)", () => {
+describe("paste anchor", () => {
   /**
-   * Reported from the preview: with a placement selected at bar 2 and the
-   * playhead at bar 1, paste landed at bar 1. The playhead is the right anchor
-   * only "with no explicit target selected", which the handler's own comment
-   * says — a live selection *is* that explicit target, and `edit.paste`
-   * declares `ableton: { kind: "follows" }`, where Ableton pastes at the
-   * selection. Verified against Ableton by the reporter.
+   * Paste lands at the anchor the caller passes — the playhead, from
+   * `edit.paste`. PR #285 briefly anchored it at the selection instead, to
+   * match Ableton; that produced a copy stacked invisibly on its own source,
+   * and dodging the stack needed rules this schema cannot express yet (no
+   * overlap invariant, no overwrite semantics). The anchoring question is
+   * #290/#291; until they are settled, paste stays predictable.
    */
-  it("pastes at the selection, not the playhead, when something is selected", () => {
-    const h = harness();
-    const first = h.placementId();
-    h.editing.select(first);
-    h.editing.copy();
-
-    // The playhead is somewhere else entirely.
-    h.editing.paste(TICKS_PER_BAR * 4);
-
-    const placements = h.getProject().song.placements;
-    expect(placements).toHaveLength(2);
-    const source = placements.find((p) => p.id === first);
-    if (!source) throw new Error("the copied placement is gone");
-    const pasted = placements.find((p) => p.id !== first);
-    // Anchored to the selection at bar 1, not the playhead at bar 5 — and
-    // immediately *after* its own source rather than on top of it. The
-    // preview showed the stacked version: "Copying a clip then pasting it
-    // results in 2 clips at the current location."
-    expect(pasted?.startTicks).toBe(source.startTicks + source.durationTicks);
-  });
-
-  it("cascades a repeated paste rather than stacking copies", () => {
+  it("pastes at the caller's anchor", () => {
     const h = harness();
     h.editing.select(h.placementId());
     h.editing.copy();
-
-    h.editing.paste(TICKS_PER_BAR * 4);
-    h.editing.paste(TICKS_PER_BAR * 4);
-
-    const starts = h.getProject().song.placements.map((p) => p.startTicks);
-    expect(starts).toHaveLength(3);
-    expect(new Set(starts).size).toBe(3);
-  });
-
-  it("still pastes at the caller's anchor when nothing is selected", () => {
-    const h = harness();
-    h.editing.select(h.placementId());
-    h.editing.copy();
-    h.editing.clearSelection();
 
     h.editing.paste(TICKS_PER_BAR * 4);
 

--- a/src/arrangement/placementEditingController.test.ts
+++ b/src/arrangement/placementEditingController.test.ts
@@ -120,3 +120,43 @@ describe("discrete operations", () => {
     expect(h.getProject().song.placements[0].looped).toBe(false);
   });
 });
+
+describe("paste anchor (#258)", () => {
+  /**
+   * Reported from the preview: with a placement selected at bar 2 and the
+   * playhead at bar 1, paste landed at bar 1. The playhead is the right anchor
+   * only "with no explicit target selected", which the handler's own comment
+   * says — a live selection *is* that explicit target, and `edit.paste`
+   * declares `ableton: { kind: "follows" }`, where Ableton pastes at the
+   * selection. Verified against Ableton by the reporter.
+   */
+  it("pastes at the selection, not the playhead, when something is selected", () => {
+    const h = harness();
+    const first = h.placementId();
+    h.editing.select(first);
+    h.editing.copy();
+
+    // The playhead is somewhere else entirely.
+    h.editing.paste(TICKS_PER_BAR * 4);
+
+    const placements = h.getProject().song.placements;
+    expect(placements).toHaveLength(2);
+    const selectedStart = placements.find((p) => p.id === first)?.startTicks;
+    const pasted = placements.find((p) => p.id !== first);
+    expect(pasted?.startTicks).toBe(selectedStart);
+  });
+
+  it("still pastes at the caller's anchor when nothing is selected", () => {
+    const h = harness();
+    h.editing.select(h.placementId());
+    h.editing.copy();
+    h.editing.clearSelection();
+
+    h.editing.paste(TICKS_PER_BAR * 4);
+
+    const pasted = h
+      .getProject()
+      .song.placements.find((p) => p.startTicks === TICKS_PER_BAR * 4);
+    expect(pasted).toBeDefined();
+  });
+});

--- a/src/arrangement/placementEditingController.test.ts
+++ b/src/arrangement/placementEditingController.test.ts
@@ -141,9 +141,27 @@ describe("paste anchor (#258)", () => {
 
     const placements = h.getProject().song.placements;
     expect(placements).toHaveLength(2);
-    const selectedStart = placements.find((p) => p.id === first)?.startTicks;
+    const source = placements.find((p) => p.id === first);
+    if (!source) throw new Error("the copied placement is gone");
     const pasted = placements.find((p) => p.id !== first);
-    expect(pasted?.startTicks).toBe(selectedStart);
+    // Anchored to the selection at bar 1, not the playhead at bar 5 — and
+    // immediately *after* its own source rather than on top of it. The
+    // preview showed the stacked version: "Copying a clip then pasting it
+    // results in 2 clips at the current location."
+    expect(pasted?.startTicks).toBe(source.startTicks + source.durationTicks);
+  });
+
+  it("cascades a repeated paste rather than stacking copies", () => {
+    const h = harness();
+    h.editing.select(h.placementId());
+    h.editing.copy();
+
+    h.editing.paste(TICKS_PER_BAR * 4);
+    h.editing.paste(TICKS_PER_BAR * 4);
+
+    const starts = h.getProject().song.placements.map((p) => p.startTicks);
+    expect(starts).toHaveLength(3);
+    expect(new Set(starts).size).toBe(3);
   });
 
   it("still pastes at the caller's anchor when nothing is selected", () => {

--- a/src/arrangement/placementEditingController.ts
+++ b/src/arrangement/placementEditingController.ts
@@ -20,6 +20,7 @@ import type { Analytics } from "../analytics/analytics";
 import type { RawCommandInput } from "../commands/types";
 import type { Project } from "../domain/entities";
 import type { IdFactory, PlacementId } from "../domain/ids";
+import { TICKS_PER_BAR } from "../domain/time";
 import {
   copyPlacements,
   cutPlacements,
@@ -33,9 +34,11 @@ import {
 } from "./placementDuplication";
 import {
   deletePlacements,
+  MAX_ARRANGEMENT_TICKS,
   movePlacement,
   resizePlacement,
   setPlacementLooped,
+  snapToBar,
 } from "./placementGeometry";
 
 /** Applies commands as one transaction; returns whether anything landed. */
@@ -232,6 +235,17 @@ export function createPlacementEditing(options: PlacementEditingOptions) {
     return true;
   };
 
+  /** Everything a paste sets, so "is this copy already exactly here?" is one
+   * string comparison. */
+  const identity = (p: {
+    trackId: string;
+    clipId: string;
+    startTicks: number;
+    durationTicks: number;
+    clipOffsetTicks: number;
+  }): string =>
+    `${p.trackId}|${p.clipId}|${p.startTicks}|${p.durationTicks}|${p.clipOffsetTicks}`;
+
   /**
    * Where a paste lands: the start of the current selection when there is one,
    * and only otherwise the caller's anchor (the playhead).
@@ -242,13 +256,42 @@ export function createPlacementEditing(options: PlacementEditingOptions) {
    * the playhead however deliberately the user had picked a spot (#258).
    * `edit.paste` declares `ableton: { kind: "follows" }`, and Ableton pastes
    * at the selection.
+   *
+   * An anchor whose material the clipboard already holds is advanced past it,
+   * one clipboard-span at a time. After a copy the selection *is* the copied
+   * material, so anchoring there re-created it exactly where it already was —
+   * invisible, and stacked, because schema v1 has no overlap invariant.
+   * Ableton settles that by overwriting (a track there cannot hold two clips
+   * at one position); with no overwrite semantics to lean on, landing the copy
+   * immediately after its source is the outcome that is both visible and
+   * non-destructive, and it makes a repeated paste cascade rather than pile up.
    */
   function pasteAnchor(current: Project, fallbackTicks: number): number {
-    if (selected.length === 0) return fallbackTicks;
     const starts = current.song.placements
       .filter((placement) => selected.includes(placement.id))
       .map((placement) => placement.startTicks);
-    return starts.length === 0 ? fallbackTicks : Math.min(...starts);
+    if (starts.length === 0 || clipboard.length === 0) return fallbackTicks;
+
+    const origin = Math.min(...clipboard.map((entry) => entry.startTicks));
+    const span = Math.max(
+      ...clipboard.map((entry) => entry.startTicks + entry.durationTicks - origin),
+    );
+    // Always at least a bar, so the walk below cannot stall on a snap.
+    const step = Math.max(TICKS_PER_BAR, span);
+    const present = new Set(current.song.placements.map(identity));
+    const alreadyThere = (anchor: number): boolean =>
+      clipboard.every((entry) =>
+        present.has(
+          identity({
+            ...entry,
+            startTicks: snapToBar(anchor) + entry.startTicks - origin,
+          }),
+        ),
+      );
+
+    let anchor = Math.min(...starts);
+    while (anchor + step <= MAX_ARRANGEMENT_TICKS && alreadyThere(anchor)) anchor += step;
+    return anchor;
   }
 
   const paste = (targetTicks: number): boolean => {

--- a/src/arrangement/placementEditingController.ts
+++ b/src/arrangement/placementEditingController.ts
@@ -20,7 +20,6 @@ import type { Analytics } from "../analytics/analytics";
 import type { RawCommandInput } from "../commands/types";
 import type { Project } from "../domain/entities";
 import type { IdFactory, PlacementId } from "../domain/ids";
-import { TICKS_PER_BAR } from "../domain/time";
 import {
   copyPlacements,
   cutPlacements,
@@ -34,11 +33,9 @@ import {
 } from "./placementDuplication";
 import {
   deletePlacements,
-  MAX_ARRANGEMENT_TICKS,
   movePlacement,
   resizePlacement,
   setPlacementLooped,
-  snapToBar,
 } from "./placementGeometry";
 
 /** Applies commands as one transaction; returns whether anything landed. */
@@ -235,76 +232,10 @@ export function createPlacementEditing(options: PlacementEditingOptions) {
     return true;
   };
 
-  /** Everything a paste sets, so "is this copy already exactly here?" is one
-   * string comparison. */
-  const identity = (p: {
-    trackId: string;
-    clipId: string;
-    startTicks: number;
-    durationTicks: number;
-    clipOffsetTicks: number;
-  }): string =>
-    `${p.trackId}|${p.clipId}|${p.startTicks}|${p.durationTicks}|${p.clipOffsetTicks}`;
-
-  /**
-   * Where a paste lands: the start of the current selection when there is one,
-   * and only otherwise the caller's anchor (the playhead).
-   *
-   * The playhead is the right anchor "with no explicit target selected", as
-   * the shortcut handler's own comment puts it — but a live placement
-   * selection *is* that explicit target, and ignoring it sent every paste to
-   * the playhead however deliberately the user had picked a spot (#258).
-   * `edit.paste` declares `ableton: { kind: "follows" }`, and Ableton pastes
-   * at the selection.
-   *
-   * An anchor whose material the clipboard already holds is advanced past it,
-   * one clipboard-span at a time. After a copy the selection *is* the copied
-   * material, so anchoring there re-created it exactly where it already was —
-   * invisible, and stacked, because schema v1 has no overlap invariant.
-   * Ableton settles that by overwriting (a track there cannot hold two clips
-   * at one position); with no overwrite semantics to lean on, landing the copy
-   * immediately after its source is the outcome that is both visible and
-   * non-destructive, and it makes a repeated paste cascade rather than pile up.
-   */
-  function pasteAnchor(current: Project, fallbackTicks: number): number {
-    const starts = current.song.placements
-      .filter((placement) => selected.includes(placement.id))
-      .map((placement) => placement.startTicks);
-    if (starts.length === 0 || clipboard.length === 0) return fallbackTicks;
-
-    const origin = Math.min(...clipboard.map((entry) => entry.startTicks));
-    const span = Math.max(
-      ...clipboard.map((entry) => entry.startTicks + entry.durationTicks - origin),
-    );
-    // Always at least a bar, so the walk below cannot stall on a snap.
-    const step = Math.max(TICKS_PER_BAR, span);
-    const present = new Set(current.song.placements.map(identity));
-    const alreadyThere = (anchor: number): boolean =>
-      clipboard.every((entry) =>
-        present.has(
-          identity({
-            ...entry,
-            startTicks: snapToBar(anchor) + entry.startTicks - origin,
-          }),
-        ),
-      );
-
-    let anchor = Math.min(...starts);
-    while (anchor + step <= MAX_ARRANGEMENT_TICKS && alreadyThere(anchor)) anchor += step;
-    return anchor;
-  }
-
   const paste = (targetTicks: number): boolean => {
     const current = project();
     return current
-      ? run(
-          pastePlacements(
-            current,
-            clipboard,
-            pasteAnchor(current, targetTicks),
-            options.ids,
-          ),
-        )
+      ? run(pastePlacements(current, clipboard, targetTicks, options.ids))
       : false;
   };
 

--- a/src/arrangement/placementEditingController.ts
+++ b/src/arrangement/placementEditingController.ts
@@ -232,10 +232,36 @@ export function createPlacementEditing(options: PlacementEditingOptions) {
     return true;
   };
 
+  /**
+   * Where a paste lands: the start of the current selection when there is one,
+   * and only otherwise the caller's anchor (the playhead).
+   *
+   * The playhead is the right anchor "with no explicit target selected", as
+   * the shortcut handler's own comment puts it — but a live placement
+   * selection *is* that explicit target, and ignoring it sent every paste to
+   * the playhead however deliberately the user had picked a spot (#258).
+   * `edit.paste` declares `ableton: { kind: "follows" }`, and Ableton pastes
+   * at the selection.
+   */
+  function pasteAnchor(current: Project, fallbackTicks: number): number {
+    if (selected.length === 0) return fallbackTicks;
+    const starts = current.song.placements
+      .filter((placement) => selected.includes(placement.id))
+      .map((placement) => placement.startTicks);
+    return starts.length === 0 ? fallbackTicks : Math.min(...starts);
+  }
+
   const paste = (targetTicks: number): boolean => {
     const current = project();
     return current
-      ? run(pastePlacements(current, clipboard, targetTicks, options.ids))
+      ? run(
+          pastePlacements(
+            current,
+            clipboard,
+            pasteAnchor(current, targetTicks),
+            options.ids,
+          ),
+        )
       : false;
   };
 

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -859,6 +859,62 @@ describe("EditorView keyboard shortcuts", () => {
       loaded.value.song.placements.find((p) => p.id === placementId),
     ).toBeUndefined();
   });
+
+  // #258. The reporter hit this by selecting a placement on one track, deleting
+  // it, then selecting one on another track — but moving between tracks is
+  // incidental. What decides it is the *edited* track's instrument, which
+  // clicking a placement re-points (#228): once that track is one the editor
+  // shows the piano roll for, the arrangement's placement selection stopped
+  // reaching `edit.delete` at all, so Delete did nothing. The piano-roll
+  // fixture is the smallest case — one synth track, one placement, no track
+  // switching anywhere.
+  it("deletes a selected placement while the piano roll is showing (#258)", async () => {
+    repository = inMemoryModule.createInMemoryProjectRepository();
+    const project = createPianoRollFixtureProject();
+    const created = await repository.createProject(project);
+    if (!created.ok) throw new Error("fixture project failed to create");
+    renderEditor(project.metadata.id);
+    await screen.findByRole("region", { name: /^Piano roll:/ });
+
+    const placementId = project.song.placements[0].id;
+    const canvas = document.querySelector(".arrangement-layer-interactive");
+    if (!canvas) throw new Error("no arrangement interaction canvas rendered");
+    const PIXELS_PER_TICK = 0.08;
+    const RULER_HEIGHT_PX = 22;
+    const ROW_HEIGHT_PX = 28;
+    const TICKS_PER_BAR = 768;
+    const down = new MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      clientX: (TICKS_PER_BAR / 2) * PIXELS_PER_TICK,
+      clientY: RULER_HEIGHT_PX + ROW_HEIGHT_PX / 2,
+    });
+    Object.defineProperty(down, "pointerId", { value: 1 });
+    fireEvent(canvas, down);
+    const up = new MouseEvent("pointerup", { bubbles: true, cancelable: true });
+    Object.defineProperty(up, "pointerId", { value: 1 });
+    fireEvent(canvas, up);
+    await waitFor(() => {
+      expect(
+        document.querySelector(`[data-selected-placement="${placementId}"]`),
+      ).not.toBeNull();
+    });
+
+    fireEvent.keyDown(window, { key: "Delete" });
+
+    // Asserted against the stored project rather than the "Saved" indicator, so
+    // a failure names the placement that is still there instead of dumping the
+    // editor's DOM.
+    await waitFor(
+      async () => {
+        const loaded = await repository.loadProject(project.metadata.id);
+        if (!loaded.ok) throw new Error("expected the project to load");
+        expect(loaded.value.song.placements.map((p) => p.id)).not.toContain(placementId);
+      },
+      { timeout: 3_000 },
+    );
+  });
 });
 
 /** The LOOP-003 transport surface: tempo, 4/4 display, loop, and metronome. */

--- a/src/editor/EditorView.test.tsx
+++ b/src/editor/EditorView.test.tsx
@@ -860,23 +860,13 @@ describe("EditorView keyboard shortcuts", () => {
     ).toBeUndefined();
   });
 
-  // #258. The reporter hit this by selecting a placement on one track, deleting
-  // it, then selecting one on another track — but moving between tracks is
-  // incidental. What decides it is the *edited* track's instrument, which
-  // clicking a placement re-points (#228): once that track is one the editor
-  // shows the piano roll for, the arrangement's placement selection stopped
-  // reaching `edit.delete` at all, so Delete did nothing. The piano-roll
-  // fixture is the smallest case — one synth track, one placement, no track
-  // switching anywhere.
-  it("deletes a selected placement while the piano roll is showing (#258)", async () => {
-    repository = inMemoryModule.createInMemoryProjectRepository();
-    const project = createPianoRollFixtureProject();
-    const created = await repository.createProject(project);
-    if (!created.ok) throw new Error("fixture project failed to create");
-    renderEditor(project.metadata.id);
-    await screen.findByRole("region", { name: /^Piano roll:/ });
-
-    const placementId = project.song.placements[0].id;
+  /**
+   * Clicks the first bar of the first arrangement row, where the piano-roll
+   * fixture's placement sits, and waits for the accessible selection mirror to
+   * show it. The geometry constants mirror the renderer's own — the canvas has
+   * no DOM nodes to query for a hit.
+   */
+  async function selectPlacementInArrangement(placementId: string): Promise<void> {
     const canvas = document.querySelector(".arrangement-layer-interactive");
     if (!canvas) throw new Error("no arrangement interaction canvas rendered");
     const PIXELS_PER_TICK = 0.08;
@@ -900,6 +890,26 @@ describe("EditorView keyboard shortcuts", () => {
         document.querySelector(`[data-selected-placement="${placementId}"]`),
       ).not.toBeNull();
     });
+  }
+
+  // #258. The reporter hit this by selecting a placement on one track, deleting
+  // it, then selecting one on another track — but moving between tracks is
+  // incidental. What decides it is the *edited* track's instrument, which
+  // clicking a placement re-points (#228): once that track is one the editor
+  // shows the piano roll for, the arrangement's placement selection stopped
+  // reaching `edit.delete` at all, so Delete did nothing. The piano-roll
+  // fixture is the smallest case — one synth track, one placement, no track
+  // switching anywhere.
+  it("deletes a selected placement while the piano roll is showing (#258)", async () => {
+    repository = inMemoryModule.createInMemoryProjectRepository();
+    const project = createPianoRollFixtureProject();
+    const created = await repository.createProject(project);
+    if (!created.ok) throw new Error("fixture project failed to create");
+    renderEditor(project.metadata.id);
+    await screen.findByRole("region", { name: /^Piano roll:/ });
+
+    const placementId = project.song.placements[0].id;
+    await selectPlacementInArrangement(placementId);
 
     fireEvent.keyDown(window, { key: "Delete" });
 
@@ -911,6 +921,39 @@ describe("EditorView keyboard shortcuts", () => {
         const loaded = await repository.loadProject(project.metadata.id);
         if (!loaded.ok) throw new Error("expected the project to load");
         expect(loaded.value.song.placements.map((p) => p.id)).not.toContain(placementId);
+      },
+      { timeout: 3_000 },
+    );
+  });
+
+  // #258 again, found by walking the preview channel: Delete, Cut and Copy all
+  // came back, but Paste stayed dead on a piano-roll track. Its `isEnabled`
+  // carried the same `!showPianoRoll()` term the rest of this handler block
+  // shed — and because a disabled mapping leaves the browser default alone,
+  // the failure is silent. The registry lists `edit.paste` under both
+  // `selection` and `arrangement`, so the context was active the whole time
+  // and only this gate stood in the way. Nothing is stolen from the roll: it
+  // registers no clipboard action of its own (`PianoRollActions` is delete,
+  // duplicate, select-all, has-selection).
+  it("pastes a copied placement while the piano roll is showing (#258)", async () => {
+    repository = inMemoryModule.createInMemoryProjectRepository();
+    const project = createPianoRollFixtureProject();
+    const created = await repository.createProject(project);
+    if (!created.ok) throw new Error("fixture project failed to create");
+    renderEditor(project.metadata.id);
+    await screen.findByRole("region", { name: /^Piano roll:/ });
+
+    const placementId = project.song.placements[0].id;
+    await selectPlacementInArrangement(placementId);
+
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "v", ctrlKey: true });
+
+    await waitFor(
+      async () => {
+        const loaded = await repository.loadProject(project.metadata.id);
+        if (!loaded.ok) throw new Error("expected the project to load");
+        expect(loaded.value.song.placements).toHaveLength(2);
       },
       { timeout: 3_000 },
     );

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -197,8 +197,15 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
   // internal (non-signal) state, so this must be re-evaluated live on every
   // call — the same reason `pianoRollActions()?.hasSelection()` is called
   // directly rather than memoized elsewhere in this file.
+  //
+  // Deliberately *not* gated on `showPianoRoll()` (#258). `showPianoRoll()`
+  // says which editor is mounted *below* the arrangement, not which surface
+  // has focus, and the arrangement is on screen either way — so gating on it
+  // made a placement selected on a synth track invisible to the shortcut
+  // layer and undeletable. Which surface a selection-scoped shortcut acts on
+  // is `useEditorShortcuts`' to decide, from the selections that exist.
   const hasArrangementSelection = (): boolean =>
-    !showPianoRoll() && (arrangementEditingActions()?.hasSelection() ?? false);
+    arrangementEditingActions()?.hasSelection() ?? false;
 
   const { shortcuts, editorContexts, keyHint } = useEditorShortcuts({
     audio,

--- a/src/editor/useEditorShortcuts.ts
+++ b/src/editor/useEditorShortcuts.ts
@@ -172,8 +172,11 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
       // Pastes at the live playhead position, the same anchor most DAWs use
       // with no explicit target selected.
       run: () => arrangementEditingActions()?.paste(audio.positionTicks()),
-      isEnabled: () =>
-        !showPianoRoll() && (arrangementEditingActions()?.getClipboard().length ?? 0) > 0,
+      // Gated on the clipboard alone (#258), not on which editor is mounted
+      // below the arrangement — the same term the rest of this block shed.
+      // Nothing is stolen from the piano roll: it registers no clipboard
+      // action of its own, so Mod+V has exactly one meaning in the editor.
+      isEnabled: () => (arrangementEditingActions()?.getClipboard().length ?? 0) > 0,
     },
   });
 

--- a/src/editor/useEditorShortcuts.ts
+++ b/src/editor/useEditorShortcuts.ts
@@ -25,9 +25,11 @@ export interface UseEditorShortcutsOptions {
    * `ArrangementView` the same way `pianoRollActions` is lifted from the
    * piano roll. */
   readonly arrangementEditingActions: Accessor<PlacementEditingActions | null>;
-  /** Whether the arrangement (not the piano roll) currently has a placement
-   * selection — gates the `arrangement` shortcut context, mirroring how
-   * `selection` is only added while the piano roll shows a selection. */
+  /** Whether the arrangement currently has a placement selection — gates the
+   * `arrangement` shortcut context, mirroring how `selection` is only added
+   * while the piano roll shows a selection. Live whichever editor is mounted
+   * below the arrangement, because the arrangement is on screen either way
+   * (#258). */
   readonly hasArrangementSelection: () => boolean;
 }
 
@@ -65,6 +67,28 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
     hasArrangementSelection,
   } = options;
 
+  /**
+   * Which surface a selection-scoped edit acts on right now (#258).
+   *
+   * Precedence, not visibility: the piano roll takes it while it is showing
+   * *and* holds a note selection, otherwise the arrangement's placement
+   * selection wins, and the step editor's lifted note selection is the last
+   * resort (only while its grid is the one showing). Asking "is the piano roll
+   * showing?" first is what broke Delete — that answers which editor is
+   * mounted below the arrangement, not which surface the user selected in, so
+   * a placement selected on a synth track was routed to a piano roll with
+   * nothing selected and the keypress did nothing.
+   */
+  type SelectionOwner = "piano_roll" | "arrangement" | "step_editor";
+  const selectionOwner = (): SelectionOwner | null => {
+    if (showPianoRoll() && (pianoRollActions()?.hasSelection() ?? false)) {
+      return "piano_roll";
+    }
+    if (hasArrangementSelection()) return "arrangement";
+    if (!showPianoRoll() && selectedNoteIds().length > 0) return "step_editor";
+    return null;
+  };
+
   // The KEY-01 registry owns every mapping; this component only says which
   // actions exist here and what they do. An action the slice does not
   // implement yet simply has no handler and never fires.
@@ -86,20 +110,17 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
     // a selection: the piano roll keeps its own and hands the operation up
     // through `registerActions` (CLP-03), the step editor's is lifted into this
     // component (CLP-02), and the arrangement's placement selection is lifted
-    // the same way (ARR-002). Each only fires when its own selection is
+    // the same way (ARR-002). Only fires when some surface's selection is
     // non-empty, so an empty-selection Delete leaves the browser default alone
     // (PRD KEY-02).
     "edit.delete": {
       run: () => {
-        if (showPianoRoll()) pianoRollActions()?.deleteSelection();
-        else if (hasArrangementSelection())
-          arrangementEditingActions()?.deleteSelection();
-        else deleteSelection();
+        const owner = selectionOwner();
+        if (owner === "piano_roll") pianoRollActions()?.deleteSelection();
+        else if (owner === "arrangement") arrangementEditingActions()?.deleteSelection();
+        else if (owner === "step_editor") deleteSelection();
       },
-      isEnabled: () =>
-        showPianoRoll()
-          ? (pianoRollActions()?.hasSelection() ?? false)
-          : hasArrangementSelection() || selectedNoteIds().length > 0,
+      isEnabled: () => selectionOwner() !== null,
     },
     "help.shortcut_guide": { run: () => setGuideOpen(true) },
     "view.close_surface": {
@@ -121,22 +142,24 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
     // (CLP-01's actual UI requirement) right above the arrangement.
     "edit.duplicate": {
       run: () => {
-        if (showPianoRoll()) pianoRollActions()?.duplicateSelection();
-        else if (hasArrangementSelection())
+        const owner = selectionOwner();
+        if (owner === "piano_roll") pianoRollActions()?.duplicateSelection();
+        else if (owner === "arrangement")
           arrangementEditingActions()?.duplicate("linked");
       },
-      isEnabled: () =>
-        showPianoRoll()
-          ? (pianoRollActions()?.hasSelection() ?? false)
-          : hasArrangementSelection(),
+      isEnabled: () => {
+        const owner = selectionOwner();
+        return owner === "piano_roll" || owner === "arrangement";
+      },
     },
     "edit.select_all": {
       run: () => pianoRollActions()?.selectAll(),
       isEnabled: () => pianoRollActions() !== null,
     },
     // The arrangement's clipboard (ARR-002). Only active while the arrangement
-    // itself has a selection and the piano roll is not showing, matching
-    // `edit.delete`/`edit.duplicate` above.
+    // itself has a selection — whichever editor is mounted below it, matching
+    // `edit.delete`/`edit.duplicate` above (#258). Nothing is stolen from the
+    // piano roll: it registers no cut/copy handler of its own.
     "edit.cut": {
       run: () => arrangementEditingActions()?.cut(),
       isEnabled: () => hasArrangementSelection(),
@@ -158,18 +181,19 @@ export function useEditorShortcuts(options: UseEditorShortcutsOptions) {
   // so "shortcuts valid in the current context" means the editor underneath
   // rather than the modal covering it. The piano roll adds its own contexts:
   // `piano_roll` (where `edit.delete` lives) and `selection` (where
-  // `edit.duplicate`/`edit.select_all` live). `arrangement` is added only
-  // while the arrangement plausibly has focus — a live placement selection —
-  // the same conditional pattern `selection` already follows for the piano
-  // roll, so cut/copy/paste/delete/duplicate never steal a keystroke from an
-  // editor that has nothing selected.
+  // `edit.duplicate`/`edit.select_all` live). `arrangement` is added while the
+  // arrangement holds a live placement selection, the same conditional pattern
+  // `selection` already follows for the piano roll, so
+  // cut/copy/paste/delete/duplicate never steal a keystroke from an editor
+  // that has nothing selected.
   const editorContexts = (): readonly ShortcutContext[] => {
-    if (showPianoRoll()) {
-      return ["editor", "step_editor", "piano_roll", "selection"];
-    }
-    return hasArrangementSelection()
-      ? ["editor", "step_editor", "arrangement"]
+    const base: readonly ShortcutContext[] = showPianoRoll()
+      ? ["editor", "step_editor", "piano_roll", "selection"]
       : ["editor", "step_editor"];
+    // A live placement selection makes the arrangement's own mappings active
+    // whichever editor is mounted below it (#258), not only when that editor
+    // happens to be the step grid.
+    return hasArrangementSelection() ? [...base, "arrangement"] : base;
   };
 
   // While a modal is open it is the only active context, so nothing behind it


### PR DESCRIPTION
## What &amp; why

Selection-scoped shortcuts asked the wrong question. `hasArrangementSelection()` was defined as `!showPianoRoll() && arrangementEditingActions()?.hasSelection()`, and `edit.delete` branched on `showPianoRoll()` before consulting any selection. But `showPianoRoll()` says which editor is mounted *below* the arrangement — not which surface the user selected in, and the arrangement is on screen either way. So a placement selected while a piano roll was showing got routed to a piano roll with nothing selected, and the handler reported itself disabled.

The fix replaces the visibility test with one `selectionOwner()` accessor (`"piano_roll" | "arrangement" | "step_editor" | null`) that every selection-scoped mapping reads. Precedence is unchanged wherever it existed: the piano roll wins while it is showing **and** holds a note selection; only the case where it had no selection changes.

**The reported trigger is not the real one.** The issue describes moving between tracks, but track switching is incidental — clicking a placement re-points the *edited* track (#228), and Delete only breaks once that track is one the editor shows the piano roll for (a synth track holding a note clip). Verified both directions before touching source: two sampler tracks with a delete on each **passes**; one synth track with one placement and no track switching at all **fails**.

Closes #258

## What this PR contains, after a deliberate narrowing

Three defects, all confirmed fixed on the preview channel by the product owner:

1. **Delete, Duplicate, Cut and Copy** reach the arrangement's selection while a piano roll is showing. (The original defect.)
2. **Paste is no longer gated on which editor is mounted.** Its `isEnabled` carried the same `!showPianoRoll()` term, and because a disabled mapping leaves the browser default alone, it failed *silently*. The registry already lists `edit.paste` under both `selection` and `arrangement` (`registry.ts:209`), so only this gate stood in the way. Nothing is stolen from the piano roll: `PianoRollActions` is delete, duplicate, select-all and has-selection, so `Mod+V` has one meaning in the editor.
3. **Only one arrangement selection is painted at a time.** The shell's ARR-01 bar range (`canvasRenderer.ts:278`) and the ARR-002 placement selection (`canvasRenderer.ts:294`) are drawn in the same cyan, and each click set one without clearing the other — a placement hit returns before `shell.handlePointerDown` runs, and an empty-space click never touched the placement selection. They are now mutually exclusive. This one **predates the PR** (`git diff origin/main` on those files was empty) and is included because it is three one-line writes and because two lit boxes make every selection-scoped operation unreadable.

## What was removed, and why

**Paste *anchoring* was attempted here and has been taken out.** `placementEditingController.ts` is byte-identical to `main` again.

The sequence, recorded because it is the useful part: paste ignored the selection and went to the playhead → anchoring it at the selection fixed that but stacked a copy invisibly on its own source → dodging the stack fixed that but ignored the bar-range selection the user had just made to point at a target. Three rounds, each fix uncovering the next.

The reason it kept failing is structural, not carelessness: the anchor depends on two things schema v1 does not have — a rule about whether placements may overlap (#290) and overwrite semantics for what a paste lands on (#291). Without those, every anchor rule is a heuristic that surprises somewhere. #291 will rewrite this code regardless.

So paste lands at the caller's anchor (the playhead), exactly as on `main`. That is **worse than what the reporter asked for** and is stated here rather than buried: pasting with a placement selected still ignores that selection. It is predictable, it is not a regression against `main`, and #290/#291 are where it gets settled.

## Core flows

Untouched. A bug fix's contract is its regression tests. `bun run verify:core-flows` passes — 7 flows, one spec each; CF-006/CF-007 remain `test.fixme` exactly as on `main`. No flow spec, `docs/core-flows.md` or `docs/prd.md` was edited.

## Walkthrough

Not captured. The changes are user-visible — five keyboard operations that did nothing now work, and one selection box is lit instead of two — but there is no *visual* change to screenshot: no new component, layout, styling or copy. The regression tests carry the proof instead, asserting against stored project state and the accessible selection mirror.

## Evidence

Four regression tests, each verified red by reverting **only** its own source change:

```
 FAIL  EditorView > deletes a selected placement while the piano roll is showing (#258)
AssertionError: expected [ 'plc_elLyKQlVOiYStrzI-Qz6h' ] to not include 'plc_elLyKQlVOiYStrzI-Qz6h'

 FAIL  EditorView > pastes a copied placement while the piano roll is showing (#258)
- Expected   2
+ Received   1

 FAIL  ArrangementView > keeps exactly one arrangement selection live at a time
AssertionError: expected 'Selected BD, bars 4 to 5' to be 'No selection'
```

In the `ArrangementView` case the assertion above it (`selectedPlacementIds` is `[placementId]`) passes, so the red is specifically "the placement is selected *and* the earlier bar range is still live". A fourth test pins that paste uses the caller's anchor, so the removal above cannot silently drift back.

| Command | Result |
| --- | --- |
| `bun run typecheck` | pass |
| `bun run check` | pass — biome 507 files, `verify:no-solid-1` clean |
| `bun run test:all` | pass — 177 files, 2366 tests (the command CI runs) |
| `bun run verify:core-flows` | pass — 7 flows, one spec each |

Rebased onto `main` after #286 merged; every check re-run on the rebased head.

Diffstat: 6 files changed, 231 insertions(+), 33 deletions(-) — **264 changed lines**, comfortably inside the 400 ceiling after the narrowing (it had reached 370).

Nothing that predates this PR changed: the pre-existing ARR-002 delete test keeps its own inline selection helper and is byte-identical.

**Browser suites did not run locally.** `bun run test:browser:install` cannot reach the Playwright CDN in this container, which CLAUDE.md anticipates. CI on push is the browser check.

## Follow-ups filed

- #290 — placements can silently overlap; no invariant, no defined resolution. Governs the two below.
- #291 — paste should overwrite what it lands on (Ableton parity), which is where paste anchoring belongs.
- #292 — the arrangement's two selection models, now mutually exclusive rather than unified.

## Acceptance criteria met

- Both selected placements delete, and nothing else does — asserted against the stored project.
- Cut, copy, duplicate and paste work on the same surface and selection as delete.
- Exactly one arrangement selection is painted at a time.
- No contract touched: domain, command registry, persistence, projections and `src/selection/` are unchanged.
- No analytics change. `shortcut_used` is logged by `ShortcutController` from the registry entry; the set of firing actions is unchanged apart from now firing when it should.