### PR TITLE
Fix #255 (1/2): Note and step velocity sliders had thumbs and no fill

### DIFF
--- a/src/editor/PianoRoll.css
+++ b/src/editor/PianoRoll.css
@@ -154,12 +154,21 @@
   background: rgba(255, 255, 255, 0.25);
 }
 
+/* The note's velocity fill slider, in the compact shape: a 4px track and no
+   chrome, so it fits inside the note block without changing its height. */
 .pr-note-velocity {
+  --fill-slider-track-thickness: 4px;
+
   width: 100%;
-  height: 4px;
-  margin: 0;
-  accent-color: rgba(0, 0, 0, 0.55);
   cursor: pointer;
+}
+
+.pr-note-velocity .fill-slider-track {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.pr-note-velocity .fill-slider-fill {
+  background-color: rgba(0, 0, 0, 0.55);
 }
 
 .pr-marquee {

--- a/src/editor/PianoRoll.test.tsx
+++ b/src/editor/PianoRoll.test.tsx
@@ -421,7 +421,7 @@ describe("PianoRoll", () => {
     const { container } = renderRoll();
     const note = noteEvents(session.project.clips[0])[0];
     const el = noteEl(container, note.id);
-    const slider = el.querySelector(".pr-note-velocity") as HTMLInputElement;
+    const slider = el.querySelector(".pr-note-velocity input") as HTMLInputElement;
 
     fireEvent.input(slider, { target: { value: "0.3" } });
     // `change` fires when the slider settles, committing the gesture.
@@ -460,7 +460,7 @@ describe("PianoRoll", () => {
     const { container } = renderRoll();
     const note = noteEvents(session.project.clips[0])[0];
     const el = noteEl(container, note.id);
-    const slider = el.querySelector(".pr-note-velocity") as HTMLInputElement;
+    const slider = el.querySelector(".pr-note-velocity input") as HTMLInputElement;
     const startRevision = session.project.metadata.revision;
     const startUndoDepth = session.history.entries.length;
     const startEdited = clipEditedEvents(transport).length;
@@ -542,7 +542,9 @@ describe("PianoRoll", () => {
       beginGesture: wrappedBeginGesture,
     });
     const reenterEl = noteEl(reenterContainer, note.id);
-    reenterSlider = reenterEl.querySelector(".pr-note-velocity") as HTMLInputElement;
+    reenterSlider = reenterEl.querySelector(
+      ".pr-note-velocity input",
+    ) as HTMLInputElement;
 
     reenter = true;
     expect(() => {
@@ -670,7 +672,7 @@ describe("PianoRoll", () => {
       });
       const note = noteEvents(session.project.clips[0])[0];
       const slider = noteEl(container, note.id).querySelector(
-        ".pr-note-velocity",
+        ".pr-note-velocity input",
       ) as HTMLInputElement;
       fireEvent.input(slider, { target: { value: "0.2" } });
 

--- a/src/editor/PianoRoll.test.tsx
+++ b/src/editor/PianoRoll.test.tsx
@@ -431,6 +431,30 @@ describe("PianoRoll", () => {
     expect(updated?.velocity).toBeCloseTo(0.3);
   });
 
+  // #255: the note's velocity was a raw `<input type="range">` — a native
+  // thumb where every other continuous control in the editor is a thumbless
+  // fill. It has to be the same control, in a compact shape that fits inside a
+  // note block, and it has to keep its per-note accessible name.
+  it("paints the note velocity as a compact thumbless fill slider (#255)", async () => {
+    const { session, renderRoll } = await setUp();
+    const { container } = renderRoll();
+    const note = noteEvents(session.project.clips[0])[0];
+    const el = noteEl(container, note.id);
+    // Found structurally, so this reads the raw input of the broken note block
+    // as well as the fill slider of the fixed one.
+    const slider = el.querySelector('input[type="range"]') as HTMLInputElement;
+
+    expect(slider.closest(".fill-slider-track")).not.toBeNull();
+    const wrapper = slider.closest(".fill-slider");
+    expect(wrapper?.querySelector(".fill-slider-fill")).not.toBeNull();
+    // Compact: the label row and value readout are suppressed, so the control
+    // still fits a note rectangle a few pixels tall…
+    expect(wrapper?.classList.contains("compact")).toBe(true);
+    expect(wrapper?.querySelector("output")).toBeNull();
+    // …and the accessible name survives without a visible label.
+    expect(slider.getAttribute("aria-label")).toMatch(/^Velocity of /);
+  });
+
   it("sets velocity across a slider drag as ONE undo transaction and ONE clip_edited", async () => {
     const { session, renderRoll, transport } = await setUp();
     const { container } = renderRoll();

--- a/src/editor/PianoRollNote.tsx
+++ b/src/editor/PianoRollNote.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "@solidjs/web";
 import type { NoteEvent } from "../domain/entities";
 import { NOTE_VELOCITY } from "../domain/parameters";
+import FillSlider from "../instrument/FillSlider";
 import { pitchOf } from "./pianoRollGestures";
 import { pitchLabel } from "./pitchClass";
 
@@ -38,25 +39,26 @@ export default function PianoRollNote(props: PianoRollNoteProps): JSX.Element {
       onPointerUp={() => props.onPointerUp()}
     >
       <span class="pr-note-resize" aria-hidden="true" />
-      <input
-        class="pr-note-velocity"
-        type="range"
-        min={NOTE_VELOCITY.min}
-        max={NOTE_VELOCITY.max}
-        step={0.01}
-        value={props.note.velocity}
-        aria-label={`Velocity of ${pitchLabel(pitchOf(props.note))}`}
-        onPointerDown={(event) => event.stopPropagation()}
-        onInput={(event) =>
-          props.applyVelocity(props.note, event.currentTarget.valueAsNumber)
-        }
-        // `change` fires once the drag (or keyboard nudge) settles;
-        // pointer-up/cancel cover the mouse path. All commit the one
-        // open gesture — extra calls are a safe no-op.
-        onChange={() => props.commitVelocity()}
-        onPointerUp={() => props.commitVelocity()}
-        onPointerCancel={() => props.commitVelocity()}
-      />
+      {/* The same fill slider as every other continuous control in the editor,
+			    in its compact shape — the note block has no room for a label row or a
+			    readout, and a native thumb here read as a different control language
+			    entirely (#255). Pressing it must not also start dragging the note, so
+			    the wrapper swallows `pointerdown` before it reaches the note body.
+			    `change` / pointer-up / pointer-cancel all reach `onCommit`, which
+			    closes the one open gesture; extra commits are a safe no-op. */}
+      <div class="pr-note-velocity" onPointerDown={(event) => event.stopPropagation()}>
+        <FillSlider
+          definition={NOTE_VELOCITY}
+          inputId={`pr-note-velocity-${props.note.id}`}
+          compact
+          orientation="horizontal"
+          ariaLabel={`Velocity of ${pitchLabel(pitchOf(props.note))}`}
+          value={props.note.velocity}
+          displayValue={String(Math.round(props.note.velocity * 127))}
+          onInput={(value) => props.applyVelocity(props.note, value)}
+          onCommit={() => props.commitVelocity()}
+        />
+      </div>
     </div>
   );
 }

--- a/src/editor/StepEditor.css
+++ b/src/editor/StepEditor.css
@@ -17,11 +17,18 @@
   min-height: 30px;
 }
 
-.step-editor-length,
-.step-editor-velocity {
+.step-editor-length {
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: var(--font-size-small);
+  color: var(--color-text-secondary);
+}
+
+/* Wide enough for the fill slider to be draggable, narrow enough to leave the
+   toolbar room; the slider itself measures this box rather than setting it. */
+.step-editor-velocity {
+  width: 140px;
   font-size: var(--font-size-small);
   color: var(--color-text-secondary);
 }
@@ -36,15 +43,8 @@
   font-size: var(--font-size-small);
 }
 
-.step-editor-velocity-input {
-  accent-color: var(--step-accent);
-  width: 120px;
-}
-
-.step-editor-velocity-value {
-  min-width: 2ch;
-  font-variant-numeric: tabular-nums;
-  color: var(--color-text);
+.step-editor-velocity .fill-slider-fill {
+  background-color: var(--step-accent);
 }
 
 .step-editor-grid {

--- a/src/editor/StepEditor.test.tsx
+++ b/src/editor/StepEditor.test.tsx
@@ -13,6 +13,8 @@ import {
 } from "../domain/fixtures";
 import type { EventId } from "../domain/ids";
 import { TICKS_PER_BAR } from "../domain/time";
+import { fillExtent, moveTo } from "../instrument/panelTesting";
+import { fireAndFlush } from "../testing/events";
 import { memoryStorage } from "../testing/storage";
 import StepEditor from "./StepEditor";
 
@@ -74,6 +76,13 @@ function renderEditor(project: Project) {
 
 function cell(name: string): HTMLElement {
   return screen.getByRole("button", { name });
+}
+
+/** The velocity of the note starting on the given tick, as the clip holds it. */
+function velocityAt(clip: Clip, startTicks: number): number | undefined {
+  const content = clip.content;
+  if (content.kind !== "notes") throw new Error("expected a note clip");
+  return content.events.find((event) => event.startTicks === startTicks)?.velocity;
 }
 
 /** A complete paint/erase stroke: down on the first cell, up to commit. */
@@ -255,6 +264,9 @@ describe("StepEditor", () => {
     const velocity = screen.getByRole("slider", { name: "Velocity" });
     fireEvent.input(velocity, { target: { value: "0.25" } });
     flush();
+    // The drag settles: `change` is what closes the slider's gesture (#255).
+    fireEvent.change(velocity, { target: { value: "0.25" } });
+    flush();
 
     const content = clip().content;
     if (content.kind !== "notes") throw new Error("expected a note clip");
@@ -262,6 +274,42 @@ describe("StepEditor", () => {
     expect(painted?.velocity).toBeCloseTo(0.25, 2);
     // The paint stroke and the velocity edit are two separate history entries.
     expect(history.entries.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // #255: the selected step's velocity was a raw `<input type="range">` with a
+  // native thumb and no fill, and every pointer move dispatched its own
+  // `note.update` — dozens of revisions and undo steps for one drag.
+  it("paints the step velocity as a thumbless fill slider (#255)", () => {
+    renderEditor(createSliceFixtureProject());
+    stroke("Notes, step 2, off");
+
+    const velocity = screen.getByRole("slider", { name: "Velocity" }) as HTMLInputElement;
+    expect(velocity.closest(".fill-slider-track")).not.toBeNull();
+    expect(fillExtent(velocity)).not.toBe("");
+    const readout = velocity.closest(".fill-slider")?.querySelector("output");
+    expect(readout?.textContent ?? "").not.toBe("");
+  });
+
+  it("runs one velocity drag as one history entry and one revision (#255)", () => {
+    const { history, clip } = renderEditor(createSliceFixtureProject());
+    stroke("Notes, step 2, off");
+    const afterStroke = history.entries.length;
+    const startRevision = history.project.metadata.revision;
+
+    const velocity = screen.getByRole("slider", { name: "Velocity" }) as HTMLInputElement;
+    moveTo(velocity, "0.4");
+    moveTo(velocity, "0.25");
+    // Mid-drag the value has to follow the pointer, in the project the audio
+    // graph reads…
+    expect(velocityAt(clip(), 48)).toBeCloseTo(0.25, 2);
+    // …but nothing is committed until the drag ends.
+    expect(history.entries).toHaveLength(afterStroke);
+
+    fireAndFlush(() => {
+      fireEvent.change(velocity, { target: { value: "0.25" } });
+    });
+    expect(history.entries).toHaveLength(afterStroke + 1);
+    expect(history.project.metadata.revision).toBe(startRevision + 1);
   });
 
   it("shift-click selects an existing note without erasing it", () => {

--- a/src/editor/StepEditor.tsx
+++ b/src/editor/StepEditor.tsx
@@ -2,12 +2,13 @@ import { For, type JSX, Show } from "@solidjs/web";
 import { type Accessor, createMemo, createSignal } from "solid-js";
 import { type Analytics, analytics as defaultAnalytics } from "../analytics/analytics";
 import type { Gesture, GestureOptions, RawCommandInput } from "../commands";
-import { removeNotes, updateClip, updateNote } from "../commands";
+import { createControlGesture, removeNotes, updateClip, updateNote } from "../commands";
 import type { Clip, Instrument, NoteEvent, NoteTrigger } from "../domain/entities";
 import { createFactoryContext } from "../domain/factories";
 import type { EventId } from "../domain/ids";
 import { NOTE_VELOCITY } from "../domain/parameters";
 import { TICKS_PER_BAR, TICKS_PER_SIXTEENTH } from "../domain/time";
+import FillSlider from "../instrument/FillSlider";
 import {
   barCount,
   isBarStart,
@@ -176,14 +177,25 @@ export default function StepEditor(props: StepEditorProps): JSX.Element {
     return note.velocity;
   }
 
-  function applyVelocity(note: NoteEvent, value: number): void {
-    if (!Number.isFinite(value)) return;
-    props.dispatch(
-      updateNote(props.clip.id, note.id, {
+  /**
+   * The selected step's velocity, as one gesture per drag (#255). Dispatching
+   * a `note.update` straight from `input` made every pointer sample its own
+   * transaction — dozens of revisions, dozens of autosaves, and one undo press
+   * per sample to get back. The control gesture applies each step live inside
+   * a single open gesture and commits it once on release.
+   */
+  const velocityControl = createControlGesture({
+    beginGesture: (options) => props.beginGesture(options),
+    dispatch: (commands) => {
+      props.dispatch(commands);
+      return undefined;
+    },
+    summary: () => "Set velocity",
+    command: (value) =>
+      updateNote(props.clip.id, selectedNote()?.id as EventId, {
         velocity: value as NoteEvent["velocity"],
       }),
-    );
-  }
+  });
 
   function resizeToBars(nextBars: number): void {
     const clamped = Math.min(MAX_BARS, Math.max(MIN_BARS, Math.round(nextBars)));
@@ -227,23 +239,21 @@ export default function StepEditor(props: StepEditorProps): JSX.Element {
         </label>
         <Show when={selectedNote()}>
           {(note) => (
-            <label class="step-editor-velocity">
-              <span class="step-editor-velocity-label">Velocity</span>
-              <input
-                class="step-editor-velocity-input"
-                type="range"
-                min={NOTE_VELOCITY.min}
-                max={NOTE_VELOCITY.max}
-                step={0.01}
+            <div class="step-editor-velocity">
+              <FillSlider
+                definition={NOTE_VELOCITY}
+                inputId="step-editor-velocity"
+                label="Velocity"
+                // The value already reads as a left-right axis, as the mixer's
+                // pan does, and the toolbar is a single row.
+                orientation="horizontal"
                 value={velocityFor(note())}
-                onInput={(event) =>
-                  applyVelocity(note(), event.currentTarget.valueAsNumber)
-                }
+                // MIDI velocity, which is what the readout always showed.
+                displayValue={String(Math.round(velocityFor(note()) * 127))}
+                onInput={(value) => velocityControl.input(value)}
+                onCommit={(value) => velocityControl.commit(value)}
               />
-              <span class="step-editor-velocity-value" aria-hidden="true">
-                {Math.round(velocityFor(note()) * 127)}
-              </span>
-            </label>
+            </div>
           )}
         </Show>
       </div>

--- a/src/instrument/FillSlider.css
+++ b/src/instrument/FillSlider.css
@@ -190,3 +190,18 @@
   height: 100%;
   cursor: ew-resize;
 }
+
+/* The fill track on its own, for a control with nowhere to put a label row or
+   a readout — a piano-roll note block. It claims the width of whatever holds
+   it and no height beyond the track, so it cannot change that block's layout;
+   the host sets `--fill-slider-track-thickness` to whatever it can spare. */
+.fill-slider.compact {
+  display: block;
+  width: 100%;
+  gap: 0;
+}
+
+.fill-slider.compact .fill-slider-track {
+  width: auto;
+  height: var(--fill-slider-track-thickness, 10px);
+}

--- a/src/instrument/FillSlider.tsx
+++ b/src/instrument/FillSlider.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "@solidjs/web";
+import { type JSX, Show } from "@solidjs/web";
 import { createMemo } from "solid-js";
 import { clampParameterValue, type ParameterDefinition } from "../domain/parameters";
 import "./FillSlider.css";
@@ -50,6 +50,13 @@ export interface FillSliderProps {
    * filled from the left would read "half loud" at centre.
    */
   readonly bipolar?: boolean;
+  /**
+   * Drop the label row and the value readout, leaving the fill track alone,
+   * for a control with nowhere to put them — a piano-roll note block is a few
+   * pixels tall. `ariaLabel` then carries the name the visible label would
+   * have, so the control is still announced and still keyboard-operable.
+   */
+  readonly compact?: boolean;
 }
 
 /**
@@ -108,12 +115,18 @@ export default function FillSlider(props: FillSliderProps): JSX.Element {
     <div
       class={[
         "fill-slider",
-        { horizontal: horizontal(), bipolar: props.bipolar === true },
+        {
+          horizontal: horizontal(),
+          bipolar: props.bipolar === true,
+          compact: props.compact === true,
+        },
       ]}
     >
-      <label class="fill-slider-label" for={id()}>
-        {props.label ?? props.definition.label}
-      </label>
+      <Show when={props.compact !== true}>
+        <label class="fill-slider-label" for={id()}>
+          {props.label ?? props.definition.label}
+        </label>
+      </Show>
       <div class="fill-slider-track">
         <div class="fill-slider-fill" style={fillStyle()} aria-hidden="true" />
         <input
@@ -148,9 +161,11 @@ export default function FillSlider(props: FillSliderProps): JSX.Element {
           }
         />
       </div>
-      <output class="fill-slider-value" for={id()}>
-        {props.displayValue}
-      </output>
+      <Show when={props.compact !== true}>
+        <output class="fill-slider-value" for={id()}>
+          {props.displayValue}
+        </output>
+      </Show>
     </div>
   );
 }

--- a/src/instrument/panelTesting.ts
+++ b/src/instrument/panelTesting.ts
@@ -41,10 +41,14 @@ export function moveTo(slider: HTMLInputElement, value: string): void {
   });
 }
 
-/** The painted fill's own extent, which is what a fill-slider's value *is*. */
+/**
+ * The painted fill's own extent along its axis, which is what a fill-slider's
+ * value *is* — height for the vertical shape, width for the horizontal one.
+ */
 export function fillExtent(slider: HTMLInputElement): string {
   const fill = slider
     .closest(".fill-slider")
     ?.querySelector<HTMLElement>(".fill-slider-fill");
-  return fill?.style.height ?? "";
+  if (!fill) return "";
+  return fill.style.height || fill.style.width;
 }


### PR DESCRIPTION
## What & why

The piano roll and step editor velocity sliders were raw `<input type="range">` — native thumb, no fill — instead of `FillSlider`, which every other continuous control in the editor already uses. Root cause: they were hand-rolled before `FillSlider` existed and never migrated. In the step editor the same raw input also dispatched a full `note.update` command straight from `onInput`, with no `createControlGesture`, so one pointer drag produced one history entry and one revision per pointer sample instead of one for the whole gesture.

The fix gives `FillSlider` a new `compact` shape — the fill track alone, no label row and no readout — for a control with nowhere to put them, and switches both velocity sliders to it. The step editor's velocity now runs through `createControlGesture` so a drag applies live inside one open gesture and commits once. The piano roll's velocity already used a gesture correctly; only its appearance changed. `fillExtent` was extended to read a horizontal shape's width as well as a vertical shape's height, since it previously only measured vertical fill sliders.

This is 1/2 in the stack, base `main`. PR 2/2 (`claude/fix-255-drum-pad-controls`) builds on this branch and fixes the same class of bug in the drum machine panel's pitch/level/pan controls.

Violates PRD principle 5, "Legible controls" ([`docs/prd.md`](../blob/main/docs/prd.md)): "Consistent control shape and layout. Controls of the same kind share size, styling, and layout across every instrument and device."

Refs #255

## Core flows

None — bug fix, no core flow specced or completed by this PR.

## Walkthrough

This is 1/2 of the stack. The captured walkthrough for issue #255 is on the closing PR, #296, per CLAUDE.md ("a walkthrough in the body of the PR that closes the issue").

This slice does change the UI: the note and step velocity sliders lose their native thumb and gain a fill. Those surfaces are visible in #296's walkthrough, which was captured from CF-001 running against the tip of this stack — CF-001 step 3 renders the step editor, and so exercises `StepEditor.tsx` and `FillSlider.tsx`, both changed by this PR.

## Evidence

The branch passed an adversarial Opus review before this PR was opened.

Regression test red→green, from `bun run test:watch` / `bunx vitest run src/editor/PianoRoll.test.tsx src/editor/StepEditor.test.tsx` on the commit that added the tests, before the fix (verified independently by the reviewer as well):

```
PianoRoll > paints the note velocity as a compact thumbless fill slider
  AssertionError: expected null not to be null
    expect(slider.closest(".fill-slider-track")).not.toBeNull();

StepEditor > paints the step velocity as a thumbless fill slider
  AssertionError: expected null not to be null
    expect(velocity.closest(".fill-slider-track")).not.toBeNull();

StepEditor > runs one velocity drag as one history entry and one revision
  AssertionError: expected [ ... ] to have a length of 1 but got 3
    expect(history.entries).toHaveLength(afterStroke);
```

After the fix, on this PR's HEAD:

```
$ bunx vitest run src/editor/PianoRoll.test.tsx src/editor/StepEditor.test.tsx src/instrument/FillSlider.test.tsx
 ✓ |ui| src/editor/PianoRoll.test.tsx (19 tests) 572ms
 ✓ |ui| src/editor/StepEditor.test.tsx (19 tests) 1269ms
 Test Files  2 passed (2)
      Tests  38 passed (38)

$ bun run typecheck
$ tsc --noEmit
(no output, exit 0)

$ bun run check
$ tsc --noEmit && biome check && bun run verify:no-solid-1
Checked 507 files in 582ms. No fixes applied.
check-no-solid-1 — no Solid 1 idioms found.

$ bun run test
 Test Files  160 passed (160)
      Tests  2060 passed (2060)
```

## Acceptance criteria met

Issue #255 has no checkboxes; it lists three symptoms as prose. All three are addressed for the note and step velocity sliders (drum pad controls follow in PR 2/2):

- Thumb removed (native `<input type="range">` swapped for `FillSlider`'s thumbless track)
- Fill added (`FillSlider`'s `compact` shape)
- Updating on drag works (step editor velocity now runs one `createControlGesture` per drag instead of one command per pointer sample; piano roll velocity already worked and is now verified by test)

The three tests added to reproduce the bug (`PianoRoll.test.tsx`, `StepEditor.test.tsx`) now pass and guard the fix.