### PR TITLE
Fix #254 (1/1): Run instrument slider drags as one live gesture

### DIFF
--- a/src/commands/controlGesture.test.ts
+++ b/src/commands/controlGesture.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createSliceFixtureProject } from "../domain/fixtures";
+import {
+  bareParameterId,
+  readInstrumentParameter,
+  SAMPLER_PITCH,
+} from "../domain/parameters";
+import { createControlGesture } from "./controlGesture";
+import { setParameter } from "./definitions/parameters";
+import { CommandHistory } from "./history";
+
+/**
+ * One drag is one gesture — covered by the panel tests. What is covered here is
+ * the case the panels cannot stage: what a control does when the *rest of the
+ * editor* has left a gesture open. `CommandHistory.beginGesture` throws in that
+ * situation, and a control has no way to know before it asks.
+ */
+describe("createControlGesture", () => {
+  function setup() {
+    const history = new CommandHistory(createSliceFixtureProject());
+    const trackId = history.project.song.tracks[0].id;
+    const pitch = () =>
+      readInstrumentParameter(
+        SAMPLER_PITCH,
+        // biome-ignore lint/suspicious/noExplicitAny: fixture track is a sampler
+        (history.project.song.tracks[0].instrument as any).parameters,
+      );
+    const make = () =>
+      createControlGesture({
+        beginGesture: (options) => history.beginGesture(options),
+        dispatch: (commands) => history.execute(commands),
+        summary: () => "Set pitch",
+        command: (value) =>
+          setParameter(
+            {
+              scope: "instrument",
+              trackId,
+              // The panels address instrument parameters by their bare id.
+              parameterId: bareParameterId(SAMPLER_PITCH.id),
+            },
+            value,
+          ),
+      });
+    return { history, make, pitch };
+  }
+
+  it("still lands values while another gesture is open, instead of throwing", () => {
+    const { history, make, pitch } = setup();
+
+    // A drag that never got its `change` — released off-element, or the panel
+    // unmounted mid-drag — leaves this gesture open.
+    make().input(3);
+    expect(history.gestureActive).toBe(true);
+
+    // The next control the user touches must keep working. Before this, the
+    // `beginGesture` throw escaped through the control's own `input` handler
+    // and the slider locked up: no movement, no value, no message.
+    const next = make();
+    expect(() => next.input(7)).not.toThrow();
+    expect(pitch()).toBe(7);
+
+    next.commit(7);
+    expect(pitch()).toBe(7);
+  });
+});

--- a/src/commands/controlGesture.ts
+++ b/src/commands/controlGesture.ts
@@ -1,0 +1,57 @@
+import type { TransactionResult } from "./execute";
+import type { Gesture, GestureOptions } from "./history";
+import type { RawCommandInput } from "./types";
+
+/**
+ * Drives one continuous control — a fader, a pan, an instrument slider —
+ * through the command layer.
+ *
+ * A drag is one gesture: the first `input` opens it, every later `input`
+ * applies live inside it, and the `change` the browser fires on release closes
+ * it — so the whole drag is one history entry, one revision, one save, and at
+ * most one analytics event, however many pointer moves it took. A keyboard
+ * arrow fires `input` then `change`, so it is one gesture per press.
+ *
+ * Applying every step live is the behaviour, not an optimization: a control
+ * painted from project state sits frozen under the pointer, and the audio
+ * graph reading that state does not move either, if nothing applies until
+ * release (#254). A caller whose `beginGesture` declines still lands each
+ * value, through `dispatch`.
+ */
+export function createControlGesture(props: {
+  beginGesture(options?: GestureOptions): Gesture | undefined;
+  dispatch(
+    commands: RawCommandInput | readonly RawCommandInput[],
+  ): TransactionResult | undefined;
+  /** The history summary for the whole gesture, read when it opens. */
+  summary(): string;
+  /** The command that writes `value`, built fresh for every step. */
+  command(value: number): RawCommandInput;
+}) {
+  let gesture: Gesture | undefined;
+
+  return {
+    input(value: number): void {
+      if (!gesture?.active) {
+        gesture = props.beginGesture({ summary: props.summary() });
+      }
+      const command = props.command(value);
+      if (gesture?.active) {
+        gesture.apply(command);
+      } else {
+        props.dispatch(command);
+      }
+    },
+    commit(value: number): void {
+      // The final `input` already applied this exact value inside the gesture;
+      // closing it is all that is left. With no gesture open (a `change` with
+      // no preceding `input`) the value still has to land.
+      if (gesture?.active) {
+        gesture.commit();
+      } else {
+        props.dispatch(props.command(value));
+      }
+      gesture = undefined;
+    },
+  };
+}

