### PR TITLE
Fix #255 (2/2): Drum pad pitch/level/pan sliders had thumbs, no fill, and dragging died

### DIFF
--- a/src/editor/DrumMachinePanel.css
+++ b/src/editor/DrumMachinePanel.css
@@ -54,16 +54,17 @@
   min-width: 0;
 }
 
+/* Pitch/level/pan are fill sliders sitting straight in the lane grid; like the
+   other cells they have to be allowed to shrink below their content. */
+.drum-pad > .fill-slider {
+  min-width: 0;
+}
+
 .pad-control-label {
   font-size: var(--font-size-tiny);
   color: var(--color-foreground);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-}
-
-.pad-control input[type="range"] {
-  width: 100%;
-  accent-color: var(--color-foreground-bright);
 }
 
 .pad-control select {

--- a/src/editor/DrumMachinePanel.test.tsx
+++ b/src/editor/DrumMachinePanel.test.tsx
@@ -1,12 +1,19 @@
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Analytics } from "../analytics/analytics";
 import { ConsentStore } from "../analytics/consent";
 import { createRecordingTransport } from "../analytics/transport";
-import type { RawCommandInput, TransactionResult } from "../commands";
-import type { Track } from "../domain/entities";
+import {
+  CommandHistory,
+  type RawCommandInput,
+  type TransactionResult,
+} from "../commands";
+import type { DrumPad, Track } from "../domain/entities";
 import { createDrumMachineFixtureProject } from "../domain/fixtures";
 import type { PadId } from "../domain/ids";
+import { fillExtent, moveTo, testAnalytics } from "../instrument/panelTesting";
+import { fireAndFlush } from "../testing/events";
 import { memoryStorage } from "../testing/storage";
 import DrumMachinePanel from "./DrumMachinePanel";
 
@@ -44,11 +51,53 @@ function renderPanel() {
       track={track}
       assets={assets}
       dispatch={dispatch}
+      // No history behind this render: a control gesture that cannot open one
+      // falls back to plain `dispatch`, which is what these assertions read.
+      beginGesture={() => undefined}
       audition={audition}
       analytics={analytics}
     />
   ));
   return { project, track, assets, dispatch, audition, transport };
