### PR TITLE
Fix #256 (1/1): Duplicating notes refused instead of extending the clip

### DIFF
--- a/src/commands/definitions/parameters.ts
+++ b/src/commands/definitions/parameters.ts
@@ -287,6 +287,7 @@ function expectParameter(
 }
 
 const UNIT_SUFFIX: Record<ParameterDefinition["unit"], string> = {
+  bars: " bars",
   bpm: " BPM",
   decibels: " dB",
   hertz: " Hz",

--- a/src/commands/definitions/transforms.ts
+++ b/src/commands/definitions/transforms.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { nextClipLengthTicks } from "../../domain/clipLength";
 import type { Clip, NoteEvent, Project } from "../../domain/entities";
 import {
   type ClipId,
@@ -27,6 +28,7 @@ import {
   type RegisteredCommand,
   rejected,
 } from "../types";
+import { updateClip } from "./clips";
 import { addNotes, type NoteChanges, removeNotes, updateNotes } from "./notes";
 
 /**
@@ -311,6 +313,7 @@ export const notesDuplicateCommand = defineCommand<NotesDuplicatePayload>({
       (noteEventsOf(selection.clip) ?? []).map((event) => event.id),
     );
     const copies: NoteEvent[] = [];
+    let neededTicks = 0;
     for (const [index, event] of selection.events.entries()) {
       const id = payload.newIds[index];
       if (existing.has(id)) {
@@ -321,29 +324,59 @@ export const notesDuplicateCommand = defineCommand<NotesDuplicatePayload>({
       // leaves the safe-integer range is a rejection with a reason, not a
       // throw out of `toTicks`.
       const startTicks = event.startTicks + payload.offsetTicks;
-      if (!isTicks(startTicks) || startTicks >= selection.clip.lengthTicks) {
-        return rejected(
-          `Duplicating by ${payload.offsetTicks} ticks would push a note past the end of clip ${selection.clip.id}`,
-        );
+      if (!isTicks(startTicks)) {
+        return rejected(pastTheEnd(payload.offsetTicks, selection.clip));
       }
+      neededTicks = Math.max(neededTicks, startTicks + event.durationTicks);
       copies.push({ ...event, id, startTicks });
     }
     if (copies.length !== payload.newIds.length) {
       return rejected("Duplicate note ids must be new");
     }
-    return applied(
-      replaceClip(
-        project,
-        withNoteEvents(selection.clip, [
-          ...(noteEventsOf(selection.clip) ?? []),
-          ...copies,
-        ]),
-      ),
-    );
+    // Issue #256: asking to duplicate is an unambiguous intent, so a copy with
+    // no room grows the clip instead of rejecting the edit. The resize happens
+    // inside this one command, which is what makes it one revision and one
+    // undo step with the copies rather than a second transaction.
+    const lengthTicks = extendedLength(selection.clip, neededTicks);
+    if (lengthTicks === null) {
+      return rejected(pastTheEnd(payload.offsetTicks, selection.clip));
+    }
+    const withCopies = withNoteEvents(selection.clip, [
+      ...(noteEventsOf(selection.clip) ?? []),
+      ...copies,
+    ]);
+    return applied(replaceClip(project, { ...withCopies, lengthTicks }));
   },
-  invert: (payload) =>
-    payload.newIds.length > 0 ? [removeNotes(payload.clipId, payload.newIds)] : [],
+  invert(payload, before, after) {
+    const commands: RawCommandInput[] = [];
+    if (payload.newIds.length > 0) {
+      commands.push(removeNotes(payload.clipId, payload.newIds));
+    }
+    // The notes come out before the clip shrinks back, or the restored project
+    // would briefly hold notes outside their clip.
+    const previous = findClip(before, payload.clipId);
+    const next = findClip(after, payload.clipId);
+    if (previous && next && previous.lengthTicks !== next.lengthTicks) {
+      commands.push(updateClip(payload.clipId, { lengthTicks: previous.lengthTicks }));
+    }
+    return commands;
+  },
 });
+
+function pastTheEnd(offsetTicks: number, clip: Clip): string {
+  return `Duplicating by ${offsetTicks} ticks would push a note past the end of clip ${clip.id}`;
+}
+
+/**
+ * The length the clip needs to hold copies ending at `neededTicks`: its own
+ * length when they already fit, the next listed clip length when they do not,
+ * and `null` when even the longest clip could not hold them.
+ */
+function extendedLength(clip: Clip, neededTicks: number): Ticks | null {
+  return neededTicks > clip.lengthTicks
+    ? nextClipLengthTicks(neededTicks)
+    : clip.lengthTicks;
+}
 
 export const notesClearCommand = defineCommand<NotesClearPayload>({
   type: "notes.clear",

--- a/src/commands/structure.test.ts
+++ b/src/commands/structure.test.ts
@@ -5,6 +5,7 @@ import {
   createPlacement,
   createSamplerInstrument,
   createTrack as createTrackEntity,
+  MAX_CLIP_LENGTH_BARS,
   type Project,
   TICKS_PER_BAR,
   toTicks,
@@ -183,6 +184,31 @@ describe("structural commands", () => {
       if (result.ok) return;
       expect(result.issues[0].code).toBe("invalid_project");
       expect(result.issues[0].domainIssues?.[0].code).toBe("invalid_musical_time");
+    });
+
+    it("resizes a clip up to the 32-bar maximum", () => {
+      const next = apply(
+        fixture.project,
+        updateClip(fixture.clipAId, {
+          lengthTicks: toTicks(TICKS_PER_BAR * MAX_CLIP_LENGTH_BARS),
+        }),
+      );
+      expect(findClip(next, fixture.clipAId)?.lengthTicks).toBe(
+        TICKS_PER_BAR * MAX_CLIP_LENGTH_BARS,
+      );
+    });
+
+    it("refuses a clip longer than the 32-bar maximum (#256)", () => {
+      const result = executeCommand(fixture.project, {
+        type: "clip.update",
+        payload: {
+          clipId: fixture.clipAId,
+          changes: { lengthTicks: TICKS_PER_BAR * (MAX_CLIP_LENGTH_BARS + 1) },
+        },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.issues[0].code).toBe("invalid_payload");
     });
   });
 

--- a/src/commands/transforms.test.ts
+++ b/src/commands/transforms.test.ts
@@ -30,10 +30,7 @@ function eventsOf(
   return clip ? (noteEventsOf(clip) ?? []) : [];
 }
 
-function clipLengthOf(
-  project: Project,
-  clipId: CommandTestProject["clipAId"],
-): number {
+function clipLengthOf(project: Project, clipId: CommandTestProject["clipAId"]): number {
   return findClip(project, clipId)?.lengthTicks ?? -1;
 }
 

--- a/src/commands/transforms.test.ts
+++ b/src/commands/transforms.test.ts
@@ -14,10 +14,11 @@ import {
   quantizeNotes,
   scaleNoteVelocity,
   transposeNotes,
+  updateClip,
   updateNote,
   varyNotes,
 } from ".";
-import { executeCommand } from "./execute";
+import { executeCommand, executeTransaction } from "./execute";
 import { findClip, noteEventsOf } from "./projectEdits";
 import { type CommandTestProject, createCommandTestProject } from "./testProjects";
 
@@ -27,6 +28,13 @@ function eventsOf(
 ): readonly NoteEvent[] {
   const clip = findClip(project, clipId);
   return clip ? (noteEventsOf(clip) ?? []) : [];
+}
+
+function clipLengthOf(
+  project: Project,
+  clipId: CommandTestProject["clipAId"],
+): number {
+  return findClip(project, clipId)?.lengthTicks ?? -1;
 }
 
 function pitchesOf(project: Project, clipId: CommandTestProject["clipAId"]): number[] {
@@ -206,10 +214,78 @@ describe("musical transformations (CLP-04)", () => {
       expect(eventsOf(next, fixture.clipAId)).toHaveLength(8);
     });
 
-    it("refuses to push a copy past the end of the clip", () => {
+    // Issue #256. This used to assert the opposite: a duplicate with no room
+    // rejected the whole transaction, which is the bug — the user's intent is
+    // unambiguous, so the clip grows to hold the copies instead.
+    it("extends the clip to the next listed length instead of rejecting", () => {
       const command = duplicateNotes(createIdFactory(), fixture.project, {
         clipId: fixture.clipAId,
         offsetTicks: TICKS_PER_BAR,
+      });
+      const result = executeCommand(fixture.project, command);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(clipLengthOf(result.project, fixture.clipAId)).toBe(TICKS_PER_BAR * 2);
+      expect(eventsOf(result.project, fixture.clipAId)).toHaveLength(8);
+      // One transaction, so one revision and one history entry.
+      expect(result.revision).toBe(fixture.project.metadata.revision + 1);
+      expect(result.commands).toHaveLength(1);
+    });
+
+    it("rounds the extension up to a listed length, never an unlisted one", () => {
+      const wider = apply(
+        fixture.project,
+        updateClip(fixture.clipAId, { lengthTicks: toTicks(TICKS_PER_BAR * 2) }),
+      );
+      // The copies land in the third bar, which 1/2/4/8/16/32 cannot express.
+      const next = apply(
+        wider,
+        duplicateNotes(createIdFactory(), wider, {
+          clipId: fixture.clipAId,
+          offsetTicks: TICKS_PER_BAR * 2,
+        }),
+      );
+      expect(clipLengthOf(next, fixture.clipAId)).toBe(TICKS_PER_BAR * 4);
+    });
+
+    it("undoes the extension and the copies as one step", () => {
+      const result = executeCommand(
+        fixture.project,
+        duplicateNotes(createIdFactory(), fixture.project, {
+          clipId: fixture.clipAId,
+          offsetTicks: TICKS_PER_BAR,
+        }),
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const undone = executeTransaction(result.project, result.inverse);
+      expect(undone.ok).toBe(true);
+      if (!undone.ok) return;
+      expect(clipLengthOf(undone.project, fixture.clipAId)).toBe(TICKS_PER_BAR);
+      expect(eventsOf(undone.project, fixture.clipAId)).toHaveLength(4);
+    });
+
+    it("leaves the clip length alone when the copies already fit", () => {
+      const wider = apply(
+        fixture.project,
+        updateClip(fixture.clipAId, { lengthTicks: toTicks(TICKS_PER_BAR * 2) }),
+      );
+      const next = apply(
+        wider,
+        duplicateNotes(createIdFactory(), wider, {
+          clipId: fixture.clipAId,
+          offsetTicks: TICKS_PER_BAR,
+        }),
+      );
+      expect(clipLengthOf(next, fixture.clipAId)).toBe(TICKS_PER_BAR * 2);
+    });
+
+    it("still refuses to push a copy past the 32-bar clip maximum", () => {
+      const command = duplicateNotes(createIdFactory(), fixture.project, {
+        clipId: fixture.clipAId,
+        offsetTicks: TICKS_PER_BAR * 32,
       });
       const result = executeCommand(fixture.project, command);
       expect(result.ok).toBe(false);

--- a/src/domain/clipLength.ts
+++ b/src/domain/clipLength.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { CLIP_LENGTH } from "./parameters";
+import { TICKS_PER_BAR, type Ticks, toTicks } from "./time";
+
+/**
+ * The clip-length bound, in the two units the rest of the app needs it.
+ *
+ * `CLIP_LENGTH` (`src/domain/parameters.ts`) is where the range is declared;
+ * everything here derives from it, so the domain schema, the step editor's bar
+ * control, and `notes.duplicate`'s auto-extend cannot drift apart. The bound
+ * belongs to clip length alone — `durationTickSchema` stays unbounded because
+ * note, placement, and section durations share it and are not capped at 32
+ * bars.
+ */
+
+export const MIN_CLIP_LENGTH_BARS = CLIP_LENGTH.min;
+export const MAX_CLIP_LENGTH_BARS = CLIP_LENGTH.max;
+export const MAX_CLIP_LENGTH_TICKS = MAX_CLIP_LENGTH_BARS * TICKS_PER_BAR;
+
+/**
+ * The clip lengths a user can choose, in bars. Doubling lengths are what fit
+ * musically and keep the control a short list rather than a 32-item dropdown,
+ * so an auto-extend rounds up to one of these rather than to any whole bar.
+ */
+export const CLIP_LENGTH_BARS: readonly number[] = [1, 2, 4, 8, 16, 32];
+
+/** A clip length: positive, and no longer than the maximum. */
+export const clipLengthTickSchema = z
+  .int()
+  .min(1)
+  .max(MAX_CLIP_LENGTH_TICKS)
+  .brand<"ticks">();
+
+/**
+ * The shortest listed clip length that holds `minimumTicks`, or `null` when
+ * that is past the maximum.
+ */
+export function nextClipLengthTicks(minimumTicks: number): Ticks | null {
+  for (const bars of CLIP_LENGTH_BARS) {
+    const ticks = bars * TICKS_PER_BAR;
+    if (ticks >= minimumTicks) {
+      return toTicks(ticks);
+    }
+  }
+  return null;
+}

--- a/src/domain/entities.ts
+++ b/src/domain/entities.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { clipLengthTickSchema } from "./clipLength";
 import {
   assetIdSchema,
   automationIdSchema,
@@ -369,7 +370,7 @@ export const clipSchema = z.strictObject({
   trackId: trackIdSchema,
   name: displayName,
   color: colorSchema,
-  lengthTicks: durationTickSchema,
+  lengthTicks: clipLengthTickSchema,
   content: clipContentSchema,
 });
 export type Clip = z.infer<typeof clipSchema>;

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -10,6 +10,7 @@
  * commands, audio, and rendering consume this model from the outside.
  */
 
+export * from "./clipLength";
 export * from "./devices";
 export * from "./entities";
 export * from "./factories";

--- a/src/domain/parameters.test.ts
+++ b/src/domain/parameters.test.ts
@@ -41,6 +41,7 @@ describe("parameter definitions", () => {
 
   it("registers exactly the parameters the alpha needs so far", () => {
     expect([...parameterDefinitions().keys()].sort()).toEqual([
+      "clip.length",
       "master.volume",
       "note.probability",
       "note.velocity",

--- a/src/domain/parameters.ts
+++ b/src/domain/parameters.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
  */
 
 export type ParameterUnit =
+  | "bars"
   | "bpm"
   | "decibels"
   | "normalized"
@@ -108,6 +109,23 @@ export const SONG_TEMPO = register({
   min: 20,
   max: 300,
   defaultValue: 120,
+  automatable: false,
+});
+
+/**
+ * How long a clip may be. Declared here so the domain schema, the step
+ * editor's bar control, and `notes.duplicate`'s auto-extend all read one
+ * number; `src/domain/clipLength.ts` derives the tick forms.
+ */
+export const CLIP_LENGTH = register({
+  id: "clip.length",
+  label: "Clip length",
+  unit: "bars",
+  min: 1,
+  max: 32,
+  defaultValue: 1,
+  step: 1,
+  clampPolicy: "reject",
   automatable: false,
 });
 

--- a/src/domain/parse/clip.ts
+++ b/src/domain/parse/clip.ts
@@ -1,3 +1,4 @@
+import { MAX_CLIP_LENGTH_BARS, MAX_CLIP_LENGTH_TICKS } from "../clipLength";
 import type { Clip, Track } from "../entities";
 import { TICKS_PER_BAR } from "../time";
 import { claimId, type DomainIssue, issue } from "./primitives";
@@ -16,6 +17,18 @@ export function checkClipInvariants(
   seenIds: Set<string> = new Set(),
 ): DomainIssue[] {
   const issues: DomainIssue[] = [];
+  // The clip-length bound is checked here as well as in the schema, so every
+  // path that writes a length obeys it: `executeTransaction` runs the
+  // invariants over the project a command produced, not its schemas.
+  if (clip.lengthTicks > MAX_CLIP_LENGTH_TICKS) {
+    issues.push(
+      issue(
+        "invalid_musical_time",
+        [...path, "lengthTicks"],
+        `Clip ${clip.id} is ${clip.lengthTicks} ticks long, past the ${MAX_CLIP_LENGTH_BARS}-bar maximum of ${MAX_CLIP_LENGTH_TICKS} ticks`,
+      ),
+    );
+  }
   if (clip.content.kind !== "notes") {
     return issues;
   }

--- a/src/editor/PianoRoll.test.tsx
+++ b/src/editor/PianoRoll.test.tsx
@@ -7,6 +7,7 @@ import {
   createRecordingTransport,
   type RecordingTransport,
 } from "../analytics/transport";
+import { updateClip } from "../commands";
 import type { Clip, NoteEvent } from "../domain/entities";
 import { createPianoRollFixtureProject } from "../domain/fixtures";
 import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
@@ -391,6 +392,34 @@ describe("PianoRoll", () => {
     const copy = after.find((n) => n.startTicks === first.startTicks + TICKS_PER_BAR);
     expect(copy).toBeDefined();
     expect(copy?.trigger).toEqual(first.trigger);
+  });
+
+  it("extends a full clip rather than refusing to duplicate", async () => {
+    const { session, renderRoll, getActions } = await setUp();
+    // A one-bar clip with a bar of notes — the starter project's shape, where
+    // every copy lands at the clip end and duplicating used to be refused
+    // outright (#256).
+    session.dispatch(
+      updateClip(session.project.clips[0].id, {
+        lengthTicks: TICKS_PER_BAR as Clip["lengthTicks"],
+      }),
+    );
+    flush();
+    renderRoll();
+
+    getActions()?.selectAll();
+    flush();
+    getActions()?.duplicateSelection();
+    flush();
+
+    const clip = session.project.clips[0];
+    expect(noteEvents(clip)).toHaveLength(8);
+    expect(clip.lengthTicks).toBe(TICKS_PER_BAR * 2);
+    // One transaction, so one undo puts the copies and the extension back.
+    session.undo();
+    flush();
+    expect(noteEvents(session.project.clips[0])).toHaveLength(4);
+    expect(session.project.clips[0].lengthTicks).toBe(TICKS_PER_BAR);
   });
 
   it("deletes the selection from the toolbar Delete button", async () => {

--- a/src/editor/StepEditor.test.tsx
+++ b/src/editor/StepEditor.test.tsx
@@ -295,6 +295,15 @@ describe("StepEditor", () => {
     expect(history.entries.at(-1)?.commands[0].type).toBe("clip.update");
   });
 
+  it("offers the musical bar lengths up to 32 rather than every integer", () => {
+    renderEditor(createSliceFixtureProject());
+    const select = screen.getByRole("combobox", { name: "Bars" });
+    const options = Array.from(select.querySelectorAll("option")).map(
+      (option) => option.textContent,
+    );
+    expect(options).toEqual(["1", "2", "4", "8", "16", "32"]);
+  });
+
   it("marks the current playback step while playing", () => {
     const { setPlaybackStep } = renderEditor(createSliceFixtureProject());
     setPlaybackStep(3);

--- a/src/editor/StepEditor.tsx
+++ b/src/editor/StepEditor.tsx
@@ -10,6 +10,7 @@ import { NOTE_VELOCITY } from "../domain/parameters";
 import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
 import {
   barCount,
+  barOptions,
   isBarStart,
   isBeatStart,
   lanesFor,
@@ -53,7 +54,7 @@ export interface StepEditorProps {
 }
 
 /**
- * The CLP-02 step editor: a 1-8 bar, 16th-note grid for sampler and
+ * The CLP-02 step editor: a 1-32 bar, 16th-note grid for sampler and
  * drum-machine clips. Replaces the `FND-009` slice's minimal 16-step
  * `StepGrid`.
  *
@@ -215,12 +216,7 @@ export default function StepEditor(props: StepEditorProps): JSX.Element {
             value={bars()}
             onChange={(event) => resizeToBars(Number(event.currentTarget.value))}
           >
-            <For
-              each={Array.from(
-                { length: MAX_BARS - MIN_BARS + 1 },
-                (_, index) => MIN_BARS + index,
-              )}
-            >
+            <For each={barOptions(props.clip)}>
               {(count) => <option value={count}>{count}</option>}
             </For>
           </select>

--- a/src/editor/stepEditorModel.test.ts
+++ b/src/editor/stepEditorModel.test.ts
@@ -8,6 +8,7 @@ import {
 import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
 import {
   barCount,
+  barOptions,
   eventCountBucket,
   isBarStart,
   isBeatStart,
@@ -47,24 +48,38 @@ describe("stepEditorModel", () => {
     );
   });
 
-  it("counts steps from the clip's bar length, clamped to 1-8 bars", () => {
+  it("counts steps from the clip's bar length, up to the 32-bar maximum", () => {
     const project = createSliceFixtureProject();
     const clip = project.clips[0];
     expect(barCount(clip)).toBe(1);
     expect(stepCount(clip)).toBe(STEPS_PER_BAR);
 
-    const eightBars = {
-      ...clip,
-      lengthTicks: (TICKS_PER_BAR * 8) as typeof clip.lengthTicks,
-    };
-    expect(barCount(eightBars)).toBe(8);
-    expect(stepCount(eightBars)).toBe(8 * STEPS_PER_BAR);
-
-    const overMax = {
+    const twelveBars = {
       ...clip,
       lengthTicks: (TICKS_PER_BAR * 12) as typeof clip.lengthTicks,
     };
+    // Twelve bars used to clamp to eight, hiding a third of the clip (#256).
+    expect(barCount(twelveBars)).toBe(12);
+    expect(stepCount(twelveBars)).toBe(12 * STEPS_PER_BAR);
+
+    const overMax = {
+      ...clip,
+      lengthTicks: (TICKS_PER_BAR * 40) as typeof clip.lengthTicks,
+    };
     expect(barCount(overMax)).toBe(MAX_BARS);
+    expect(MAX_BARS).toBe(32);
+  });
+
+  it("offers the musical bar lengths, plus the clip's own when unlisted", () => {
+    const project = createSliceFixtureProject();
+    const clip = project.clips[0];
+    expect(barOptions(clip)).toEqual([1, 2, 4, 8, 16, 32]);
+
+    const threeBars = {
+      ...clip,
+      lengthTicks: (TICKS_PER_BAR * 3) as typeof clip.lengthTicks,
+    };
+    expect(barOptions(threeBars)).toEqual([1, 2, 3, 4, 8, 16, 32]);
   });
 
   it("marks bar and beat starts distinctly across two bars", () => {

--- a/src/editor/stepEditorModel.ts
+++ b/src/editor/stepEditorModel.ts
@@ -1,5 +1,10 @@
 import type { BucketLabel } from "../analytics/buckets";
 import { bucketOf } from "../analytics/buckets";
+import {
+  CLIP_LENGTH_BARS,
+  MAX_CLIP_LENGTH_BARS,
+  MIN_CLIP_LENGTH_BARS,
+} from "../domain/clipLength";
 import type { Clip, Instrument, NoteEvent, NoteTrigger } from "../domain/entities";
 import type { EventId, PadId } from "../domain/ids";
 import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
@@ -17,9 +22,9 @@ import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
 /** A 16th note is the grid's fixed resolution (PRD CLP-02, 192 PPQ). */
 export const STEPS_PER_BAR = TICKS_PER_BAR / TICKS_PER_SIXTEENTH;
 
-/** The clip-length range CLP-02 supports, in bars. */
-export const MIN_BARS = 1;
-export const MAX_BARS = 8;
+/** The clip-length range CLP-02 supports, in bars — the domain's bound. */
+export const MIN_BARS = MIN_CLIP_LENGTH_BARS;
+export const MAX_BARS = MAX_CLIP_LENGTH_BARS;
 
 /**
  * One row of the grid. A drum-machine clip shows one lane per pad, named after
@@ -33,13 +38,26 @@ export interface StepLane {
 }
 
 /**
- * How many bars the clip spans, clamped to the 1-8 bar range. A clip whose
+ * How many bars the clip spans, clamped to the supported range. A clip whose
  * `lengthTicks` is not a whole number of bars rounds up to the next bar so no
  * step is hidden.
  */
 export function barCount(clip: Clip): number {
   const bars = Math.ceil(clip.lengthTicks / TICKS_PER_BAR);
   return Math.min(MAX_BARS, Math.max(MIN_BARS, bars));
+}
+
+/**
+ * The bar lengths the length control offers: the musical list (1/2/4/8/16/32)
+ * rather than every integer, which at 32 bars would be an unusable dropdown.
+ * A clip already sitting at an unlisted length keeps its own value in the list
+ * so the control shows what the clip actually is instead of rendering blank.
+ */
+export function barOptions(clip: Clip): number[] {
+  const current = barCount(clip);
+  return CLIP_LENGTH_BARS.includes(current)
+    ? [...CLIP_LENGTH_BARS]
+    : [...CLIP_LENGTH_BARS, current].sort((a, b) => a - b);
 }
 
 /** Total 16th-note steps across the clip's bars. */


### PR DESCRIPTION
## What & why

Duplicating notes on a clip with no room left told the user "Duplicating by N ticks would push a note past the end of clip …" instead of doing what they clearly asked for. Root cause: `notes.duplicate` (`src/commands/definitions/transforms.ts`) rejected the whole transaction as soon as any copy's `startTicks` reached `clip.lengthTicks`, and the piano roll always duplicates by exactly one bar (`TICKS_PER_BAR`) — so on the starter project's one-bar clip, Duplicate could never succeed at all, only ever refuse.

The fix addresses the cause, not the symptom: `notes.duplicate.apply` now grows the clip to hold the copies instead of rejecting.

- The resize happens *inside* `notes.duplicate.apply`, not as a second dispatch, so `executeTransaction` still gives one revision and one history entry — honoring the command-layer invariant in CLAUDE.md "Shared command layer": *"One committed transaction produces exactly one revision and one history entry."* The generated inverse removes the copies before shrinking the clip back, so no intermediate project state ever holds notes outside their clip.
- The extension rounds up to the next *listed* clip length (1/2/4/8/16/32 bars) past the end of the last copy, per the acceptance criteria settled on the issue, so every length auto-extend can produce is one the step editor's bar control can also select.
- Clip length gets a real domain-level ceiling (32 bars) instead of a UI-only 8-bar clamp: `CLIP_LENGTH` is declared once in `src/domain/parameters.ts` (per CLAUDE.md's "Canonical domain model" — *"A user-controlled numeric value declares its range, unit, default, clamping policy… once… UI, validation, audio, and assistant tools read that definition"*), `clipLengthTickSchema` bounds `Clip.lengthTicks` so both `clip.update`'s payload and `parseProject` enforce it, and a clip invariant covers every command path. `durationTickSchema` stays unbounded, as instructed on the issue — note/placement/section durations share it and are not being capped.
- No placement is resized (settled explicitly on the issue): a clip is shared, so every placement picks up the new notes, but an unlooped placement still sounds only its own length until the user lengthens it themselves.
- Duplicating past the 32-bar ceiling still rejects, with the existing message.

**One consequence worth stating**, since it widens when auto-extend fires: the extension is measured from the **end** of the last copy (`startTicks + durationTicks`), which is the literal reading of the settled criterion "past the end of the last duplicated note". The domain invariant only rejects notes by their *start* (`checkClipInvariants` checks `startTicks >= lengthTicks`), so a copy that begins inside the clip but overhangs its end was previously accepted with no resize, and now triggers one. Because the listed lengths double, a 4-bar clip holding a 2-bar note at bar 3, duplicated by one bar, jumps straight to 8 bars. That is a deliberate widening, derived from the criteria rather than assumed.

Closes #256

## Core flows

None — bug fix, no core flow specced or completed by this PR.

## Walkthrough

No walkthrough — and not because this fix is invisible. It changes two things a user sees (the `Duplicate` button now grows the clip instead of reporting "The copies would not fit inside this clip"; the step editor's **Bars** control now lists 1/2/4/8/16/32 instead of every integer 1–8), but **no registered core flow walks either surface**, so there is no passing spec to capture from.

Verified rather than asserted — `bun run walkthrough:capture` was run on this branch:

- Only **CF-001** is an active flow; CF-002…CF-007 are all still `test.fixme`, each gated on its own unmerged issue. CF-001's journey is landing page → dashboard → new project → step editor → toggle one step → play. It never selects or duplicates a note, and never opens the bar-length control. Its five screenshots show **Bars** as a collapsed select control reading "1" — pixel-identical before and after this change.
- **CF-003** and **CF-007** are the only registered flows that mention duplication, and both duplicate something else: a *placement* and a *device* respectively. Both are `test.fixme`, and a bug fix must not remove a fixme marker — that belongs to the feature delivering the flow.

So the gap is flow coverage, not tooling. Capturing CF-001 here would dress an unrelated journey up as evidence for this fix, which is worse than saying plainly that no flow covers it. Flagged for the product owner: a flow exercising note duplication would close this gap.

## Evidence

Independently reproduced the red before merging on top of the branch's own commits:

```
$ bunx vitest run --project=domain src/commands/transforms.test.ts   # source reverted to main, test kept as-is
 FAIL  |domain| src/commands/transforms.test.ts > musical transformations (CLP-04) > notes.duplicate > extends the clip to the next listed length instead of rejecting
AssertionError: expected false to be true
 FAIL  |domain| src/commands/transforms.test.ts > musical transformations (CLP-04) > notes.duplicate > rounds the extension up to a listed length, never an unlisted one
Error: Expected the command to apply: Duplicating by 1536 ticks would push a note past the end of clip clp_1b-xq0neNLrXMmVv5Qj-z
 FAIL  |domain| src/commands/transforms.test.ts > musical transformations (CLP-04) > notes.duplicate > undoes the extension and the copies as one step
AssertionError: expected false to be true
 Test Files  1 failed (1)
      Tests  3 failed | 24 passed (27)
```

That matches, line for line, the red the fixer recorded before writing the fix (issue comment, and the regression-test commit message). With the fix's source restored:

```
$ bunx vitest run --project=domain src/commands/transforms.test.ts
 ✓ |domain| src/commands/transforms.test.ts (27 tests) 64ms
 Test Files  1 passed (1)
      Tests  27 passed (27)
```

Full suite, run fresh on this branch:

```
$ bun run typecheck
$ tsc --noEmit
(no output — clean)

$ bun run test
 Test Files  160 passed (160)
      Tests  2070 passed (2070)

$ bun run check
$ tsc --noEmit && biome check && bun run verify:no-solid-1
Checked 508 files in 550ms. No fixes applied.
check-no-solid-1 — no Solid 1 idioms found.
```

The fixer additionally ran (see issue #256 comments): `bun run verify:core-flows`, `bun run verify:test-projects`, `bun run test:browser:chromium` (20 passed), `bun run test:browser:emulator:chromium` (5 passed, 6 skipped) — Chromium only in this container; CI gates the cross-browser matrix on push.

This branch went through an adversarial Opus review before this PR was opened.

## Acceptance criteria met

From the issue's settled acceptance criteria (see comments):

- [x] Duplicating on a clip with no room extends the clip to the next listed length (1/2/4/8/16/32) past the end of the last duplicated note and succeeds; no rejection message reaches the user.
- [x] The clip extension and the new notes are one history entry and one revision — one undo puts both back. The resize does not dispatch separately.
- [x] No placement is resized. Duplicating changes the clip only.
- [x] Clips can reach 32 bars, capped at the domain level so every clip-length write obeys it; the step editor's bar control offers 1/2/4/8/16/32.
- [x] Duplicating past 32 bars still rejects, with the existing message.