--- a/src/commands/controlGesture.ts
+++ b/src/commands/controlGesture.ts
@@ -30,10 +30,30 @@ export function createControlGesture(props: {
 }) {
   let gesture: Gesture | undefined;
 
+  /**
+   * Opens this control's gesture, or gives up and lets the caller fall back to
+   * plain dispatch.
+   *
+   * `CommandHistory.beginGesture` *throws* when another gesture is already
+   * open, and a control cannot know what the rest of the editor is doing. One
+   * orphaned gesture must not take every other control down with it: the
+   * value still has to land, and the control still has to follow the pointer.
+   * The worst case here is that this drag records one history entry per step
+   * instead of one for the whole gesture — visibly worse to undo, but the
+   * control keeps working.
+   */
+  function openGesture(): Gesture | undefined {
+    try {
+      return props.beginGesture({ summary: props.summary() });
+    } catch {
+      return undefined;
+    }
+  }
+
   return {
     input(value: number): void {
       if (!gesture?.active) {
-        gesture = props.beginGesture({ summary: props.summary() });
+        gesture = openGesture();
       }
       const command = props.command(value);
       if (gesture?.active) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,7 @@
  * repository, and the assistant all sit outside it.
  */
 
+export * from "./controlGesture";
 export * from "./definitions/assets";
 export * from "./definitions/clips";
 export * from "./definitions/deviceChains";

--- a/src/editor/InstrumentPanel.tsx
+++ b/src/editor/InstrumentPanel.tsx
@@ -1,5 +1,10 @@
 import { Match, Switch } from "@solidjs/web";
-import type { RawCommandInput, TransactionResult } from "../commands";
+import type {
+  Gesture,
+  GestureOptions,
+  RawCommandInput,
+  TransactionResult,
+} from "../commands";
 import type { Instrument } from "../domain/entities";
 import type { TrackId } from "../domain/ids";
 import SamplerPanel from "../instrument/SamplerPanel";
@@ -13,6 +18,8 @@ export interface InstrumentPanelProps {
   dispatch(
     commands: RawCommandInput | readonly RawCommandInput[],
   ): TransactionResult | undefined;
+  /** Opens the one history gesture a slider drag commits as (#254). */
+  beginGesture(options?: GestureOptions): Gesture | undefined;
   audition(): void;
 }
 
@@ -41,6 +48,7 @@ export default function InstrumentPanel(props: InstrumentPanelProps) {
             instrument={sampler()}
             sampleName={props.sampleName}
             dispatch={props.dispatch}
+            beginGesture={props.beginGesture}
             audition={props.audition}
           />
         )}
@@ -56,6 +64,7 @@ export default function InstrumentPanel(props: InstrumentPanelProps) {
             trackId={props.trackId}
             instrument={synth()}
             dispatch={props.dispatch}
+            beginGesture={props.beginGesture}
             audition={props.audition}
           />
         )}

--- a/src/editor/Mixer.tsx
+++ b/src/editor/Mixer.tsx
@@ -10,6 +10,7 @@ import type {
 } from "../commands";
 import {
   addTrack,
+  createControlGesture,
   removeTrack,
   reorderTrack,
   setParameter,
@@ -442,51 +443,6 @@ interface FaderProps {
     commands: RawCommandInput | readonly RawCommandInput[],
   ): TransactionResult | undefined;
   beginGesture(options?: GestureOptions): Gesture | undefined;
-}
-
-/**
- * Drives one continuous mixer control through the command layer.
- *
- * A drag is one gesture: the first `input` opens it, every later `input`
- * applies live inside it, and the `change` the browser fires on release closes
- * it — so the whole drag is one history entry, one revision, one save, and at
- * most one analytics event, however many pointer moves it took. A keyboard
- * arrow fires `input` then `change`, so it is one gesture per press.
- */
-function createControlGesture(props: {
-  beginGesture(options?: GestureOptions): Gesture | undefined;
-  dispatch(
-    commands: RawCommandInput | readonly RawCommandInput[],
-  ): TransactionResult | undefined;
-  summary(): string;
-  command(value: number): RawCommandInput;
-}) {
-  let gesture: Gesture | undefined;
-
-  return {
-    input(value: number): void {
-      if (!gesture?.active) {
-        gesture = props.beginGesture({ summary: props.summary() });
-      }
-      const command = props.command(value);
-      if (gesture?.active) {
-        gesture.apply(command);
-      } else {
-        props.dispatch(command);
-      }
-    },
-    commit(value: number): void {
-      // The final `input` already applied this exact value inside the gesture;
-      // closing it is all that is left. With no gesture open (a `change` with
-      // no preceding `input`) the value still has to land.
-      if (gesture?.active) {
-        gesture.commit();
-      } else {
-        props.dispatch(props.command(value));
-      }
-      gesture = undefined;
-    },
-  };
 }
 
 function VolumeFader(props: FaderProps): JSX.Element {

--- a/src/editor/TrackEditor.tsx
+++ b/src/editor/TrackEditor.tsx
@@ -156,6 +156,7 @@ export default function TrackEditor(props: TrackEditorProps) {
               instrument={props.instrument}
               sampleName={props.sampleName}
               dispatch={props.dispatch}
+              beginGesture={props.beginGesture}
               audition={props.auditionInstrument}
             />
           )}

--- a/src/instrument/FillSlider.tsx
+++ b/src/instrument/FillSlider.tsx
@@ -131,7 +131,21 @@ export default function FillSlider(props: FillSliderProps): JSX.Element {
           step={scale().step ?? "any"}
           value={props.value}
           onInput={(event) => props.onInput(coerce(event.currentTarget.valueAsNumber))}
+          // `change` settles a drag or a keyboard nudge, but it does not fire
+          // at all when a drag ends somewhere the input never hears about —
+          // released off-element, or the panel unmounted mid-drag by a track
+          // switch. That left the gesture open forever, and the next control
+          // touched anywhere in the editor threw "a gesture is already in
+          // progress" out of its own `input` handler and locked up. Pointer
+          // up/cancel close the same gesture; extra commits are a safe no-op.
+          // (`PianoRollNote` already covers its velocity slider this way.)
           onChange={(event) => props.onCommit(coerce(event.currentTarget.valueAsNumber))}
+          onPointerUp={(event) =>
+            props.onCommit(coerce(event.currentTarget.valueAsNumber))
+          }
+          onPointerCancel={(event) =>
+            props.onCommit(coerce(event.currentTarget.valueAsNumber))
+          }
         />
       </div>
       <output class="fill-slider-value" for={id()}>

--- a/src/instrument/SamplerPanel.test.tsx
+++ b/src/instrument/SamplerPanel.test.tsx
@@ -1,12 +1,22 @@
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Analytics } from "../analytics/analytics";
 import { ConsentStore } from "../analytics/consent";
 import { createRecordingTransport } from "../analytics/transport";
-import type { RawCommandInput, TransactionResult } from "../commands";
+import {
+  CommandHistory,
+  type Gesture,
+  type RawCommandInput,
+  type TransactionResult,
+} from "../commands";
 import type { Instrument } from "../domain/entities";
+import { createSliceFixtureProject } from "../domain/fixtures";
 import type { AssetId, TrackId } from "../domain/ids";
+import { readInstrumentParameter, SAMPLER_PITCH } from "../domain/parameters";
+import { fireAndFlush } from "../testing/events";
 import { memoryStorage } from "../testing/storage";
+import { fillExtent, moveTo, recordingGesture, testAnalytics } from "./panelTesting";
 import SamplerPanel from "./SamplerPanel";
 
 afterEach(() => cleanup());
@@ -28,6 +38,7 @@ function renderPanel(
     ) => TransactionResult | undefined
   >(() => ({ ok: true }) as TransactionResult);
   const audition = vi.fn();
+  const applied: RawCommandInput[] = [];
   const transport = createRecordingTransport();
   const consent = new ConsentStore(memoryStorage());
   const analytics = new Analytics({
@@ -42,11 +53,36 @@ function renderPanel(
       instrument={instrument}
       sampleName={sampleName}
       dispatch={dispatch}
+      beginGesture={(): Gesture => recordingGesture(applied)}
       audition={audition}
       analytics={analytics}
     />
   ));
-  return { dispatch, audition, transport };
+  return { dispatch, applied, audition, transport };
+}
+
+/**
+ * The panel over a real command history, so the slider's `value` comes back
+ * out of the project it edits — which is what a drag has to move.
+ */
+function renderLivePanel() {
+  const history = new CommandHistory(createSliceFixtureProject());
+  const [project, setProject] = createSignal(history.project);
+  history.subscribe(() => setProject(history.project));
+  const track = () => project().song.tracks[0];
+  const instrument = () => track().instrument as Extract<Instrument, { kind: "sampler" }>;
+  render(() => (
+    <SamplerPanel
+      trackId={track().id}
+      instrument={instrument()}
+      sampleName="909 Bass Drum"
+      dispatch={(commands) => history.execute(commands)}
+      beginGesture={(options) => history.beginGesture(options)}
+      audition={() => {}}
+      analytics={testAnalytics().analytics}
+    />
+  ));
+  return { history, project, instrument };
 }
 
 describe("SamplerPanel", () => {
@@ -66,13 +102,13 @@ describe("SamplerPanel", () => {
   });
 
   it("dispatches an instrument parameter.set once when a slider commits", () => {
-    const { dispatch, transport } = renderPanel();
+    const { applied, transport } = renderPanel();
     const pitch = screen.getByLabelText("Pitch") as HTMLInputElement;
     fireEvent.input(pitch, { target: { value: "5" } });
     fireEvent.change(pitch, { target: { value: "5" } });
 
-    expect(dispatch).toHaveBeenCalledTimes(1);
-    const command = dispatch.mock.calls[0][0] as {
+    expect(applied).toHaveLength(1);
+    const command = applied[0] as {
       type: string;
       payload: { target: { scope: string; parameterId: string } };
     };
@@ -90,6 +126,33 @@ describe("SamplerPanel", () => {
     fireEvent.input(pitch, { target: { value: "2" } });
     expect(dispatch).not.toHaveBeenCalled();
     expect(transport.events).toHaveLength(0);
+  });
+
+  it("follows the pointer mid-drag, and still commits once (#254)", () => {
+    const { history, project, instrument } = renderLivePanel();
+    const startRevision = project().metadata.revision;
+    const pitch = screen.getByLabelText("Pitch") as HTMLInputElement;
+    expect(screen.getByText("0 st")).toBeInTheDocument();
+    const restingFill = fillExtent(pitch);
+
+    // Mid-drag: `input` has fired, `change` has not.
+    moveTo(pitch, "5");
+    expect(screen.getByText("+5 st")).toBeInTheDocument();
+    expect(fillExtent(pitch)).not.toBe(restingFill);
+    // The audio graph reads the same project state, so the pitch is audible.
+    expect(readInstrumentParameter(SAMPLER_PITCH, instrument().parameters)).toBe(5);
+
+    moveTo(pitch, "7");
+    expect(screen.getByText("+7 st")).toBeInTheDocument();
+    expect(history.entries).toHaveLength(0);
+
+    // One drag = one history entry and one revision, however many moves it took.
+    fireAndFlush(() => {
+      fireEvent.change(pitch, { target: { value: "7" } });
+    });
+    expect(history.entries).toHaveLength(1);
+    expect(project().metadata.revision).toBe(startRevision + 1);
+    expect(readInstrumentParameter(SAMPLER_PITCH, instrument().parameters)).toBe(7);
   });
 
   it("auditions on the audition button", () => {

--- a/src/instrument/SamplerPanel.test.tsx
+++ b/src/instrument/SamplerPanel.test.tsx
@@ -155,6 +155,22 @@ describe("SamplerPanel", () => {
     expect(readInstrumentParameter(SAMPLER_PITCH, instrument().parameters)).toBe(7);
   });
 
+  // The orphan half of the same defect: a drag that ends without a `change`
+  // (released off-element, or the panel unmounted by a track switch) used to
+  // leave its gesture open forever, and the next control touched anywhere in
+  // the editor threw out of its own `input` handler and locked up.
+  it("commits its gesture on pointer-up, with no change event (#254)", () => {
+    const { history } = renderLivePanel();
+    const pitch = screen.getByLabelText("Pitch") as HTMLInputElement;
+
+    moveTo(pitch, "5");
+    expect(history.gestureActive).toBe(true);
+
+    fireEvent.pointerUp(pitch);
+    expect(history.gestureActive).toBe(false);
+    expect(history.entries).toHaveLength(1);
+  });
+
   it("auditions on the audition button", () => {
     const { audition } = renderPanel();
     fireEvent.click(screen.getByRole("button", { name: "Audition" }));

--- a/src/instrument/SamplerPanel.tsx
+++ b/src/instrument/SamplerPanel.tsx
@@ -1,7 +1,12 @@
 import { For, type JSX } from "@solidjs/web";
 import { type Analytics, analytics as defaultAnalytics } from "../analytics/analytics";
-import type { RawCommandInput, TransactionResult } from "../commands";
-import { setParameter } from "../commands";
+import type {
+  Gesture,
+  GestureOptions,
+  RawCommandInput,
+  TransactionResult,
+} from "../commands";
+import { createControlGesture, setParameter } from "../commands";
 import type { Instrument } from "../domain/entities";
 import type { TrackId } from "../domain/ids";
 import {
@@ -28,6 +33,7 @@ export interface SamplerPanelProps {
   dispatch(
     commands: RawCommandInput | readonly RawCommandInput[],
   ): TransactionResult | undefined;
+  beginGesture(options?: GestureOptions): Gesture | undefined;
   audition(): void;
   readonly analytics?: Analytics;
 }
@@ -54,17 +60,19 @@ const ENVELOPE_SLIDERS = [
  * particular one; this panel stays a panel.
  *
  * Parameter edits dispatch a validated `parameter.set` in the `instrument`
- * scope; a continuous slider commits once per gesture, so a drag is one command
- * and emits nothing per tick.
+ * scope. A continuous slider runs the whole drag as one history gesture
+ * (`createControlGesture`): every move applies live, so the fill, the readout
+ * and the audio follow the pointer, and the release commits the lot as one
+ * entry, one revision and one analytics event (#254).
  */
 export default function SamplerPanel(props: SamplerPanelProps): JSX.Element {
   const analytics = () => props.analytics ?? defaultAnalytics;
 
-  function commit(parameterId: string, value: number): void {
-    props.dispatch(
-      setParameter({ scope: "instrument", trackId: props.trackId, parameterId }, value),
+  function parameterCommand(parameterId: string, value: number) {
+    return setParameter(
+      { scope: "instrument", trackId: props.trackId, parameterId },
+      value,
     );
-    analytics().logFeatureFirstUse("sampler");
   }
 
   return (
@@ -105,15 +113,22 @@ export default function SamplerPanel(props: SamplerPanelProps): JSX.Element {
 
   function sliderFor(definition: (typeof PLAYBACK_SLIDERS)[number]): JSX.Element {
     const value = () => readInstrumentParameter(definition, props.instrument.parameters);
+    const control = createControlGesture({
+      beginGesture: (options) => props.beginGesture(options),
+      dispatch: (commands) => props.dispatch(commands),
+      summary: () => `Set ${definition.label}`,
+      command: (next) => parameterCommand(bareParameterId(definition.id), next),
+    });
     return (
       <FillSlider
         definition={definition}
         value={value()}
         displayValue={formatInstrumentValue(definition, value())}
-        onInput={() => {
-          /* live audio follows on commit; nothing per tick */
+        onInput={(next) => control.input(next)}
+        onCommit={(next) => {
+          control.commit(next);
+          analytics().logFeatureFirstUse("sampler");
         }}
-        onCommit={(next) => commit(bareParameterId(definition.id), next)}
       />
     );
   }

--- a/src/instrument/SynthPanel.test.tsx
+++ b/src/instrument/SynthPanel.test.tsx
@@ -1,12 +1,22 @@
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Analytics } from "../analytics/analytics";
 import { ConsentStore } from "../analytics/consent";
 import { createRecordingTransport } from "../analytics/transport";
-import type { RawCommandInput, TransactionResult } from "../commands";
+import {
+  CommandHistory,
+  type Gesture,
+  type RawCommandInput,
+  type TransactionResult,
+} from "../commands";
 import type { Instrument } from "../domain/entities";
+import { createPianoRollFixtureProject } from "../domain/fixtures";
 import type { TrackId } from "../domain/ids";
+import { readInstrumentParameter, SYNTH_FILTER_CUTOFF } from "../domain/parameters";
+import { fireAndFlush } from "../testing/events";
 import { memoryStorage } from "../testing/storage";
+import { fillExtent, moveTo, recordingGesture, testAnalytics } from "./panelTesting";
 import SynthPanel from "./SynthPanel";
 
 afterEach(() => cleanup());
@@ -25,6 +35,7 @@ function renderPanel(
     ) => TransactionResult | undefined
   >(() => ({ ok: true }) as TransactionResult);
   const audition = vi.fn();
+  const applied: RawCommandInput[] = [];
   const transport = createRecordingTransport();
   const consent = new ConsentStore(memoryStorage());
   const analytics = new Analytics({
@@ -38,11 +49,35 @@ function renderPanel(
       trackId={TRACK_ID}
       instrument={instrument}
       dispatch={dispatch}
+      beginGesture={(): Gesture => recordingGesture(applied)}
       audition={audition}
       analytics={analytics}
     />
   ));
-  return { dispatch, audition, transport };
+  return { dispatch, applied, audition, transport };
+}
+
+/**
+ * The panel over a real command history, so the slider's `value` comes back
+ * out of the project it edits — which is what a drag has to move.
+ */
+function renderLivePanel() {
+  const history = new CommandHistory(createPianoRollFixtureProject());
+  const [project, setProject] = createSignal(history.project);
+  history.subscribe(() => setProject(history.project));
+  const track = () => project().song.tracks[0];
+  const instrument = () => track().instrument as Extract<Instrument, { kind: "synth" }>;
+  render(() => (
+    <SynthPanel
+      trackId={track().id}
+      instrument={instrument()}
+      dispatch={(commands) => history.execute(commands)}
+      beginGesture={(options) => history.beginGesture(options)}
+      audition={() => {}}
+      analytics={testAnalytics().analytics}
+    />
+  ));
+  return { history, project, instrument };
 }
 
 describe("SynthPanel", () => {
@@ -56,14 +91,14 @@ describe("SynthPanel", () => {
   });
 
   it("dispatches a validated instrument parameter.set when a slider commits", () => {
-    const { dispatch } = renderPanel();
+    const { applied } = renderPanel();
     const cutoff = screen.getByLabelText("Cutoff") as HTMLInputElement;
     fireEvent.input(cutoff, { target: { value: "5000" } });
     fireEvent.change(cutoff, { target: { value: "5000" } });
 
-    // Exactly one command, on commit — not one per input tick.
-    expect(dispatch).toHaveBeenCalledTimes(1);
-    const command = dispatch.mock.calls[0][0] as {
+    // Exactly one command for the drag — not one per input tick.
+    expect(applied).toHaveLength(1);
+    const command = applied[0] as {
       type: string;
       payload: {
         target: { scope: string; parameterId: string };
@@ -95,6 +130,37 @@ describe("SynthPanel", () => {
     expect(
       transport.named("feature_first_use").filter((e) => e.params.feature === "synth"),
     ).toHaveLength(1);
+  });
+
+  it("follows the pointer mid-drag, and still commits once (#254)", () => {
+    const { history, project, instrument } = renderLivePanel();
+    const startRevision = project().metadata.revision;
+    const cutoff = screen.getByLabelText("Cutoff") as HTMLInputElement;
+    expect(screen.getByText("12 kHz")).toBeInTheDocument();
+    const restingFill = fillExtent(cutoff);
+
+    // Mid-drag: `input` has fired, `change` has not.
+    moveTo(cutoff, "760");
+    expect(screen.getByText("760 Hz")).toBeInTheDocument();
+    expect(fillExtent(cutoff)).not.toBe(restingFill);
+    // The audio graph reads the same project state, so the sweep is audible.
+    expect(readInstrumentParameter(SYNTH_FILTER_CUTOFF, instrument().parameters)).toBe(
+      760,
+    );
+
+    moveTo(cutoff, "400");
+    expect(screen.getByText("400 Hz")).toBeInTheDocument();
+    expect(history.entries).toHaveLength(0);
+
+    // One drag = one history entry and one revision, however many moves it took.
+    fireAndFlush(() => {
+      fireEvent.change(cutoff, { target: { value: "400" } });
+    });
+    expect(history.entries).toHaveLength(1);
+    expect(project().metadata.revision).toBe(startRevision + 1);
+    expect(readInstrumentParameter(SYNTH_FILTER_CUTOFF, instrument().parameters)).toBe(
+      400,
+    );
   });
 
   it("emits nothing per input tick before the gesture commits", () => {

--- a/src/instrument/SynthPanel.tsx
+++ b/src/instrument/SynthPanel.tsx
@@ -1,7 +1,12 @@
 import { For, type JSX } from "@solidjs/web";
 import { type Analytics, analytics as defaultAnalytics } from "../analytics/analytics";
-import type { RawCommandInput, TransactionResult } from "../commands";
-import { setParameter } from "../commands";
+import type {
+  Gesture,
+  GestureOptions,
+  RawCommandInput,
+  TransactionResult,
+} from "../commands";
+import { createControlGesture, setParameter } from "../commands";
 import type { Instrument } from "../domain/entities";
 import type { TrackId } from "../domain/ids";
 import {
@@ -29,6 +34,7 @@ export interface SynthPanelProps {
   dispatch(
     commands: RawCommandInput | readonly RawCommandInput[],
   ): TransactionResult | undefined;
+  beginGesture(options?: GestureOptions): Gesture | undefined;
   /** Plays one preview note through the track. */
   audition(): void;
   /** Defaults to the application singleton; injectable for tests. */
@@ -52,17 +58,25 @@ const SLIDERS = [
  * Every control dispatches a validated `parameter.set` command in the
  * `instrument` scope — never a direct project mutation — so edits are
  * revision-checked and undoable, and the audio graph reuses its nodes with
- * smoothing. A continuous slider commits once per gesture (on release/blur), so
- * a drag is one command, one history entry, and emits nothing per tick;
+ * smoothing. A continuous slider runs the whole drag as one history gesture
+ * (`createControlGesture`): every move applies live, so the fill, the readout
+ * and the filter follow the pointer, and the release (or blur) commits the lot
+ * as one history entry, one revision and one analytics event (#254).
  * `feature_first_use` for `synth` fires once, on the first edit, not per render.
  */
 export default function SynthPanel(props: SynthPanelProps): JSX.Element {
   const analytics = () => props.analytics ?? defaultAnalytics;
 
-  function commit(parameterId: string, value: number): void {
-    props.dispatch(
-      setParameter({ scope: "instrument", trackId: props.trackId, parameterId }, value),
+  function parameterCommand(parameterId: string, value: number) {
+    return setParameter(
+      { scope: "instrument", trackId: props.trackId, parameterId },
+      value,
     );
+  }
+
+  /** A discrete choice: one command, no gesture to hold open. */
+  function commit(parameterId: string, value: number): void {
+    props.dispatch(parameterCommand(parameterId, value));
     analytics().logFeatureFirstUse("synth");
   }
 
@@ -97,15 +111,23 @@ export default function SynthPanel(props: SynthPanelProps): JSX.Element {
               {(definition) => {
                 const value = () =>
                   readInstrumentParameter(definition, props.instrument.parameters);
+                const control = createControlGesture({
+                  beginGesture: (options) => props.beginGesture(options),
+                  dispatch: (commands) => props.dispatch(commands),
+                  summary: () => `Set ${definition.label}`,
+                  command: (next) =>
+                    parameterCommand(bareParameterId(definition.id), next),
+                });
                 return (
                   <FillSlider
                     definition={definition}
                     value={value()}
                     displayValue={formatInstrumentValue(definition, value())}
-                    onInput={() => {
-                      /* live audio follows on commit; nothing per tick */
+                    onInput={(next) => control.input(next)}
+                    onCommit={(next) => {
+                      control.commit(next);
+                      analytics().logFeatureFirstUse("synth");
                     }}
-                    onCommit={(next) => commit(bareParameterId(definition.id), next)}
                   />
                 );
               }}

--- a/src/instrument/panelTesting.ts
+++ b/src/instrument/panelTesting.ts
@@ -1,0 +1,50 @@
+import { fireEvent } from "@solidjs/testing-library";
+import { Analytics } from "../analytics/analytics";
+import { ConsentStore } from "../analytics/consent";
+import { createRecordingTransport } from "../analytics/transport";
+import type { Gesture, RawCommandInput, TransactionResult } from "../commands";
+import { fireAndFlush } from "../testing/events";
+import { memoryStorage } from "../testing/storage";
+
+/** An `Analytics` with a recording transport, never the app singleton. */
+export function testAnalytics() {
+  const transport = createRecordingTransport();
+  const analytics = new Analytics({
+    transport,
+    consent: new ConsentStore(memoryStorage()),
+    storage: memoryStorage(),
+  });
+  analytics.setAccountType("anonymous");
+  return { transport, analytics };
+}
+
+/**
+ * A gesture that records what a drag applies, for a panel test with no project
+ * behind it. It stays open until the control drops it, as a real one does.
+ */
+export function recordingGesture(applied: RawCommandInput[]): Gesture {
+  return {
+    active: true,
+    apply(commands) {
+      applied.push(...(Array.isArray(commands) ? commands : [commands]));
+      return { ok: true } as TransactionResult;
+    },
+    commit: () => null,
+    cancel: () => {},
+  };
+}
+
+/** One pointer move within a drag: the browser fires `input`, not `change`. */
+export function moveTo(slider: HTMLInputElement, value: string): void {
+  fireAndFlush(() => {
+    fireEvent.input(slider, { target: { value } });
+  });
+}
+
+/** The painted fill's own extent, which is what a fill-slider's value *is*. */
+export function fillExtent(slider: HTMLInputElement): string {
+  const fill = slider
+    .closest(".fill-slider")
+    ?.querySelector<HTMLElement>(".fill-slider-fill");
+  return fill?.style.height ?? "";
+}


### PR DESCRIPTION
## What &amp; why

`SamplerPanel` and `SynthPanel` passed a literal no-op `onInput` and wrote state only in `onCommit`. `FillSlider` is controlled — it paints its fill and its `<output>` readout from `value`, which is read back out of project state — so with nothing applied per tick there was no new state to paint, and the control (and the audio graph reading the same state) sat frozen under the pointer until release.

**The fix suggested in the issue body does not apply and was not done.** It asks to "reuse the mixer slider component as the canonical slider component", but that migration already happened: `SamplerPanel`, `SynthPanel` and `Mixer` all already render the same `FillSlider`. What differed was the *gesture wiring* — the mixer routed every move through a private `createControlGesture` helper, and the instrument panels hand-rolled around it. Re-verified before planning; written up on the issue.

So this extracts that helper and gives the instrument panels the same treatment.

Closes #254

## Second commit: the intermittent lock-up found on the preview

Walking the preview channel turned up a symptom the first commit did not cover: sometimes a slider moved smoothly and the audio followed, sometimes the control **locked up entirely** — no movement, no value change, no message.

Two halves of one defect:

1. **`CommandHistory.beginGesture` throws** when a gesture is already open (`history.ts:210`), and `createControlGesture.input` called it unguarded. So a gesture left open *anywhere* in the editor took down the next control the user touched, from inside its own `input` handler.
2. **Gestures were being left open**, because `FillSlider` only committed on `change` — which never fires when a drag ends somewhere the input does not hear about: released off-element, or the panel unmounted mid-drag by a track switch. One dropped drag then wedged every slider until something else happened to commit.

Both are fixed at their own level. `FillSlider` now commits on pointer up/cancel as well as `change`, closing the gesture at its source — the pattern `PianoRollNote` already uses for its velocity slider. And `createControlGesture` no longer lets a foreign open gesture escape as an exception: it falls back to plain dispatch, so the value still lands and the control still follows the pointer. The cost in that fallback is one history entry per step instead of one per drag — worse to undo, but never a dead control.

Note that half of this was **pre-existing on `main`**, latent in the mixer's private copy of the helper, which is byte-identical. It was rarely hit there (two faders per strip, little unmounting); it became reachable when the same helper started serving seven sliders in a panel that unmounts on every track switch.

## Core flows

Untouched. A bug fix's contract is its regression test, not a core flow. `bun run verify:core-flows` reports 3 flows with one spec each, CF-002/CF-003 still `test.fixme` exactly as on `main` — no flow spec, `docs/core-flows.md`, or `docs/prd.md` was edited, and no `test.fixme` marker was removed.

## Where the helper went

`src/commands/controlGesture.ts`, exported from the `src/commands` barrel. It is a framework-free adapter over `beginGesture`/`dispatch` — no Solid, Firebase or Tone imports, so `commands/boundaries.test.ts` still passes — which puts it beside `history.ts`, the module that owns `beginGesture`. Both `editor/` and `instrument/` already import from `../commands`, so #255's drum-machine, step-editor and piano-roll sliders can reach it without a new dependency direction.

**The move is only a move.** The mixer's private copy is deleted rather than duplicated, and the function body was unchanged in the extracting commit apart from two added doc lines; the lock-up guard arrived as its own later commit, on top. `Mixer.test.tsx` is untouched and green at 23 tests. `beginGesture` is threaded `TrackEditor` → `InstrumentPanel` → both panels; `EditorView` already passed it to `TrackEditor`.

## Two pre-existing tests changed shape — deliberately

`"dispatches an instrument parameter.set once when a slider commits"` in both panel test files now reads the commands the gesture applied instead of the `dispatch` spy. That is not a weakened assertion dodging the change — it is the change: a slider's command sink moves from `dispatch` to `gesture.apply`, which is the whole point of the fix. Both still assert exactly one command with the right scope and `parameterId`.

Every other pre-existing test is byte-identical and passing, including both `"emits nothing per input tick"` tests and the synth `feature_first_use` test.

## Walkthrough

Not captured — the browser suites cannot run in this environment (see Evidence), and `walkthrough:capture` drives the Playwright flow specs.

The change **is** user-visible: sampler pitch / sample start-end / ADSR and synth ADSR / filter cutoff / resonance now move under the pointer — fill, numeric readout and `aria-valuetext` — and the sound changes during the drag instead of jumping on release. Undo is unchanged: one drag is still one step. The regression tests below assert exactly that, including the painted fill extent.

## Evidence

Regression tests, one per panel: `SamplerPanel > follows the pointer mid-drag, and still commits once (#254)` and the matching `SynthPanel` test. Each renders the panel over a real `CommandHistory`, so the slider's `value` really does come back out of the project it edits.

Red first, on the test-only commit with every product file at `origin/main`:

```
 FAIL  |ui| src/instrument/SamplerPanel.test.tsx > SamplerPanel > follows the pointer mid-drag, and still commits once (#254)
TestingLibraryElementError: Unable to find an element with the text: +5 st.

 FAIL  |ui| src/instrument/SynthPanel.test.tsx > SynthPanel > follows the pointer mid-drag, and still commits once (#254)
TestingLibraryElementError: Unable to find an element with the text: 760 Hz.

 Test Files  2 failed (2)
      Tests  4 failed | 9 passed (13)
```

The dumped DOM in that failure is the symptom itself: after dragging pitch to +5 the `<output>` still reads `0 st`, `aria-valuetext="0 st"`, and `<div class="fill-slider-fill" style="height: 50%;">` is unmoved.

For the lock-up, two more tests, each verified red by reverting only its own source change:

- `createControlGesture > still lands values while another gesture is open, instead of throwing` — red with `Error: A gesture is already in progress; commit or cancel it first`.
- `SamplerPanel > commits its gesture on pointer-up, with no change event (#254)` — asserts `history.gestureActive` goes false and exactly one entry lands, with no `change` fired.

| Command | Result |
| --- | --- |
| `bun run typecheck` | pass |
| `bun run check` | pass — biome 503 files, `verify:no-solid-1` clean |
| `bun run test` | pass — 160 files, 2057 tests (run twice, zero failures in the JSON report both times) |
| `bun run verify:test-projects` | pass — one owner per file |
| `bun run verify:core-flows` | pass — 3 flows, one spec each |

**Browser suites did not run.** `bun run test:browser:install` fails to reach the Playwright CDN in this container, which CLAUDE.md anticipates. CI's matrix on push is the cross-browser check for this change; there is no Chromium pre-flight evidence and none should be inferred.

## Known gap, not fixed here

Clicks and pops while dragging were reported on the preview. Not addressed in this PR, and not yet attributed: the sampler cannot be the source (`instruments/sampler.ts:111` `update()` is a plain assignment read on the *next* trigger, so no live node is touched), and the mixer, synth filter and drum pads all ramp over `SMOOTHING_SECONDS`/`MIXER_SMOOTHING_SECONDS` (0.02s). Whether this predates the PR — the mixer has always applied live — is the open question, and it wants its own issue rather than a speculative fix bolted on here.

## Acceptance criteria met

- Instrument sliders track the pointer during a drag, on screen and in audio.
- One drag is still one history entry and one revision — asserted, not assumed (`history.entries` is empty mid-drag, length 1 after `change`, `revision === startRevision + 1`).
- A dropped drag no longer wedges the editor's other controls.
- Scope held to the instrument panels. The drum-machine, step-editor and piano-roll sliders have the mirror-image defect (they track the pointer but write one history entry and one revision *per pointer move*) and are deliberately left for #255, which builds on this same extraction.