+}
+
+/**
+ * The panel over a real command history, so a pad control's rendered value
+ * comes back out of the project it edits — which is what a drag has to move,
+ * and what one undo press has to put back.
+ */
+function renderLivePanel() {
+  const history = new CommandHistory(createDrumMachineFixtureProject());
+  const [project, setProject] = createSignal(history.project);
+  history.subscribe(() => setProject(history.project));
+  const track = () => drumTrackOf(project());
+  const pad = (): DrumPad => {
+    const instrument = track().instrument;
+    if (instrument?.kind !== "drumMachine") throw new Error("expected a drum machine");
+    return instrument.pads[0];
+  };
+  render(() => (
+    <DrumMachinePanel
+      track={track()}
+      assets={project().song.assets.filter((asset) => asset.kind === "sample")}
+      dispatch={(commands) => history.execute(commands)}
+      beginGesture={(options) => history.beginGesture(options)}
+      analytics={testAnalytics().analytics}
+    />
+  ));
+  return { history, project, pad };
+}
+
+/**
+ * Every range input the panel renders, in DOM order — pitch, level, pan per
+ * pad. Selected structurally rather than by accessible name so the same helper
+ * reads the raw inputs of the broken panel and the fill sliders of the fixed
+ * one, and a red run can only mean the control itself is wrong.
+ */
+function rangeInputs(): HTMLInputElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLInputElement>('.drum-machine input[type="range"]'),
+  );
 }
 
 describe("DrumMachinePanel", () => {
@@ -121,6 +170,53 @@ describe("DrumMachinePanel", () => {
     expect(command.type).toBe("drum.setPadFlag");
     expect(command.payload.flag).toBe("muted");
     expect(command.payload.value).toBe(true);
+  });
+
+  // #255: the pad controls were raw `<input type="range">` — native track,
+  // native thumb, no fill, no readout — beside the mixer's thumbless fill
+  // sliders, and each pointer move dispatched a whole command of its own.
+  it("paints every pad control as a thumbless fill slider (#255)", () => {
+    renderPanel();
+    const sliders = rangeInputs();
+    expect(sliders.length).toBeGreaterThan(0);
+    for (const slider of sliders) {
+      // The fill track is what carries the value; a bare input has a thumb.
+      expect(slider.closest(".fill-slider-track")).not.toBeNull();
+      // The filled portion *is* the value, so it has a measurable extent…
+      expect(fillExtent(slider)).not.toBe("");
+      // …and the live value is written out beside it.
+      const readout = slider.closest(".fill-slider")?.querySelector("output");
+      expect(readout?.textContent ?? "").not.toBe("");
+    }
+  });
+
+  it("runs one pad-level drag as one history entry and one revision (#255)", () => {
+    const { history, project, pad } = renderLivePanel();
+    const startRevision = project().metadata.revision;
+    const restingLevel = pad().mixer.volume;
+    // Pitch, level, pan — the first pad's level is the second control.
+    const level = rangeInputs()[1];
+
+    // Mid-drag: `input` has fired, `change` has not. The value still has to
+    // follow the pointer, on screen and in the project the audio graph reads.
+    moveTo(level, "-6");
+    expect(pad().mixer.volume).toBeCloseTo(-6);
+    moveTo(level, "-12");
+    expect(pad().mixer.volume).toBeCloseTo(-12);
+    // Nothing is committed until the drag ends.
+    expect(history.entries).toHaveLength(0);
+
+    fireAndFlush(() => {
+      fireEvent.change(level, { target: { value: "-12" } });
+    });
+    expect(history.entries).toHaveLength(1);
+    expect(project().metadata.revision).toBe(startRevision + 1);
+
+    // …so a single undo puts the whole drag back.
+    fireAndFlush(() => {
+      history.undo();
+    });
+    expect(pad().mixer.volume).toBeCloseTo(restingLevel);
   });
 
   it("auditions a pad when its name button is clicked", () => {

--- a/src/editor/DrumMachinePanel.tsx
+++ b/src/editor/DrumMachinePanel.tsx
@@ -1,10 +1,29 @@
 import { For, type JSX, Show } from "@solidjs/web";
 import { type Analytics, analytics as defaultAnalytics } from "../analytics/analytics";
-import type { RawCommandInput, TransactionResult } from "../commands";
-import { setPadAsset, setPadChoke, setPadFlag, setPadParameter } from "../commands";
+import type {
+  Gesture,
+  GestureOptions,
+  RawCommandInput,
+  TransactionResult,
+} from "../commands";
+import {
+  createControlGesture,
+  setPadAsset,
+  setPadChoke,
+  setPadFlag,
+  setPadParameter,
+} from "../commands";
 import type { Asset, DrumPad, Track } from "../domain/entities";
+import { formatDb, formatPan } from "../domain/faders";
 import type { AssetId, PadId } from "../domain/ids";
-import { PAD_PITCH, TRACK_PAN, TRACK_VOLUME } from "../domain/parameters";
+import {
+  PAD_PITCH,
+  type ParameterDefinition,
+  TRACK_PAN,
+  TRACK_VOLUME,
+} from "../domain/parameters";
+import FillSlider from "../instrument/FillSlider";
+import { formatInstrumentValue } from "../instrument/formatValue";
 import "./DrumMachinePanel.css";
 import { ariaBool } from "../shared/aria";
 
@@ -18,6 +37,8 @@ export interface DrumMachinePanelProps {
   dispatch(
     commands: RawCommandInput | readonly RawCommandInput[],
   ): TransactionResult | undefined;
+  /** Opens a pad-control drag that commits as one history entry (#255). */
+  beginGesture(options?: GestureOptions): Gesture | undefined;
   /** Plays one pad immediately so the user hears their choice (audition). */
   audition?(padId: PadId): void;
   /** Defaults to the application's singleton; injectable for tests. */
@@ -50,16 +71,6 @@ export default function DrumMachinePanel(props: DrumMachinePanelProps): JSX.Elem
     analytics().log("instrument_changed", { instrument_type: "drum_machine" });
   }
 
-  function setParameter(
-    pad: DrumPad,
-    parameterId: Parameters<typeof setPadParameter>[2],
-    value: number,
-  ): void {
-    if (!Number.isFinite(value)) return;
-    markFeatureUse();
-    props.dispatch(setPadParameter(props.track.id, pad.id, parameterId, value));
-  }
-
   function toggleFlag(pad: DrumPad, flag: "muted" | "soloed"): void {
     markFeatureUse();
     props.dispatch(setPadFlag(props.track.id, pad.id, flag, !pad.mixer[flag]));
@@ -82,26 +93,30 @@ export default function DrumMachinePanel(props: DrumMachinePanelProps): JSX.Elem
 
   return (
     <section class="drum-machine" aria-label={`Drum machine: ${props.track.name}`}>
-      <For each={pads(props.track)}>
+      {/* Keyed on the pad's own id, so an edit to a pad updates its lane in
+			    place. Keyed on the pad *object* — the default — every parameter edit
+			    rebuilds that lane, and a drag applying live would lose the very input
+			    it is moving on its first sample. */}
+      <For each={pads(props.track)} keyed={(pad) => pad.id}>
         {(pad) => (
-          <div class={["drum-pad", { muted: pad.mixer.muted }]}>
+          <div class={["drum-pad", { muted: pad().mixer.muted }]}>
             <button
               type="button"
               class="pad-audition"
-              onClick={() => audition(pad)}
-              aria-label={`Audition ${pad.name}`}
-              title={`Audition ${pad.name}`}
+              onClick={() => audition(pad())}
+              aria-label={`Audition ${pad().name}`}
+              title={`Audition ${pad().name}`}
             >
-              <span class="pad-name">{pad.name}</span>
+              <span class="pad-name">{pad().name}</span>
             </button>
 
             <label class="pad-control pad-sample">
               <span class="pad-control-label">Sample</span>
               <select
-                value={pad.assetId ?? ""}
+                value={pad().assetId ?? ""}
                 onChange={(event) =>
                   changePadAsset(
-                    pad,
+                    pad(),
                     event.currentTarget.value === ""
                       ? null
                       : (event.currentTarget.value as AssetId),
@@ -115,55 +130,54 @@ export default function DrumMachinePanel(props: DrumMachinePanelProps): JSX.Elem
               </select>
             </label>
 
-            <label class="pad-control">
-              <span class="pad-control-label">Pitch</span>
-              <input
-                type="range"
-                min={PAD_PITCH.min}
-                max={PAD_PITCH.max}
-                step={PAD_PITCH.step ?? 1}
-                value={padParam(pad, "pitch", PAD_PITCH.defaultValue)}
-                onInput={(event) =>
-                  setParameter(pad, PAD_PITCH.id, event.currentTarget.valueAsNumber)
-                }
-              />
-            </label>
+            <PadControl
+              trackId={props.track.id}
+              pad={pad()}
+              definition={PAD_PITCH}
+              label="Pitch"
+              value={padParam(pad(), "pitch", PAD_PITCH.defaultValue)}
+              displayValue={formatInstrumentValue(
+                PAD_PITCH,
+                padParam(pad(), "pitch", PAD_PITCH.defaultValue),
+              )}
+              onFirstUse={markFeatureUse}
+              dispatch={(commands) => props.dispatch(commands)}
+              beginGesture={(options) => props.beginGesture(options)}
+            />
 
-            <label class="pad-control">
-              <span class="pad-control-label">Level</span>
-              <input
-                type="range"
-                min={TRACK_VOLUME.min}
-                max={TRACK_VOLUME.max}
-                step={0.5}
-                value={pad.mixer.volume}
-                onInput={(event) =>
-                  setParameter(pad, TRACK_VOLUME.id, event.currentTarget.valueAsNumber)
-                }
-              />
-            </label>
+            <PadControl
+              trackId={props.track.id}
+              pad={pad()}
+              definition={TRACK_VOLUME}
+              label="Level"
+              value={pad().mixer.volume}
+              displayValue={formatDb(TRACK_VOLUME, pad().mixer.volume)}
+              onFirstUse={markFeatureUse}
+              dispatch={(commands) => props.dispatch(commands)}
+              beginGesture={(options) => props.beginGesture(options)}
+            />
 
-            <label class="pad-control">
-              <span class="pad-control-label">Pan</span>
-              <input
-                type="range"
-                min={TRACK_PAN.min}
-                max={TRACK_PAN.max}
-                step={0.01}
-                value={pad.mixer.pan}
-                onInput={(event) =>
-                  setParameter(pad, TRACK_PAN.id, event.currentTarget.valueAsNumber)
-                }
-              />
-            </label>
+            <PadControl
+              trackId={props.track.id}
+              pad={pad()}
+              definition={TRACK_PAN}
+              label="Pan"
+              // Pan's range *is* the stereo field, so it fills from centre.
+              bipolar
+              value={pad().mixer.pan}
+              displayValue={formatPan(pad().mixer.pan)}
+              onFirstUse={markFeatureUse}
+              dispatch={(commands) => props.dispatch(commands)}
+              beginGesture={(options) => props.beginGesture(options)}
+            />
 
             <label class="pad-control pad-choke">
               <span class="pad-control-label">Choke</span>
               <select
-                value={pad.chokeGroup === null ? "" : String(pad.chokeGroup)}
+                value={pad().chokeGroup === null ? "" : String(pad().chokeGroup)}
                 onChange={(event) =>
                   changeChoke(
-                    pad,
+                    pad(),
                     event.currentTarget.value === ""
                       ? null
                       : Number(event.currentTarget.value),
@@ -180,20 +194,20 @@ export default function DrumMachinePanel(props: DrumMachinePanelProps): JSX.Elem
             <div class="pad-flags">
               <button
                 type="button"
-                class={["pad-flag", { active: pad.mixer.muted }]}
-                aria-pressed={ariaBool(pad.mixer.muted)}
-                aria-label={`Mute ${pad.name}`}
-                onClick={() => toggleFlag(pad, "muted")}
+                class={["pad-flag", { active: pad().mixer.muted }]}
+                aria-pressed={ariaBool(pad().mixer.muted)}
+                aria-label={`Mute ${pad().name}`}
+                onClick={() => toggleFlag(pad(), "muted")}
                 title="Mute"
               >
                 M
               </button>
               <button
                 type="button"
-                class={["pad-flag", { active: pad.mixer.soloed }]}
-                aria-pressed={ariaBool(pad.mixer.soloed)}
-                aria-label={`Solo ${pad.name}`}
-                onClick={() => toggleFlag(pad, "soloed")}
+                class={["pad-flag", { active: pad().mixer.soloed }]}
+                aria-pressed={ariaBool(pad().mixer.soloed)}
+                aria-label={`Solo ${pad().name}`}
+                onClick={() => toggleFlag(pad(), "soloed")}
                 title="Solo"
               >
                 S
@@ -206,5 +220,63 @@ export default function DrumMachinePanel(props: DrumMachinePanelProps): JSX.Elem
         <p class="drum-machine-empty">This track has no drum pads yet.</p>
       </Show>
     </section>
+  );
+}
+
+interface PadControlProps {
+  readonly trackId: Track["id"];
+  readonly pad: DrumPad;
+  readonly definition: ParameterDefinition;
+  readonly label: string;
+  readonly value: number;
+  readonly displayValue: string;
+  readonly bipolar?: boolean;
+  onFirstUse(): void;
+  dispatch(
+    commands: RawCommandInput | readonly RawCommandInput[],
+  ): TransactionResult | undefined;
+  beginGesture(options?: GestureOptions): Gesture | undefined;
+}
+
+/**
+ * One continuous pad control (#255): the same thumbless fill slider as every
+ * other continuous control in the editor, on its side to fit the pad lane, and
+ * driven as one gesture per drag. Each pointer sample applies live inside the
+ * open gesture — so the value follows the pointer on screen and in the audio
+ * graph — and release commits the whole drag as one history entry, one revision
+ * and one save. Dispatching a command straight from `input`, as this did, made
+ * one drag dozens of revisions and dozens of undo steps.
+ */
+function PadControl(props: PadControlProps): JSX.Element {
+  const control = createControlGesture({
+    beginGesture: (options) => props.beginGesture(options),
+    dispatch: (commands) => props.dispatch(commands),
+    summary: () => `Set ${props.definition.label} on a pad`,
+    command: (value) =>
+      setPadParameter(
+        props.trackId,
+        props.pad.id,
+        props.definition.id as Parameters<typeof setPadParameter>[2],
+        value,
+      ),
+  });
+
+  return (
+    <FillSlider
+      definition={props.definition}
+      inputId={`pad-${props.pad.id}-${props.label.toLowerCase()}`}
+      label={props.label}
+      // Every pad shows a "Pitch", so the name has to say whose.
+      ariaLabel={`${props.label} for ${props.pad.name}`}
+      orientation="horizontal"
+      bipolar={props.bipolar}
+      value={props.value}
+      displayValue={props.displayValue}
+      onInput={(value) => {
+        props.onFirstUse();
+        control.input(value);
+      }}
+      onCommit={(value) => control.commit(value)}
+    />
   );
 }

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -373,6 +373,7 @@ export default function EditorView(props: EditorViewProps): JSX.Element {
                             track={drum()}
                             assets={sampleAssets()}
                             dispatch={session.dispatch}
+                            beginGesture={session.beginGesture}
                             audition={(padId) => void audio.auditionPad(drum().id, padId)}
                           />
                         </div>


### PR DESCRIPTION
## What & why

The drum machine panel's pitch, level, and pan controls were raw `<input type="range">` — native thumb, no fill — instead of `FillSlider`, the same gap as PR 1/2's velocity sliders. Root cause is the same: hand-rolled before `FillSlider` existed and never migrated. Each also dispatched a whole `drum.setPadParameter` command straight from `onInput` with no `createControlGesture`, so a drag applied one command per pointer sample instead of one gesture — and it was worse than the velocity case: the pads `For` was keyed on the pad object (the default), so every dispatch produced a new pad object, which rebuilt that pad's lane and destroyed the very `<input>` the pointer was dragging, killing the drag after its first sample.

The fix makes pitch, level, and pan the same thumbless `FillSlider` every other continuous control uses — horizontal to fit the pad lane, pan filled from centre — each driven by `createControlGesture`, so a drag applies live inside one open gesture and commits once. The pads `For` is now keyed on the pad's id (matching how `Mixer` keys its track strips) so a live parameter update no longer rebuilds the lane mid-drag. `EditorView` now passes `session.beginGesture` into the panel, which it had never received; `beginGesture` is a required prop so the panel cannot be mounted without it and silently regress to a command per pointer move.

This is 2/2 in the stack, builds on #295 (`claude/fix-255-raw-range-sliders-miss-fill-and-gesture`), base set to that branch so this diff shows only the drum panel slice.

Violates PRD principle 5, "Legible controls" ([`docs/prd.md`](../blob/main/docs/prd.md)): "Consistent control shape and layout. Controls of the same kind share size, styling, and layout across every instrument and device."

Closes #255

## Core flows

None — bug fix, no core flow specced or completed by this PR.

## Walkthrough

### CF-001 — A visitor with no account reaches a playing loop

**1. Open the landing page**

![CF-001 step 1](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/255/CF-001/01-open-the-landing-page.png)

**2. You arrive at the dashboard as a guest, with no projects yet**

![CF-001 step 2](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/255/CF-001/02-you-arrive-at-the-dashboard-as-a-guest-with-no-projects-yet.png)``

**3. The new project opens on a step editor with a starter pattern**

![CF-001 step 3](``https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/255/CF-001/03-the-new-project-opens-on-a-step-editor-with-a-starter-patter.png)``

**4. Turn on a step that was off**

![CF-001 step 4](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/255/CF-001/04-turn-on-a-step-that-was-off.png)

**5. Start playback — the transport is running**

![CF-001 step 5](https://raw.githubusercontent.com/afternoon/solid-groove/refs/heads/claude/walkthroughs/255/CF-001/05-start-playback-the-transport-is-running.png)

<sub>Captured by `bun run walkthrough:capture` from the core-flow specs, in Chromium. Flows are defined in [`docs/core-flows.md`](https://github.com/afternoon/solid-groove/blob/main/docs/core-flows.md).</sub>


## Evidence

The branch passed an adversarial Opus review before this PR was opened.

Regression test red→green, from `bunx vitest run src/editor/DrumMachinePanel.test.tsx` on the commit that added the tests, before the fix (verified independently by the reviewer as well):

```
DrumMachinePanel > paints every pad control as a thumbless fill slider
  AssertionError: expected null not to be null
    expect(slider.closest(".fill-slider-track")).not.toBeNull();

DrumMachinePanel > runs one pad-level drag as one history entry and one revision
  AssertionError: expected -6 to be close to -12, received difference is 6
    expect(pad().mixer.volume).toBeCloseTo(-12);
```
(The second failure is the drag dying after its first sample: each dispatch produced a new pad object, the pads `For` was keyed on that object, so the lane — and the input under the pointer — was rebuilt and the second `input` event never reached a handler.)

After the fix, on this PR's HEAD:

```
$ bunx vitest run src/editor/DrumMachinePanel.test.tsx
 ✓ |ui| src/editor/DrumMachinePanel.test.tsx (7 tests) 277ms
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ bun run check
$ tsc --noEmit && biome check && bun run verify:no-solid-1
Checked 507 files in 598ms. No fixes applied.
check-no-solid-1 — no Solid 1 idioms found.

$ bun run test
 Test Files  160 passed (160)
      Tests  2062 passed (2062)
```

## Acceptance criteria met

Issue #255 has no checkboxes; it lists three symptoms as prose. This PR completes all three for the last remaining raw sliders (pitch, level, pan in the drum machine panel; note/step velocity were PR 1/2):

- Thumb removed (native `<input type="range">` swapped for `FillSlider`'s thumbless track)
- Fill added (`FillSlider`, pan filled from centre)
- Updating on drag works (one `createControlGesture` per drag, and the pads `For` no longer rebuilds the dragged input mid-gesture)

The tests added to reproduce the bug (`DrumMachinePanel.test.tsx`) now pass and guard the fix. With both PRs in the stack landed, no continuous control in the editor is a raw, thumbed `<input type="range">` any more.